### PR TITLE
Water overlay well fix

### DIFF
--- a/src/grid/water_supply.cpp
+++ b/src/grid/water_supply.cpp
@@ -49,6 +49,8 @@ static void mark_well_access(building *well) {
         if (building_id) {
             building_get(building_id)->has_well_access = true;
         }
+
+        map_terrain_add(tile.grid_offset(), TERRAIN_FOUNTAIN_RANGE);
     });
 }
 

--- a/src/grid/water_supply.cpp
+++ b/src/grid/water_supply.cpp
@@ -220,14 +220,11 @@ void map_update_canals(void) {
 void map_update_wells_range(void) {
     OZZY_PROFILER_SECTION("Game/Run/Tick/Wells Range Update");
     map_terrain_remove_all(TERRAIN_FOUNTAIN_RANGE);
-    int total_wells = building_list_small_size();
-    const int* wells = building_list_small_items();
-    for (int i = 0; i < total_wells; i++) {
-        building* b = building_get(wells[i]);
-        if (b->type == BUILDING_WELL) {
-            map_terrain_add_with_radius(b->tile.x(), b->tile.y(), 1, 3, TERRAIN_FOUNTAIN_RANGE);
+    buildings_valid_do([&](building& b) {
+        if (b.type == BUILDING_WELL) {
+            map_terrain_add_with_radius(b.tile.x(), b.tile.y(), 1, 3, TERRAIN_FOUNTAIN_RANGE);
         }
-    }
+    });
 }
 
 e_well_status map_water_supply_is_well_unnecessary(int well_id, int radius) {

--- a/src/overlays/city_overlay_water.cpp
+++ b/src/overlays/city_overlay_water.cpp
@@ -56,16 +56,21 @@ static void draw_footprint_water(vec2i pixel, tile2i point, painter &ctx) {
 }
 
 static int get_tooltip_water(tooltip_context* c, int grid_offset) {
-    if (map_terrain_is(grid_offset, TERRAIN_GROUNDWATER)) {
+    int building_id = map_building_at(grid_offset);
+    if (building_id && building_is_house(building_get(building_id)->type)) {
         if (map_terrain_is(grid_offset, TERRAIN_FOUNTAIN_RANGE)) {
+            return 3;
+        } else {
             return 2;
+        }
+    } else if (map_terrain_is(grid_offset, TERRAIN_GROUNDWATER)) {
+        if (map_terrain_is(grid_offset, TERRAIN_FOUNTAIN_RANGE)) {
+            return 3;
         } else {
             return 1;
         }
-    } else if (map_terrain_is(grid_offset, TERRAIN_FOUNTAIN_RANGE)) {
-        return 3;
     }
-
+    
     return 0;
 }
 


### PR DESCRIPTION
Closes #135 

Well effective radius is drawn and correct tooltip text is displayed for dwellings. 

Behavior should be like the original. I checked it from the original game and the text "This dwelling has only basic drinking water access" is always displayed for tiles inside well radius, with or without any buildings being present.