### PR TITLE
Update GH actions before they are sunsetted

### DIFF
--- a/.github/workflows/akhenaten_android.yml
+++ b/.github/workflows/akhenaten_android.yml
@@ -11,10 +11,10 @@ jobs:
     name: run on linux
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: temurin

--- a/.github/workflows/akhenaten_content.yml
+++ b/.github/workflows/akhenaten_content.yml
@@ -9,7 +9,7 @@ jobs:
     name: run content
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: update-workspace

--- a/.github/workflows/akhenaten_windows.yml
+++ b/.github/workflows/akhenaten_windows.yml
@@ -11,7 +11,7 @@ jobs:
     name: run on windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: ilammy/msvc-dev-cmd@v1.12.1


### PR DESCRIPTION
There are reports that github started disabling cache@v3, upload-artefact@v3 and other older actions.