### PR TITLE
Add build support for bazzite linux with homebrew; add git for barebone linux installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,24 @@ On Fedora and other `rpm` distributions:
 ##### Running the game
 
 Assuming the zip file is in your Downloads directory:
-```
+```shell
 cd ~/Downloads
 unzip akhenaten_linux.zip
 chmod +x akhenaten.linux
 ./akhenaten.linux
+```
+
+#### Building in Bazzite (https://bazzite.gg/) on Steam Deck or other platform
+You will have to use rpm-ostree to install static version of stdc++ which is not recommended
+and will make system updates slower.
+But you won't be able to build Akhenaten without it. 
+```shell
+rpm-ostree install libstdc++-static
+systemctl reboot
+```
+And after reboot:
+```shell
+./update-workspace-bazzite.sh
 ```
 
 ### MacOS

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -90,6 +90,7 @@ SET(SDL2_SEARCH_PATHS
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
+    /home/linuxbrew/.linuxbrew/opt/sdl2 # bazzite with homebrew
 	${SDL_EXT_DIR}
 	${SDL_MINGW_EXT_DIR}
 )

--- a/cmake/FindSDL2_image.cmake
+++ b/cmake/FindSDL2_image.cmake
@@ -61,6 +61,7 @@ SET(SDL2_SEARCH_PATHS
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
+    /home/linuxbrew/.linuxbrew/opt/sdl2_image # bazzite with homebrew
     ${SDL_EXT_DIR}
     ${SDL_MINGW_EXT_DIR}
 )

--- a/cmake/FindSDL2_mixer.cmake
+++ b/cmake/FindSDL2_mixer.cmake
@@ -57,6 +57,7 @@ SET(SDL2_SEARCH_PATHS
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
+    /home/linuxbrew/.linuxbrew/opt/sdl2_mixer # bazzite with homebrew
     ${SDL_EXT_DIR}
     ${SDL_MINGW_EXT_DIR}
 )

--- a/update-workspace-bazzite.sh
+++ b/update-workspace-bazzite.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+brew install sdl2 sdl2_mixer sdl2_image
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cd ..

--- a/update-workspace-linux.sh
+++ b/update-workspace-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 sudo apt -qq update
-sudo apt install --yes cmake build-essential libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev
+sudo apt install --yes git cmake build-essential libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..


### PR DESCRIPTION
1. Added new script to prepare environment in bazzite (steamos-like distribution targeted for gaming handhelds and desktops, based on Fedora Silverblue).
2. Updated FindSDL2*.cmake files to search for SDL in bazzite's homebrew directories.
3. Updated update-workspace-linux.sh script to install git in fresh debian/ubuntu installations.