### PR TITLE
fix(labor): bump category arrays to BUILDING_MAX to prevent OOB write

### DIFF
--- a/src/city/city_labor.cpp
+++ b/src/city/city_labor.cpp
@@ -51,7 +51,7 @@ static int category_for_int_arr[300] = {
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 290
 };
 
-static int category_for_int_arr_ph[303] = {
+static int category_for_int_arr_ph[BUILDING_MAX] = {
   // houses
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 0
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10
@@ -263,7 +263,7 @@ constexpr building_type_category category_alias_default[] = {
 };
 
 static bool category_alias_inited = false;
-static e_labor_category category_alias[255];
+static e_labor_category category_alias[BUILDING_MAX];
 
 e_labor_category category_for_building(building* b) {
     if (map_terrain_is(b->tile, TERRAIN_FLOODPLAIN) && b->is_farm()) {


### PR DESCRIPTION
Fixes #379.

## Summary

`category_for_int_arr_ph[303]` and `category_alias[255]` are smaller than `BUILDING_MAX == 328`. `set_category(type, ...)` was writing OOB and clobbering adjacent globals `god_bast` (8 bytes zeroed) and `god_osiris` vtable high half (4 bytes zeroed at offset +4), causing SIGSEGV on later virtual calls into religion (Mission 6 Behdet, ~1 in-game month).

## Changes

- `src/city/city_labor.cpp` (+2 / -2): bump array sizes to `[BUILDING_MAX]`.

## Verification

- Repro in mission 6 Behdet from save: crash reproduced reliably ~1 in-game month → no crash with this fix (played past the original crash point at Jan 2684 BC, pop 672).
- Confirmed via lldb watchpoint that `set_category(BUILDING_MEDIUM_STEPPED_PYRAMID=324, 0)` was the culprit write at `&god_osiris+4`.
- `git clang-format`: no modifications.