### PR TITLE
fix(ui): restore simple-callback binding in egeneric_button::draw

### DIFF
--- a/src/graphics/elements/ui.cpp
+++ b/src/graphics/elements/ui.cpp
@@ -2018,6 +2018,9 @@ void ui::egeneric_button::draw(UiFlags gflags) {
     if (clickable && _func && js_ref(ONCLICK).empty() && onclick_event.empty()) {
         btn->onclick(_func);
     }
+    if (clickable && _sfunc && js_ref(ONCLICK).empty() && onclick_event.empty()) {
+        btn->onclick(_sfunc);
+    }
     if (clickable && _rfunc && js_ref(ONRCLICK).empty()) {
         btn->onrclick(_rfunc);
     }


### PR DESCRIPTION
## Summary

Restore the button onclick binding that was accidentally dropped in 978f45991 ("ui: removed _onclick_event as outdated"). After that refactor, any C++-side `ui["name"].onclick([] { ... })` with a parameterless lambda stopped firing — the button reacted visually but the callback was never invoked.

## Changes

`src/graphics/elements/ui.cpp` — in `ui::egeneric_button::draw`, re-add the three lines that attach the `_sfunc` (parameterless) callback to the button, right after the existing `_func` block:

```cpp
if (clickable && _sfunc && js_ref(ONCLICK).empty() && onclick_event.empty()) {
    btn->onclick(_sfunc);
}
```

The `_sfunc` member itself was not removed by 978f45991 and is still populated by the `.onclick(lambda)` overload — only the attach step had to be restored.

## Verification

Built on `macos-clang-relwithdebinfo-ninja-arm64` (build 11792), tested on a mid-game Behdet save:

- Storage Yard → right-click → "Special Orders" → orders screen now opens.
- In the orders screen: per-resource state cycling, `empty_all`, `accept_none`, and close button all respond.
- Granary → "Special Orders" behaves the same way.
- Previously-working controls (advisor icon, close/help `image_button` etc.) remain functional.

## Scope

Fixes #368.

Does not touch:
- `_onclick_event` (the refactor of that member to a local is kept; this PR only restores the accidentally removed `_sfunc` block).
- Unrelated `Local stack buffer exceeded` log spam observed in Storage Yard info windows — separate issue.
