### PR TITLE
fix(scenario): prevent crash in Seth's major curse path (#360)

### DIFF
--- a/src/scenario/scenario_invasion.cpp
+++ b/src/scenario/scenario_invasion.cpp
@@ -227,7 +227,12 @@ tile2i scenario_start_invasion_impl(invasion_opts_t opts) {
             auto &lands = g_scenario.invasion_points_land;
             svector<tile2i, 8> points;
             std::copy_if(lands.begin(), lands.end(), std::back_inserter(points), [] (auto &p) { return p.valid(); });
-            invasion_tile = points.at(rand() % points.size());
+            if (points.empty()) {
+                logs::warn("scenario_invasion: no valid land invasion points, falling back to map exit");
+                invasion_tile = tile2i::invalid;
+            } else {
+                invasion_tile = points.at(rand() % points.size());
+            }
         } else {
             invasion_tile = opts.invasion_point;
         }


### PR DESCRIPTION
## Summary

Fixes #360.

`scenario_start_invasion_impl` could crash with SIGSEGV when `opts.invasion_point` is `tile2i::invalid` (e.g. from Seth's major curse → `perform_hailstorm` → `invasion_start_from_seth`) on scenarios where `g_scenario.invasion_points_land` has no valid entries. The code would hit `points.at(rand() % points.size())` on an empty container, triggering `rand() % 0` and out-of-bounds access.

This PR adds an explicit empty check: when no valid land invasion points are available, fall through to the already-existing `if (!invasion_tile.valid()) invasion_tile = scenario_map_exit();` fallback below, and emit a `logs::warn` for diagnostics.

## Changes

- `src/scenario/scenario_invasion.cpp` (+6 / -1): one defensive `if (points.empty())` branch in `scenario_start_invasion_impl`.

## Verification

- Loaded the savegame attached to #360 (mission 4 Mennefer) on `master` (`281ad84f3`) — crash reproduced with the exact stack trace from the issue.
- Applied this fix on a local branch, rebuilt (`cmake --build --preset macos-clang-relwithdebinfo-ninja-arm64`), loaded the same save, advanced ~1 in-game month: no crash. Log shows `warn: scenario_invasion: no valid land invasion points, falling back to map exit`; the invasion spawns from the map-exit path and the game continues normally.
- `git clang-format --diff master` — no modifications required.

## Scope

Minimal, defensive change. No gameplay or UI alteration — only guards against undefined behaviour in the empty-points edge case.
