### PR TITLE
Fix buffer overflow in game_menu.cpp

### DIFF
--- a/src/window/game_menu.cpp
+++ b/src/window/game_menu.cpp
@@ -135,7 +135,7 @@ static void handle_input(const mouse* m, const hotkeys* h) {
         window_player_selection_show();
     }
     const mouse* m_dialog = mouse_in_dialog(m);
-    if (generic_buttons_handle_mouse(m_dialog, {0, 0}, buttons, 7, &data.focus_button_id)) {
+    if (generic_buttons_handle_mouse(m_dialog, {0, 0}, buttons, (int)std::size(buttons), &data.focus_button_id)) {
         return;
     }
 }


### PR DESCRIPTION
After this it is possible to start a new game on mac.
![image](https://github.com/user-attachments/assets/3f460693-f12a-4ffe-a8f3-32cbbdf45d85)
