### PR TITLE
Changes to make Mac bundle

### DIFF
--- a/src/platform/akhenaten.cpp
+++ b/src/platform/akhenaten.cpp
@@ -149,7 +149,11 @@ static bool pre_init(pcstr custom_data_dir) {
 #if !defined(GAME_PLATFORM_ANDROID)
     // ...then from the executable base path...
     static_assert(SDL_VERSION_ATLEAST(2, 0, 1), "SDL version too old");
+#if defined(GAME_PLATFORM_MACOSX)
+    char* tmp_path = SDL_GetPrefPath("", "Akhenaten");
+#else
     char* tmp_path = SDL_GetBasePath();
+#endif
     bstring512 base_path(tmp_path);
     SDL_free(tmp_path);
     if (pre_init_dir_attempt(base_path, "Attempting to load game from base path %s")) {

--- a/src/platform/prefs.cpp
+++ b/src/platform/prefs.cpp
@@ -15,7 +15,11 @@ static FILE* open_pref_file(const char* filename, const char* mode) {
 #if defined(GAME_PLATFORM_ANDROID)
     bstring512 dir_path = SDL_AndroidGetExternalStoragePath();
 #else
+#if defined(GAME_PLATFORM_MACOSX)
+    char* tmp_path = SDL_GetPrefPath("", "Akhenaten");
+#else
     char* tmp_path = SDL_GetBasePath();
+#endif
     bstring512 dir_path(tmp_path);
     SDL_free(tmp_path);
 #endif

--- a/src/sound/sound.cpp
+++ b/src/sound/sound.cpp
@@ -1,10 +1,6 @@
 #include <SDL.h>
 
-#ifdef __APPLE__
-#include <SDL2_mixer/SDL_mixer.h>
-#else
 #include <SDL_mixer.h>
-#endif
 
 #include "sound/sound.h"
 #include "core/game_environment.h"


### PR DESCRIPTION
I'm working on making a Mac bundle for this to post on Mac Source Ports (www.macsourceports.com) and made a couple of changes to fit in my build system, not sure if you would want to merge them. 

I removed the subdirectory for SDL_mixer.h since I don't need it the way I build it. 

I also changed SDL BasePath to SDL_PrefPath on Mac so that a signed/notarized build can find them outside of the bundle. I went with the "~/Library/Application Support/Akhenaten" pattern. 

Let me know if you have any feedback or if changing these would cause an issue. 