### PR TITLE
Fix config windows scaling issues in MacOS

### DIFF
--- a/src/platform/akhenaten.cpp
+++ b/src/platform/akhenaten.cpp
@@ -165,7 +165,12 @@ static bool pre_init(pcstr custom_data_dir) {
 /** Show configuration window to override parameters of the startup.
  */
 static void show_options_window(Arguments& args) {
+#ifndef __APPLE__
     auto const window_flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
+#else
+    auto const window_flags = SDL_WINDOW_RESIZABLE;
+#endif
+    
     SDL_Window* platform_window = SDL_CreateWindow("Akhenaten: configuration", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
 
     SDL_Renderer* renderer = SDL_CreateRenderer(platform_window, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);


### PR DESCRIPTION
Before:
<img width="1392" height="860" alt="image" src="https://github.com/user-attachments/assets/96e881bf-35da-49a5-835b-941742897652" />
After:
<img width="1392" height="860" alt="image" src="https://github.com/user-attachments/assets/6097fab1-690c-451f-85a9-6ef7b41b8529" />
