### PR TITLE
fix: remove dangling js_register_storage_yard after building_storage_js.cpp deletion

### DIFF
--- a/src/js/js.cpp
+++ b/src/js/js.cpp
@@ -769,7 +769,6 @@ void js_reset_vm_state() {
     js_register_building(vm.J);
     js_register_imperial_visible_request(vm.J);
     js_register_house(vm.J);
-    js_register_storage_yard(vm.J);
     js_register_ui_objects(vm.J);
     //js_register_mouse_functions(vm.J);
     //js_register_hotkey_functions(vm.J);

--- a/src/js/js_game.h
+++ b/src/js/js_game.h
@@ -870,7 +870,6 @@ void js_register_city_objects(js_State *J);
 void js_register_building(js_State *J);
 void js_register_imperial_visible_request(js_State *J);
 void js_register_house(js_State *J);
-void js_register_storage_yard(js_State *J);
 js_Object *js_get_building_prototype(void);
 void js_register_ui_objects(js_State *J);
 void js_register_mission_vars(const settings_vars_t &vars);


### PR DESCRIPTION
## Summary

`src/building/building_storage_js.cpp` was deleted in 36799d0d0 as part of the storage yard JS migration, but the C++ declaration and call of `js_register_storage_yard` were not cleaned up. Current master fails to link on macOS:

```
Undefined symbols for architecture arm64:
  "js_register_storage_yard(js_State*)", referenced from:
      js_reset_vm_state() in js.cpp.o
```

## Changes

- `src/js/js_game.h` — remove declaration `void js_register_storage_yard(js_State *);`
- `src/js/js.cpp` — remove `js_register_storage_yard(vm.J);` in `js_reset_vm_state()`

## Verification

- Before: master `d1577f23d` fails at the final link step on `macos-clang-relwithdebinfo-ninja-arm64`.
- After: clean link; game starts; storage yard info / orders JS windows work as expected.

## Scope

Cleanup only. Does not touch the JS migration itself.