### PR TITLE
fix(ui): route storage orders clicks through _func overload

### DIFF
--- a/src/window/window_granary_info.cpp
+++ b/src/window/window_granary_info.cpp
@@ -78,7 +78,7 @@ void granary_info_window::init(object_info &c) {
     const uint8_t laborers = granary->max_workers();
     ui["workers_text"].text_var("%u %s (%d %s", granary->num_workers(), ui::str(8, 12), laborers, ui::str(69, 0));
 
-    ui["orders"].onclick([&c] {
+    ui["orders"].onclick([&c](int, int) {
         window_granary_orders_show(c);
     });
 }

--- a/src/window/window_granary_orders.cpp
+++ b/src/window/window_granary_orders.cpp
@@ -74,15 +74,15 @@ void granary_orders_window::init(object_info &c) {
     auto granary = c.building_get()->dcast_granary();
     backup_storage_settings(storage_id);
 
-    ui["empty_all"].onclick([storage_id] {
+    ui["empty_all"].onclick([storage_id](int, int) {
         building_storage_toggle_empty_all(storage_id);
     });
 
-    ui["accept_none"].onclick([storage_id] {
+    ui["accept_none"].onclick([storage_id](int, int) {
         building_storage_accept_none(storage_id);
     });
 
-    ui["button_close"].onclick([&c] {
+    ui["button_close"].onclick([&c](int, int) {
         events::emit(event_show_tile_info{ tile2i(c.grid_offset), /*avoid_mouse*/true, SOURCE_LOCATION });
     });
 }

--- a/src/window/window_info_dock.cpp
+++ b/src/window/window_info_dock.cpp
@@ -48,7 +48,7 @@ void dock_info_window::init(object_info &c) {
 
     ui["workers_desc"] = reason;
 
-    ui["orders"].onclick([&c] {
+    ui["orders"].onclick([&c](int, int) {
         c.ui = &dock_orders_infow;
         c.ui->init(c);
     });
@@ -58,12 +58,12 @@ void dock_orders_window::init(object_info &c) {
     building_info_window::init(c);
 
     building *b = c.building_get();
-    ui["accept_none"].onclick([building_id = b->id] {
+    ui["accept_none"].onclick([building_id = b->id](int, int) {
         building_dock *b = ::building_get(building_id)->dcast_dock();
         b->unaccept_all_goods();
     });
 
-    ui["button_close"].onclick([grid_offset = c.grid_offset] {
+    ui["button_close"].onclick([grid_offset = c.grid_offset](int, int) {
         events::emit(event_show_tile_info{ tile2i(grid_offset), /*avoid_mouse*/true, SOURCE_LOCATION });
     });
 }

--- a/src/window/window_info_storageyard.cpp
+++ b/src/window/window_info_storageyard.cpp
@@ -90,7 +90,7 @@ void info_window_storageyard::init(object_info &c) {
         }
     }
 
-    ui["orders"].onclick([&c] {
+    ui["orders"].onclick([&c](int, int) {
         c.storage_show_special_orders = 1;
     });
 }

--- a/src/window/window_info_storageyard_orders.cpp
+++ b/src/window/window_info_storageyard_orders.cpp
@@ -37,11 +37,11 @@ void info_window_storageyard_orders::draw_background(object_info *c) {
     int storage_id = storage->storage_id();
     ui["empty_all"] = storage->is_empty_all() ? ui::str(99, 5) : ui::str(99, 4);
 
-    ui["empty_all"].onclick([storage_id] {
+    ui["empty_all"].onclick([storage_id](int, int) {
         building_storage_toggle_empty_all(storage_id);
     });
 
-    ui["accept_none"].onclick([storage_id] {
+    ui["accept_none"].onclick([storage_id](int, int) {
         building_storage_accept_none(storage_id);
     });
 }


### PR DESCRIPTION
## Summary

Fixes #368 for Storage Yard / Granary / Dock. **Third option alongside #369 and #370.**

After 978f45991 removed the `_sfunc` binding in `egeneric_button::draw`, `ui["name"].onclick([]{ ... })` call sites with void lambdas stopped reaching the button widget. The `_func` branch (`void(int, int)`) is still wired in `egeneric_button::draw`, so switching the affected lambdas from `[]{ ... }` to `[](int, int) { ... }` routes the click back — without touching `ui.cpp` and without reviving the removed `_sfunc` path.

## Relation to #369 and #370

- **#369** restored `_sfunc` globally via a 3-line revert in `ui.cpp`. Maintainer asked to move handle to scripts instead.
- **#370** is a POC full migration of the Storage Yard orders window to a JS modal — bigger change, new C++ bindings + new scripts, only covers Storage Yard.
- **This PR** is a third, minimal option: no `ui.cpp` change, no new bindings, no JS migration. Just adjust the lambda signature at the broken call sites to land on the still-live `_func` path.

## Changes

10 edits in 5 files, same shape everywhere:

```diff
- ui["X"].onclick([capture] {
+ ui["X"].onclick([capture](int, int) {
      ...
  });
```

Files:
- `src/window/window_info_storageyard.cpp` — 1 (`orders`)
- `src/window/window_info_storageyard_orders.cpp` — 2 (`empty_all`, `accept_none`)
- `src/window/window_granary_info.cpp` — 1 (`orders`)
- `src/window/window_granary_orders.cpp` — 3 (`empty_all`, `accept_none`, `button_close`)
- `src/window/window_info_dock.cpp` — 3 (`orders`, `accept_none`, `button_close`)

## Why this doesn't regress anything else

`ui.button(...)` / `ui.arw_button(...)` return `generic_button&` / `arrow_button&` **directly**, bypassing `egeneric_button::draw`. Their `_onclick_void` (direct widget field) has always been fired in `generic_button.cpp:50-51` / `arrow_button.cpp:104-105, 127-128` and is unaffected by 978f45991. The regression only bites `ui["name"].onclick(...)` via the element wrapper — which is exactly the 10 sites touched here.

## Tested

Behdet save, macOS clang RelWithDebInfo, build 11797:

- Storage Yard / Granary / Dock → right-click → Special Orders → sub-window opens.
- `empty_all` / `accept_none` / `button_close` — all respond.
- Per-resource cycle (left / right click on a row) — unchanged, still works.
- `+` / `−` arrows on rows with threshold states — unchanged, still work.
- Close via Esc or the «V» button — work.

Screenshots attached in the first comment.

## Scope

Only Storage Yard / Granary / Dock orders chain touched (10 call sites). The other `ui["X"].onclick([]{})` call sites listed in #368 (popup_dialog, message_list, mission_end, tax_collector arrows, barracks, mansion, gift_to_kingdom) are **not included** in this PR. If this approach is acceptable I can extend it to the remaining sites in a follow-up, or leave them for proper script migration if that's the preferred direction.

## Why not

- No `_sfunc` revival — stays consistent with 978f45991 intent.
- No new C++→JS bindings — no new surface, no maintenance cost.
- No `ui.cpp` change — zero risk to the rest of the UI.