### PR TITLE
game: persist scroll speed via akhenaten.cfg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1502,29 +1502,40 @@ if (MSVC)
         "${CMAKE_BINARY_DIR}/${GAME_BUILD_TYPE}/${GAME}.pdb"
         "${CMAKE_SOURCE_DIR}/ext/bugtrap/BugTrap-x64.dll"
     )
+    add_custom_command(
+        TARGET ${GAME}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+        ARGS -E make_directory "${GAME_WORKING_DIRECTORY}"
+    )
     foreach( file_i ${BINARY_FILES})
         add_custom_command(
             TARGET ${GAME}
             POST_BUILD
             COMMAND ${CMAKE_COMMAND}
-            ARGS -E copy ${file_i} "${GAME_WORKING_DIRECTORY}"
+            ARGS -E copy_if_different ${file_i} "${GAME_WORKING_DIRECTORY}"
         )
     endforeach( file_i )
 
-    set(DATA_FILES "${CMAKE_SOURCE_DIR}/data/pharaoh_custom_pack.sgx" "${CMAKE_SOURCE_DIR}/data/pharaoh_fonts_pack.sgx")
-    add_custom_command(
-        OUTPUT
-        ${GAME_WORKING_DIRECTORY}/Data
-        COMMAND ${CMAKE_COMMAND}
-        -E make_directory ${GAME_WORKING_DIRECTORY}/Data
+    set(DATA_FILES
+        "${CMAKE_SOURCE_DIR}/data/pharaoh_custom_pack.sgx"
+        "${CMAKE_SOURCE_DIR}/data/pharaoh_fonts_pack.sgx"
+        "${CMAKE_SOURCE_DIR}/data/pharaoh_houses_pack.sgx"
+        "${CMAKE_SOURCE_DIR}/data/neucha.ttf"
     )
     set(BINARY_FILES_DIRECTORY "${GAME_WORKING_DIRECTORY}/Data")
+    add_custom_command(
+        TARGET ${GAME}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+        ARGS -E make_directory "${BINARY_FILES_DIRECTORY}"
+    )
     foreach( file_i ${DATA_FILES})
         add_custom_command(
             TARGET ${GAME}
             POST_BUILD
             COMMAND ${CMAKE_COMMAND}
-            ARGS -E copy ${file_i} "${BINARY_FILES_DIRECTORY}"
+            ARGS -E copy_if_different ${file_i} "${BINARY_FILES_DIRECTORY}"
         )
     endforeach( file_i )
 endif()

--- a/src/city/city.cpp
+++ b/src/city/city.cpp
@@ -671,7 +671,8 @@ io_buffer* iob_city_data = new io_buffer([](io_buffer* iob, size_t version) {
     iob->bind(BIND_SIGNATURE_INT32, &data.health.value);
     iob->bind(BIND_SIGNATURE_INT32, &data.health.num_mortuary_workers);
     iob->bind(BIND_SIGNATURE_UINT16, &game_speed());
-    iob->bind(BIND_SIGNATURE_UINT16, &game_scroll_speed());
+    static uint16_t unused_scroll_speed_slot = 0;
+    iob->bind(BIND_SIGNATURE_UINT16, &unused_scroll_speed_slot);
     iob->bind(BIND_SIGNATURE_INT32, &data.population.current);
     iob->bind(BIND_SIGNATURE_INT32, &data.population.last_year);
     iob->bind(BIND_SIGNATURE_INT32, &data.population.school_age);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -350,10 +350,9 @@ bool game_t::check_valid() {
     logs::switch_output(vfs::platform_file_manager_get_base_path());
     locale_determine_language();
 
-    scroll_speed = 70;
-
     g_settings.load(); // c3.inf
     game_features::load();   // akhenaten.conf
+    scroll_speed = game_features::gameopt_scroll_speed.to_int();
     game_hotkeys::load();    // hotkeys.conf
     g_scenario.init();
     random_init();
@@ -474,10 +473,12 @@ void game_t::decrease_game_speed() {
 
 void game_t::increase_scroll_speed() {
     scroll_speed = calc_bound(scroll_speed + 10, 0, 100);
+    game_features::gameopt_scroll_speed.set((int)scroll_speed);
 }
 
 void game_t::decrease_scroll_speed() {
     scroll_speed = calc_bound(scroll_speed - 10, 0, 100);
+    game_features::gameopt_scroll_speed.set((int)scroll_speed);
 }
 
 void game_t::before_start_simulation() {

--- a/src/game/game_config.cpp
+++ b/src/game/game_config.cpp
@@ -93,6 +93,7 @@ namespace game_features {
     game_feature gameopt_last_save_filename{ "gameopt_last_save_filename", "", "" };
     game_feature gameopt_enabled_mods{ "gameopt_enabled_mods", "", "" };
     game_feature gameopt_last_game_version{ "gameopt_last_game_version", "", "" };
+    game_feature gameopt_scroll_speed{ "gameopt_scroll_speed", "", 70.0f };
     game_feature gameplay_brewery_requires_water{ "gameplay_brewery_requires_water", "#TR_CONFIG_BREWERY_REQUIRES_WATER", true };
     game_feature gameplay_conservatory_helps_dance_school{ "gameplay_conservatory_helps_dance_school", "#TR_CONFIG_CONSERVATORY_HELPS_DANCE_SCHOOL", true };
     game_feature gameplay_jewels_workshops_culture_bonus{ "gameplay_jewels_workshops_culture_bonus", "#TR_CONFIG_JEWELS_WORKSHOPS_CULTURE_BONUS", true };
@@ -129,6 +130,10 @@ xstring game_features::game_feature::to_string() const {
 
 float game_features::game_feature::to_float() const {
     return _settings.get_float(name);
+}
+
+int game_features::game_feature::to_int() const {
+    return _settings.get_int(name);
 }
 
 void game_features::game_feature::set(bool value) {

--- a/src/game/game_config.h
+++ b/src/game/game_config.h
@@ -16,6 +16,7 @@ namespace game_features {
         bool to_bool() const;
         xstring to_string() const;
         float to_float() const;
+        int to_int() const;
         inline bool operator!() const { return !to_bool(); }
         void set(bool value);
         void set(float value);
@@ -111,6 +112,7 @@ namespace game_features {
     extern game_feature gameopt_last_save_filename;
     extern game_feature gameopt_enabled_mods;
     extern game_feature gameopt_last_game_version;
+    extern game_feature gameopt_scroll_speed;
     extern game_feature gameplay_change_hasanimals;
     extern game_feature gameplay_brewery_requires_water;
     extern game_feature gameplay_conservatory_helps_dance_school;

--- a/src/js/js_game.cpp
+++ b/src/js/js_game.cpp
@@ -20,6 +20,7 @@
 #include "core/app.h"
 #include "game/file_editor.h"
 #include "game/game.h"
+#include "game/game_config.h"
 #include "game/mission.h"
 #include "game/game_events.h"
 #include "game/settings.h"
@@ -476,7 +477,7 @@ void __game_decrease_game_speed() { game.decrease_game_speed(); } ANK_FUNCTION(_
 void __game_increase_scroll_speed() { game.increase_scroll_speed(); } ANK_FUNCTION(__game_increase_scroll_speed)
 void __game_decrease_scroll_speed() { game.decrease_scroll_speed(); } ANK_FUNCTION(__game_decrease_scroll_speed)
 void __game_set_game_speed(int v) { game.game_speed = v; } ANK_FUNCTION_1(__game_set_game_speed)
-void __game_set_scroll_speed(int v) { game.scroll_speed = v; } ANK_FUNCTION_1(__game_set_scroll_speed)
+void __game_set_scroll_speed(int v) { game.scroll_speed = v; game_features::gameopt_scroll_speed.set(v); } ANK_FUNCTION_1(__game_set_scroll_speed)
 void __game_set_player_name(pcstr name) { g_settings.set_player_name_utf8(name); } ANK_FUNCTION_1(__game_set_player_name)
 pcstr __game_get_player_name() { return g_settings.player_name_utf8.empty() ? g_settings.player_name.c_str() : g_settings.player_name_utf8.c_str(); } ANK_FUNCTION(__game_get_player_name)
 bool __game_load_savegame(pcstr filename) { return GamestateIO::load_savegame(filename); } ANK_FUNCTION_1(__game_load_savegame)

--- a/src/window/js_window_registry.cpp
+++ b/src/window/js_window_registry.cpp
@@ -10,7 +10,7 @@
 #include <cstring>
 
 hvector<std::unique_ptr<js_building_info_window>, 32> building_windows;
-hvector<std::unique_ptr<js_advisor_window>, 16> advisor_windows;
+hvector<std::unique_ptr<js_advisor_window>, ADVISOR_MAX> advisor_windows;
 hvector<std::unique_ptr<js_common_window>, 32> common_windows;
 hvector<std::unique_ptr<js_common_modal_window>, 32> modal_windows;
 
@@ -42,6 +42,10 @@ void register_es_advisor_window(pcstr name) {
 
     logs::info("JS Window Registry: Registering advisor window '%s' for advisor %d", name, (int)adv);
 
+    if (advisor_windows.size() < ADVISOR_MAX) {
+        advisor_windows.resize(ADVISOR_MAX);
+    }
+
     auto window = std::make_unique<js_advisor_window>(name);
     advisor_windows[adv] = std::move(window);
 }
@@ -49,7 +53,9 @@ void register_es_advisor_window(pcstr name) {
 void clear_es_advisor_window() {
     logs::info("JS Window Registry: Clearing %d registered advisor windows", (int)advisor_windows.size());
     for (auto &w : advisor_windows) {
-        verify_no_crash(w);
+        if (!w) {
+            continue;
+        }
         autoconfig_window::unregister_section(w->get_section());
     }
     advisor_windows.clear();

--- a/update-workspace.bat
+++ b/update-workspace.bat
@@ -8,6 +8,9 @@ if "%1"=="" (
 )
 
 cmake -DCMAKE_BUILD_TYPE=%build_type% ../
-start akhenaten.sln %debug_flag% .
+if exist akhenaten.slnx (
+  start akhenaten.slnx %debug_flag% .
+) else (
+  start akhenaten.sln %debug_flag% .
+)
 cd ..
-


### PR DESCRIPTION
## Summary
- Scroll speed is no longer hardcoded to 70 on startup and no longer stored in the city save; it's persisted in `akhenaten.cfg` via a new `gameopt_scroll_speed` feature, so it survives restarts and is independent of the active save. The old save slot is kept as a no-op `uint16` to preserve the save format.
- Incidental fix: `js_window_registry::register_es_advisor_window` was crashing with `vector subscript out of range` on first registration because `advisor_windows` was only `reserve()`'d, not resized. Now resizes to `ADVISOR_MAX` before indexed assignment; also bumped the hvector fixed capacity from 16 to `ADVISOR_MAX` (=23) so stored windows don't spill to the heap.
- Build ergonomics: post-build asset copies use `copy_if_different` (quieter incremental builds) and now include `pharaoh_houses_pack.sgx` + `neucha.ttf`; `update-workspace.bat` opens `akhenaten.slnx` when present.

## Test plan
- [ ] Launch a fresh build; confirm startup no longer crashes on advisor window registration (previous failure was at `js_window_registry.cpp:46`).
- [ ] Change scroll speed in-game (via hotkeys and via the JS setter), exit, and relaunch — scroll speed should be restored from `akhenaten.cfg`.
- [ ] Load an existing save from before this change — the unused scroll-speed slot should read/write cleanly (save format preserved).
- [ ] Verify `akhenaten.cfg` contains `gameopt_scroll_speed` after the first change.
- [ ] Incremental rebuild should skip unchanged data-pack copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)