### PR TITLE
fix(figure_docker): guard figure_action/on_destroy against destroyed home building (#364)

### DIFF
--- a/src/figuretype/figure_docker.cpp
+++ b/src/figuretype/figure_docker.cpp
@@ -334,13 +334,21 @@ void figure_docker::figure_action() {
     base.use_cart = true;
     if (b->state != BUILDING_STATE_VALID) {
         poof();
+        return;
     }
 
     if (b->type != BUILDING_DOCK && b->type != BUILDING_FISHING_WHARF) {
         poof();
+        return;
     }
 
-    auto &dock = b->dcast_dock()->runtime_data();
+    building_dock* dock_b = b->dcast_dock();
+    if (!dock_b) {
+        poof();
+        return;
+    }
+
+    auto& dock = dock_b->runtime_data();
     if (dock.num_ships) {
         dock.num_ships--;
     }
@@ -562,10 +570,15 @@ void figure_docker::on_destroy() {
         return;
     }
 
-    auto &dock = home()->dcast_dock()->runtime_data();
+    auto dock = home()->dcast_dock();
+    if (!dock) {
+        return;
+    }
+
+    auto& rt = dock->runtime_data();
     for (int i = 0; i < 3; i++) {
-        if (dock.docker_ids[i] == id()) {
-            dock.docker_ids[i] = 0;
+        if (rt.docker_ids[i] == id()) {
+            rt.docker_ids[i] = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #364. `figure_docker::figure_action` and `::on_destroy` could SIGSEGV when the docker's home dock was destroyed while the walker was still alive. Both sites dereferenced `home()->dcast_dock()->runtime_data()` without guarding against a null `dcast_dock()`.

## Changes

- `src/figuretype/figure_docker.cpp` (+17 / −4):
  - `figure_action`: `return` after `poof()` in the invalid-state / wrong-type branches; null-check the result of `dcast_dock()` before accessing `runtime_data()`.
  - `on_destroy`: same null-check before clearing `docker_ids`.

## Verification

- On `origin/master` (`08b594b01`): reproduced the crash from #364 on the attached save with the same stack trace.
- With this patch: same save, same steps — no crash; walker correctly despawns once its home is gone.
- `git clang-format --diff origin/master`: no modifications required.

## Scope

Defensive only — no gameplay or UI change.