### PR TITLE
Mac runtime fixes

### DIFF
--- a/src/city/labor.cpp
+++ b/src/city/labor.cpp
@@ -18,7 +18,7 @@
 
 const token_holder<e_labor_category, LABOR_CATEGORY_NONE, LABOR_CATEGORY_SIZE> e_labor_category_tokens;
 
-static int category_for_int_arr[] = {
+static int category_for_int_arr[300] = {
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 0
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 20
@@ -43,9 +43,15 @@ static int category_for_int_arr[] = {
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 210
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 220
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 230
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 240
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 250
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 260
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 270
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 280
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 290
 };
 
-static int category_for_int_arr_ph[] = {
+static int category_for_int_arr_ph[300] = {
   // houses
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 0
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10
@@ -241,7 +247,7 @@ const labor_category_data* city_labor_category(int category) {
 }
 
 void city_labor_set_category(e_building_type type, int category) {
-    category_for_int_arr_ph[type] = category;
+    category_for_int_arr_ph[int(type)] = category;
 }
 
 struct building_type_category {

--- a/src/city/labor.cpp
+++ b/src/city/labor.cpp
@@ -247,7 +247,7 @@ const labor_category_data* city_labor_category(int category) {
 }
 
 void city_labor_set_category(e_building_type type, int category) {
-    category_for_int_arr_ph[int(type)] = category;
+    category_for_int_arr_ph[type] = category;
 }
 
 struct building_type_category {


### PR DESCRIPTION
Fix buffer overflow, allowing main menu to load.
```
akhenaten: ui top menu config started
=================================================================
==45177==ERROR: AddressSanitizer: global-buffer-overflow on address 0x000101ba7f48 at pc 0x000100471d04 bp 0x00016fdfe2b0 sp 0x00016fdfe2a8
WRITE of size 4 at 0x000101ba7f48 thread T0
    #0 0x100471d00 in city_labor_set_category(e_building_type, int) labor.cpp:250
    #1 0x10013d3cc in building_impl::static_params::load(archive) building.cpp:1074
    #2 0x1003a12d4 in buildings::model_t<building_small_mastaba>::load()::'lambda'(archive)::operator()(archive) const building.h:820
    #3 0x1003a0ff0 in void g_archive::r_section<buildings::model_t<building_small_mastaba>::load()::'lambda'(archive)>(char const*, buildings::model_t<building_small_mastaba>::load()::'lambda'(archive)) archive.h:228
    #4 0x10038c8f4 in buildings::model_t<building_small_mastaba>::load() building.h:819
    #5 0x10038c634 in config_load_building_small_mastaba() monument_mastaba.cpp:45
    #6 0x101332450 in config::refresh(archive) js_game.cpp:102
    #7 0x10132aa08 in js_vm_sync() js.cpp:123
    #8 0x10000482c in setup() akhenaten.cpp:413
    #9 0x100004408 in main akhenaten.cpp:629
    #10 0x197f9c270  (<unknown module>)

0x000101ba7f48 is located 84 bytes after global variable 'category_for_int_arr_ph' defined in '/Users/np/src/Akhenaten/src/city/labor.cpp' (0x101ba7b40) of size 948
SUMMARY: AddressSanitizer: global-buffer-overflow labor.cpp:250 in city_labor_set_category(e_building_type, int)
Shadow bytes around the buggy address:
  0x000101ba7c80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000101ba7d00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000101ba7d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000101ba7e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x000101ba7e80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 04 f9
=>0x000101ba7f00: f9 f9 f9 f9 f9 f9 f9 f9 f9[f9]f9 f9 f9 f9 f9 f9
  0x000101ba7f80: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x000101ba8000: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 04 f9 f9 f9
  0x000101ba8080: 01 f9 f9 f9 04 f9 f9 f9 04 f9 f9 f9 01 f9 f9 f9
  0x000101ba8100: 04 f9 f9 f9 01 f9 f9 f9 04 f9 f9 f9 04 f9 f9 f9
  0x000101ba8180: 04 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==45177==ABORTING
(lldbinit) AddressSanitizer report breakpoint hit. Use 'thread info -s' to get extended information about the report.
------------------------------------------------------------------------------------------------------[regs]
   X0:  0x0000000000000000   X8:  0x0000000105F731A8  X16:  0x0000000105F870D0  X24:  0x10000000000FFFFF
   X1:  0x0000000000000000   X9:  0x0000000000000000  X17:  0x0000000105FBC0C0  X25:  0x0000010000000000
   X2:  0x0000000000010000  X10:  0x1000000000000000  X18:  0x0000000000000000  X26:  0x0000000105FD3CF8
   X3:  0x000000016FDFD402  X11:  0x1000000000000000  X19:  0x000000016FDFE236  X27:  0x10000000000FFFFF
   X4:  0x0000000000000000  X12:  0x0000000000000000  X20:  0x0000000105FD36E8  X28:  0x0000010000000000
   X5:  0x0000000000000000  X13:  0x00000001060646A8  X21:  0xAFFFFF00000FFFFF   FP:  0x000000016FDFD5B0
   X6:  0x0000000000000000  X14:  0x0000000000000000  X22:  0x0000000105FD3700   LR:  0x0000000105F8E7A0
   X7:  0x0000000000000000  X15:  0xFFFFFFFFFFFFFFFF  X23:  0x0000000105FD3000   SP:  0x000000016FDFD5B0
   PC:  0x0000000105F731A8  n Z c v a i f
------------------------------------------------------------------------------------------------------[code]
__asan::AsanDie() @ /Library/Developer/CommandLineTools/usr/lib/clang/16/lib/darwin/libclang_rt.asan_osx_dynamic.dylib:
->  0x105f731a8 (0x5f1a8): 7f 23 03 d5  pacibsp   
    0x105f731ac (0x5f1ac): f4 4f be a9  stp       x20, x19, [sp, #-0x20]!
    0x105f731b0 (0x5f1b0): fd 7b 01 a9  stp       x29, x30, [sp, #0x10]
    0x105f731b4 (0x5f1b4): fd 43 00 91  add       x29, sp, #0x10
    0x105f731b8 (0x5f1b8): 08 03 00 90  adrp      x8, 96
    0x105f731bc (0x5f1bc): 08 51 1c 91  add       x8, x8, #0x714 ; __asan::AsanDie()::num_calls
    0x105f731c0 (0x5f1c0): 29 00 80 52  mov       w9, #0x1 ; =1 
    0x105f731c4 (0x5f1c4): 08 01 e9 b8  ldaddal   w9, w8, [x8]
------------------------------------------------------------------------------------------------------------
Process 45177 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = Global buffer overflow
    frame #0: 0x0000000105f731a8 libclang_rt.asan_osx_dynamic.dylib`__asan::AsanDie()
Target 0: (akhenaten) stopped.
```