### PR TITLE
ui: move storage yard orders window to scripts (POC, alternative to #369)

### DIFF
--- a/src/building/building_storage_js.cpp
+++ b/src/building/building_storage_js.cpp
@@ -1,0 +1,66 @@
+#include "building_storage.h"
+#include "building/building.h"
+#include "js/js_game.h"
+#include "core/profiler.h"
+#include "graphics/elements/ui.h"
+#include "graphics/elements/arrow_button.h"
+
+int __storage_yard_storage_id(int bid) {
+    building *raw = building_get(bid);
+    if (!raw) { return 0; }
+    auto b = raw->dcast_storage();
+    return b ? b->storage_id() : 0;
+}
+ANK_FUNCTION_1(__storage_yard_storage_id)
+
+bool __storage_yard_is_empty_all(int storage_id) {
+    const storage_t *s = building_storage_get(storage_id);
+    return s ? (bool)s->empty_all : false;
+}
+ANK_FUNCTION_1(__storage_yard_is_empty_all)
+
+int __storage_yard_resource_state(int storage_id, int resource_id) {
+    const storage_t *s = building_storage_get(storage_id);
+    return s ? s->resource_state[resource_id] : 0;
+}
+ANK_FUNCTION_2(__storage_yard_resource_state)
+
+int __storage_yard_resource_max_accept(int storage_id, int resource_id) {
+    const storage_t *s = building_storage_get(storage_id);
+    return s ? s->resource_max_accept[resource_id] : 0;
+}
+ANK_FUNCTION_2(__storage_yard_resource_max_accept)
+
+int __storage_yard_resource_max_get(int storage_id, int resource_id) {
+    const storage_t *s = building_storage_get(storage_id);
+    return s ? s->resource_max_get[resource_id] : 0;
+}
+ANK_FUNCTION_2(__storage_yard_resource_max_get)
+
+void __storage_yard_toggle_empty_all(int storage_id) {
+    building_storage_toggle_empty_all(storage_id);
+}
+ANK_FUNCTION_1(__storage_yard_toggle_empty_all)
+
+void __storage_yard_accept_none(int storage_id) {
+    building_storage_accept_none(storage_id);
+}
+ANK_FUNCTION_1(__storage_yard_accept_none)
+
+void __storage_yard_cycle_resource_state(int storage_id, int resource_id, bool backwards) {
+    building_storage_cycle_resource_state(storage_id, resource_id, backwards);
+}
+ANK_FUNCTION_3(__storage_yard_cycle_resource_state)
+
+void __storage_yard_increase_decrease_resource_state(int storage_id, int resource_id, bool increase) {
+    building_storage_increase_decrease_resource_state(storage_id, resource_id, increase);
+}
+ANK_FUNCTION_3(__storage_yard_increase_decrease_resource_state)
+
+void __storage_yard_draw_arw_button(int pos_x, int pos_y, bool down, int storage_id, int resource_id, bool increase) {
+    auto &btn = ui::arw_button({pos_x, pos_y}, down, true);
+    btn.onclick([storage_id, resource_id, increase] {
+        building_storage_increase_decrease_resource_state(storage_id, resource_id, increase);
+    });
+}
+ANK_FUNCTION_6(__storage_yard_draw_arw_button)

--- a/src/scripts/city.js
+++ b/src/scripts/city.js
@@ -369,6 +369,10 @@ city.get_bazaar = function(building_id) {
     return new Bazaar(building_id)
 }
 
+city.get_storage_yard = function(building_id) {
+    return new StorageYard(building_id)
+}
+
 city.create_good_request = function(obj) {
     __city_create_good_request(obj)
     return {

--- a/src/scripts/modules.js
+++ b/src/scripts/modules.js
@@ -14,6 +14,7 @@ import gods
 import city
 import building_prototype
 import bazaar_prototype
+import storage_yard_prototype
 import city_finance
 import city_ratings
 import city_festival

--- a/src/scripts/storage_yard_prototype.js
+++ b/src/scripts/storage_yard_prototype.js
@@ -1,0 +1,18 @@
+log_info("akhenaten: storage_yard_prototype.js loaded")
+
+function StorageYard(building_id) {
+    this.id = building_id
+    this.storage_id = __storage_yard_storage_id(building_id)
+}
+
+StorageYard.prototype = Object.create(Building.prototype)
+StorageYard.prototype.constructor = StorageYard
+
+StorageYard.prototype.is_empty_all = function() { return __storage_yard_is_empty_all(this.storage_id) }
+StorageYard.prototype.resource_state = function(resource_type) { return __storage_yard_resource_state(this.storage_id, resource_type) }
+StorageYard.prototype.resource_max_accept = function(resource_type) { return __storage_yard_resource_max_accept(this.storage_id, resource_type) }
+StorageYard.prototype.resource_max_get = function(resource_type) { return __storage_yard_resource_max_get(this.storage_id, resource_type) }
+StorageYard.prototype.toggle_empty_all = function() { __storage_yard_toggle_empty_all(this.storage_id) }
+StorageYard.prototype.accept_none = function() { __storage_yard_accept_none(this.storage_id) }
+StorageYard.prototype.cycle_resource_state = function(resource_type, backwards) { __storage_yard_cycle_resource_state(this.storage_id, resource_type, backwards) }
+StorageYard.prototype.increase_decrease_resource_state = function(resource_type, increase) { __storage_yard_increase_decrease_resource_state(this.storage_id, resource_type, increase) }

--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -26,6 +26,7 @@ import ui_granary_info
 import ui_records_window
 import ui_bazaar_orders_window
 import ui_bazaar_window
+import ui_storage_yard_orders_window
 import ui_advisor_chief
 import ui_mission_briefing_window
 import ui_empire_window

--- a/src/scripts/ui_storage_yard_orders_window.js
+++ b/src/scripts/ui_storage_yard_orders_window.js
@@ -1,0 +1,130 @@
+log_info("akhenaten: ui storage yard orders window started")
+
+var STORAGE_STATE_PHARAOH_ACCEPT = 0
+var STORAGE_STATE_PHARAOH_REFUSE = 1
+var STORAGE_STATE_PHARAOH_GET    = 2
+var STORAGE_STATE_PHARAOH_EMPTY  = 3
+
+var current_storage_yard = null
+
+function storage_yard_order_instruction(storage, resource) {
+    var state = storage.resource_state(resource)
+    if (state == STORAGE_STATE_PHARAOH_ACCEPT) {
+        var max_accept = storage.resource_max_accept(resource)
+        var label = String(max_accept)
+        if (max_accept == 3200) { label = __loc(99, 28) }
+        else if (max_accept == 2400) { label = __loc(99, 27) }
+        else if (max_accept == 1600) { label = __loc(99, 26) }
+        else if (max_accept == 800)  { label = __loc(99, 25) }
+        var adv = ""
+        if (max_accept == 2400 || max_accept == 1600 || max_accept == 800) { adv = __loc(99, 29) }
+        return { text: __loc(99, 18) + " " + label + " " + adv, font: FONT_NORMAL_WHITE_ON_DARK }
+    }
+    if (state == STORAGE_STATE_PHARAOH_REFUSE) {
+        return { text: __loc(99, 8), font: FONT_NORMAL_BLACK_ON_DARK }
+    }
+    if (state == STORAGE_STATE_PHARAOH_GET) {
+        var max_get = storage.resource_max_get(resource)
+        var label = String(max_get)
+        if (max_get == 3200) { label = __loc(99, 31) }
+        else if (max_get == 2400) { label = __loc(99, 27) }
+        else if (max_get == 1600) { label = __loc(99, 26) }
+        else if (max_get == 800)  { label = __loc(99, 25) }
+        var adv = ""
+        if (max_get == 2400 || max_get == 1600 || max_get == 800) { adv = __loc(99, 29) }
+        return { text: __loc(99, 19) + " " + label + " " + adv, font: FONT_NORMAL_YELLOW }
+    }
+    if (state == STORAGE_STATE_PHARAOH_EMPTY) {
+        return { text: __loc(99, 21), font: FONT_NORMAL_BLACK_ON_DARK }
+    }
+    return { text: "unknown_storage", font: FONT_NORMAL_BLACK_ON_DARK }
+}
+
+function storage_yard_orders_window_accept_none() {
+    if (current_storage_yard) { current_storage_yard.accept_none() }
+}
+
+function storage_yard_orders_window_toggle_empty_all() {
+    if (current_storage_yard) { current_storage_yard.toggle_empty_all() }
+}
+
+function storage_yard_orders_window_empty_all_text() {
+    if (!current_storage_yard) { return "" }
+    return current_storage_yard.is_empty_all() ? __loc(99, 5) : __loc(99, 4)
+}
+
+function storage_yard_orders_list_on_click_item(p) {
+    if (!p || p.user_data === undefined || !current_storage_yard) { return }
+    current_storage_yard.cycle_resource_state(p.user_data, false)
+}
+
+function storage_yard_orders_list_on_dblclick_item(p) {
+    if (!p || p.user_data === undefined || !current_storage_yard) { return }
+    current_storage_yard.cycle_resource_state(p.user_data, true)
+}
+
+function storage_yard_orders_list_on_render_item(p) {
+    var resId = p.user_data
+    if (resId === undefined || resId === RESOURCE_NONE || !current_storage_yard) { return }
+
+    ui.resource_icon([p.x + 25, p.y + 2], resId)
+    ui.label_ex(__loc(23, resId), [p.x + 85, p.y], FONT_NORMAL_WHITE_ON_DARK, UiFlags_AlignYCentered, 150)
+
+    var state = current_storage_yard.resource_state(resId)
+    if (state == STORAGE_STATE_PHARAOH_ACCEPT || state == STORAGE_STATE_PHARAOH_GET) {
+        __storage_yard_draw_arw_button(p.x + p.sizex - 60, p.y + 2, false, current_storage_yard.storage_id, resId, true)
+        __storage_yard_draw_arw_button(p.x + p.sizex - 40, p.y + 2, true,  current_storage_yard.storage_id, resId, false)
+    }
+
+    var instr = storage_yard_order_instruction(current_storage_yard, resId)
+    ui.label_ex(instr.text, [p.x + p.sizex - 280, p.y], instr.font, UiFlags_AlignYCentered, 220)
+
+    if (p.hover) {
+        ui.border({x: p.x + 4, y: p.y - 2}, {x: p.sizex - 8, y: p.sizey + 2}, 0, COLOR_TOOLTIP_BORDER, UiFlags_None)
+    }
+}
+
+[es=modal_window]
+storage_yard_orders_window {
+    pos: [(sw(0) - px(29)) / 2, (sh(0) - px(17)) / 2]
+    draw_underlying: true
+    allow_rmb_goback: true
+
+    ui {
+        background   : outer_panel({size[29, 17]}),
+        title        : text({pos[0, 12], size[px(28), 0], text:{group:99, id:3}, font : FONT_LARGE_BLACK_ON_LIGHT, align:"center"})
+        goods_list   : scrollable_list({
+            pos[16, 42]
+            size[27, 11]
+            view_items: 8
+            buttons_size_y: 20
+            buttons_margin_x: 0
+            buttons_margin_y: 5
+            text_padding_x: 0
+            text_padding_y: 0
+            draw_scrollbar_always: false
+            draw_paneling: true
+            onrender_item: storage_yard_orders_list_on_render_item
+            onclick_item: storage_yard_orders_list_on_click_item
+            ondoubleclick_item: storage_yard_orders_list_on_dblclick_item
+        })
+        empty_all    : button({pos[80, -1], size[300, 24], textfn: storage_yard_orders_window_empty_all_text, margin{bottom:-64}, onclick: storage_yard_orders_window_toggle_empty_all })
+        accept_none  : button({pos[80, -1], size[300, 24], text:{group:99, id:7}, margin{bottom:-38}, onclick: storage_yard_orders_window_accept_none })
+
+        button_help   : help_button({})
+        button_close  : close_button({ onclick: window_go_back })
+    }
+}
+
+[es=(storage_yard_orders_window, init)]
+function storage_yard_orders_window_init(window) {
+    ui.set_window_pos("storage_yard_orders_window", city.object_info.offset)
+
+    current_storage_yard = city.get_storage_yard(city.object_info.building_id)
+
+    window.goods_list.clear()
+    for (var name in city.resources.available) {
+        var resId = city.resources.available[name]
+        window.goods_list.add_item(name, resId)
+    }
+}

--- a/src/scripts/ui_widgets.js
+++ b/src/scripts/ui_widgets.js
@@ -612,7 +612,7 @@ info_window_storageyard = {
         cartstate_img : resource_icon({pos:[32, 260] }),
         cartstate_desc: text({pos: [72, 260], wrap:px(27), font : FONT_NORMAL_BLACK_ON_DARK, multiline:true }),
 
-        orders        : button({margin:{left:100, bottom:-40}, size:[270, 24], text:"${99.2}"}),
+        orders        : button({margin:{left:100, bottom:-40}, size:[270, 24], text:"${99.2}", onclick: show_window_by_id("storage_yard_orders_window") }),
         button_help   : help_button({}),
         button_close  : close_button({}),
         mothball      : button({margin:{right:-90, bottom:-40}, size:[23, 23], textfn:building_info_window_text_mothball, onclick: building_info_window_toggle_mothball }),


### PR DESCRIPTION
## Summary

POC / alternative to #369. Migrates Storage Yard "Special Orders" window from C++ to a JS modal, following `ui_bazaar_orders_window.js` pattern.

## What's in

**New:**
- `src/building/building_storage_js.cpp` — ANK_FUNCTION bindings for storage state / operations / arrow-button drawing.
- `src/scripts/storage_yard_prototype.js` — `StorageYard` JS class mirroring `Bazaar`.
- `src/scripts/ui_storage_yard_orders_window.js` — `[es=modal_window]` orders window.

**Modified:** `city.js` (`get_storage_yard`), `modules.js` / `ui.js` (imports), `ui_widgets.js` (orders button triggers `show_window_by_id`).

## Tested

Behdet save. Open / state cycle / arrows / accept-none / empty-all / close — all behave like the old C++ screen.

## Scope

- Old `window_info_storageyard_orders.cpp/.h` kept in tree (no longer reachable, not deleted).
- Only Storage Yard migrated — Granary / Dock still need either #369 or the same migration.

Not in conflict with #369; either / both can land.

---

## От автора

Попытался перенести «дескриптор в скрипты» на примере Storage Yard по аналогии с `ui_bazaar_orders_window.js`. Работает, но **не уверен, что подход верный** — пришлось добавить специализированный биндинг `__storage_yard_draw_arw_button` (в JS API нет `ui.arw_button`). 

Вероятн оя решил взять слишком большой блок, как по мне, что-то не так. 

Референс-скрин старого C++ окна приложу в комментарии.
