### PR TITLE
Chore: ignore SDL_mixer.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/platform/version.c
 res/version.rc
 res/version.txt
 res/akhenaten.icns
+src/SDL_mixer.h
 
 # Build output and data directories
 /build*/


### PR DESCRIPTION
Hey, sup?!
I think this is self explanatory. Is there a reason to not ignore this generated file?
Thank youuu, see ya'll later.