### PR TITLE
hotkeys: fix screen labels, scrollbar, persistence, and stale display

### DIFF
--- a/src/config/hotkeys.cpp
+++ b/src/config/hotkeys.cpp
@@ -183,21 +183,29 @@ void game_hotkeys::install() {
 }
 
 void game_hotkeys::save() {
-    //auto &data = g_config_hotkeys_data;
-    //vfs::path fs_file = vfs::content_path(INI_FILENAME);
-    //
-    //hotkey_install_mapping(data.mappings, data.num_mappings);
-    //FILE* fp = vfs::file_open_os(fs_file, "wt");
-    //if (!fp) {
-    //    logs::error("Unable to write hotkey configuration file %s", INI_FILENAME);
-    //    return;
-    //}
-    //
-    //for (int i = 0; i < data.num_mappings; i++) {
-    //    const char* key_name = key_combination_name(data.mappings[i].key, data.mappings[i].modifiers);
-    //    fprintf(fp, "%s=%s\n", ini_keys[data.mappings[i].action], key_name);
-    //}
-    //vfs::file_close(fp);
+    vfs::path fs_file = vfs::content_path(CONF_HOTKEYS);
+    FILE *fp = vfs::file_open_os(fs_file, "wt");
+    if (!fp) {
+        logs::error("Unable to write hotkey configuration file %s", CONF_HOTKEYS);
+        return;
+    }
+
+    fprintf(fp, "var game_hotkeys = {\n");
+    for (int i = 0; i < HOTKEY_MAX_ITEMS; ++i) {
+        const hotkey_mapping &m = _hotkeys[i];
+        if (m.name.empty() || m.name == "unknown") {
+            continue;
+        }
+
+        char primary[100];
+        strncpy(primary, key_combination_name(m.state.key, m.state.modifiers), sizeof(primary) - 1);
+        primary[sizeof(primary) - 1] = 0;
+        pcstr alt = key_combination_name(m.alt.key, m.alt.modifiers);
+
+        fprintf(fp, "  %s: [\"%s\", \"%s\"],\n", m.name.c_str(), primary, alt);
+    }
+    fprintf(fp, "}\n");
+    vfs::file_close(fp);
 }
 
 hotkey_mapping::hotkey_mapping(pcstr n, e_key k, e_key_mode m, e_hotkey_action a, e_key k1, e_key_mode m1) : name(n), action(a) {

--- a/src/input/keys.h
+++ b/src/input/keys.h
@@ -110,7 +110,7 @@ enum e_key_mode {
     KEY_MOD_GUI = 8,
 };
 
-const char* key_combination_name(int key, int modifiers);
+const char* key_combination_name(e_key key, e_key_mode modifiers);
 
 bool key_combination_from_name(pcstr name, e_key &key, e_key_mode &modifiers);
 

--- a/src/scripts/localization_en.js
+++ b/src/scripts/localization_en.js
@@ -100,6 +100,9 @@ localization_en = [
   {key:"#TR_CONFIG_CONSERVATORY_HELPS_DANCE_SCHOOL", text:"Conservatory helps dance school (reduces spawn delay)"}
   {key:"#TR_CONFIG_JEWELS_WORKSHOPS_CULTURE_BONUS", text:"Jewels workshops give culture bonus (+1 per 3 workshops)"}
   {key:"#TR_CONFIG_OVERLAY_SHOW_GRAY_BUILDINGS", text:"Show gray buildings on overlays when they are not displayed"}
+  {key:"#TR_CONFIG_BREWERY_REQUIRES_WATER", text:"Brewery requires water access"}
+  {key:"#TR_CONFIG_CARTPUSHERS_YIELD_BY_ID", text:"Cartpushers yield goods by worker ID"}
+  {key:"#TR_CONFIG_PREVENT_DELETE_NEAR_BURNING_RUINS", text:"Prevent deleting buildings near burning ruins"}
   {key:"#TR_CONFIG_HEADER_SCENARIO_CHANGES", text:"Change scenarios"}
   {key:"#TR_CONFIG_HEADER_RESOURCES", text:"Change resources"}
   {key:"#TR_CONFIG_ANIMALS", text:"Change animals"}

--- a/src/window/hotkey_config.cpp
+++ b/src/window/hotkey_config.cpp
@@ -9,6 +9,7 @@
 #include "graphics/elements/panel.h"
 #include "graphics/elements/scrollbar.h"
 #include "graphics/image_groups.h"
+#include "graphics/screen.h"
 #include "graphics/text.h"
 #include "graphics/window.h"
 #include "graphics/view/view.h"
@@ -24,6 +25,10 @@
 
 #define NUM_VISIBLE_OPTIONS 14
 #define NUM_BOTTOM_BUTTONS 3
+
+static inline const uint8_t *tr(pcstr key) {
+    return (const uint8_t *)lang_text_from_key(key);
+}
 
 static void on_scroll(void);
 
@@ -177,10 +182,7 @@ static void init(void (*close_callback)(void)) {
     g_hotkey_window_scrollbar.init(0, std::size(hotkey_widgets) - NUM_VISIBLE_OPTIONS);
 
     for (int i = 0; i < HOTKEY_MAX_ITEMS; i++) {
-        hotkey_mapping empty("", KEY_NONE, KEY_MOD_NONE, (e_hotkey_action)i);
-
-        const hotkey_mapping* mapping = game_hotkeys::hotkey_for_action((e_hotkey_action)i);
-        data.mappings[i] = mapping ? *mapping : empty;
+        data.mappings[i] = *game_hotkeys::hotkey_for_action((e_hotkey_action)i);
     }
 }
 
@@ -193,10 +195,10 @@ static void draw_background(int) {
     graphics_set_to_dialog();
     outer_panel_draw(vec2i{0, 0}, 40, 30);
 
-    text_draw_centered("#TR_HOTKEY_TITLE", 16, 16, 608, FONT_LARGE_BLACK_ON_LIGHT, 0);
+    text_draw_centered(tr("#TR_HOTKEY_TITLE"), 16, 16, 608, FONT_LARGE_BLACK_ON_LIGHT, 0);
 
-    text_draw_centered("#TR_HOTKEY_LABEL", HOTKEY_X_OFFSET_1, 55, HOTKEY_BTN_WIDTH, FONT_NORMAL_BLACK_ON_LIGHT, 0);
-    text_draw_centered("#TR_HOTKEY_ALTERNATIVE_LABEL", HOTKEY_X_OFFSET_2, 55, HOTKEY_BTN_WIDTH, FONT_NORMAL_BLACK_ON_LIGHT,0);
+    text_draw_centered(tr("#TR_HOTKEY_LABEL"), HOTKEY_X_OFFSET_1, 55, HOTKEY_BTN_WIDTH, FONT_NORMAL_BLACK_ON_LIGHT, 0);
+    text_draw_centered(tr("#TR_HOTKEY_ALTERNATIVE_LABEL"), HOTKEY_X_OFFSET_2, 55, HOTKEY_BTN_WIDTH, FONT_NORMAL_BLACK_ON_LIGHT,0);
 
     inner_panel_draw({ 20, 72 }, { 35, 22 });
     int y_base = 80;
@@ -204,10 +206,10 @@ static void draw_background(int) {
         hotkey_widget* widget = &hotkey_widgets[i + g_hotkey_window_scrollbar.scroll_position];
         int text_offset = y_base + 6 + 24 * i;
         if (widget->action == HOTKEY_HEADER) {
-            text_draw(widget->name_translation, 32, text_offset, FONT_NORMAL_WHITE_ON_DARK, 0);
+            text_draw(tr(widget->name_translation), 32, text_offset, FONT_NORMAL_WHITE_ON_DARK, 0);
         } else {
             if (strlen(widget->name_translation) > 0) {
-                text_draw(widget->name_translation, 32, text_offset, FONT_NORMAL_BLACK_ON_DARK, 0);
+                text_draw(tr(widget->name_translation), 32, text_offset, FONT_NORMAL_BLACK_ON_DARK, 0);
             } else {
                 lang_text_draw(widget->name_text_group, widget->name_text_id, 32, text_offset, FONT_NORMAL_BLACK_ON_DARK);
             }
@@ -230,7 +232,7 @@ static void draw_background(int) {
     }
 
     for (int i = 0; i < NUM_BOTTOM_BUTTONS; i++) {
-        text_draw_centered((const uint8_t *)bottom_button_texts[i],
+        text_draw_centered(tr(bottom_button_texts[i]),
                            bottom_buttons[i].x,
                            bottom_buttons[i].y + 9,
                            bottom_buttons[i].width,
@@ -245,7 +247,7 @@ static void draw_foreground(int) {
     auto& data = g_hotkeys_window_data;
     graphics_set_to_dialog();
 
-    scrollbar_draw(vec2i{0, 0}, &g_hotkey_window_scrollbar);
+    scrollbar_draw(vec2i{screen_dialog_offset_x(), screen_dialog_offset_y()}, &g_hotkey_window_scrollbar);
 
     for (int i = 0; i < NUM_VISIBLE_OPTIONS; i++) {
         hotkey_widget* widget = &hotkey_widgets[i + g_hotkey_window_scrollbar.scroll_position];
@@ -270,7 +272,8 @@ static void draw_foreground(int) {
 static void handle_input(const mouse* m, const hotkeys* h) {
     auto& data = g_hotkeys_window_data;
     const mouse* m_dialog = mouse_in_dialog(m);
-    if (scrollbar_handle_mouse(&g_hotkey_window_scrollbar, m_dialog)) {
+    g_hotkey_window_scrollbar.offset = {screen_dialog_offset_x(), screen_dialog_offset_y()};
+    if (scrollbar_handle_mouse(&g_hotkey_window_scrollbar, m)) {
         return;
     }
 

--- a/src/window/hotkey_editor.cpp
+++ b/src/window/hotkey_editor.cpp
@@ -3,6 +3,7 @@
 #include "core/string.h"
 #include "graphics/graphics.h"
 #include "graphics/elements/generic_button.h"
+#include "graphics/elements/lang_text.h"
 #include "graphics/elements/panel.h"
 #include "graphics/image_groups.h"
 #include "graphics/text.h"
@@ -42,11 +43,11 @@ static void draw_background(int) {
     graphics_set_to_dialog();
     outer_panel_draw(vec2i{168, 128}, 19, 9);
 
-    text_draw_centered("#TR_HOTKEY_EDIT_TITLE", 176, 144, 296, FONT_LARGE_BLACK_ON_LIGHT, 0);
+    text_draw_centered((const uint8_t *)lang_text_from_key("#TR_HOTKEY_EDIT_TITLE"), 176, 144, 296, FONT_LARGE_BLACK_ON_LIGHT, 0);
 
     for (int i = 0; i < NUM_BOTTOM_BUTTONS; i++) {
         generic_button* btn = &bottom_buttons[i];
-        text_draw_centered((const uint8_t*)bottom_button_texts[i], btn->x, btn->y + 6, btn->width, FONT_NORMAL_BLACK_ON_LIGHT, 0);
+        text_draw_centered((const uint8_t *)lang_text_from_key(bottom_button_texts[i]), btn->x, btn->y + 6, btn->width, FONT_NORMAL_BLACK_ON_LIGHT, 0);
     }
 
     graphics_reset_dialog();


### PR DESCRIPTION
## Summary
Several defects in the in-game hotkey configuration screen (opened from the display options dialog) are fixed here as a single bundle because they all surface together in the same flow. Also cleans up three missing translations in the Gameplay changes menu.

- **Untranslated labels.** Section headers, column headers, row labels, and bottom buttons in both `window_hotkey_config` and `window_hotkey_editor` rendered as raw `#TR_*` keys (displaying as `?TR HOTKEY …` because the font renders `#` as `?` and `_` as space). The C++ drawers called `text_draw*` directly, which doesn't resolve translation keys. Both windows now pipe `#TR_*` literals through `lang_text_from_key()` before drawing.
- **Scrollbar placement.** The scroll buttons and drag dot rendered near the top-left of the screen instead of inside the dialog. `scrollbar_draw` pushes its image buttons through `ui::image_abs`, which bypasses the viewport translation set by `graphics_set_to_dialog()`. Pass the dialog offset explicitly into `scrollbar_draw`, and use the raw mouse (not `mouse_in_dialog`) for `scrollbar_handle_mouse` so hit-test and render agree on absolute coordinates.
- **Rebinds didn't survive restarts.** `game_hotkeys::save()` was a commented-out stub. It now serializes `_hotkeys` into `hotkeys.conf` using the same `var game_hotkeys = { name: [primary, alt], … }` JS-object schema that the existing loader already parses via `r_objects("game_hotkeys", …)`. The save copies `primary` into a local buffer first because `key_combination_name` returns a pointer to a `static char name[100]` that two consecutive calls would clobber.
- **Linker fix.** `src/input/keys.h:113` declared `key_combination_name(int, int)` while `src/input/keys.cpp:44` defined it as `(e_key, e_key_mode)`. Those mangle to different symbols, so the declared overload didn't exist; calling it from the new save path surfaced `LNK2019`. Aligned the header with the definition.
- **Input boxes blank on every (re)open — the big one.** `hotkey_config.cpp:init()` constructed a temporary `hotkey_mapping empty("", …, (e_hotkey_action)i)` in every loop iteration before reading `hotkey_for_action(i)`. The parameterized `hotkey_mapping` ctor has a side effect (intentional for the 40+ static-init globals): it writes `*this` into `game_hotkeys::_hotkeys[action]` and `_defaults[action]`. So every call to `init()` was wiping the live hotkey table, then reading back the wiped slot. Keybindings still *worked* in-session only because `hotkeys::install()` copies the mappings into its own `data.definitions`/`data.arrows` arrays by value before the wipe. Also wiping `_defaults` broke Reset Defaults. The `hotkey_for_action` null-branch was dead code (it never returns null), so both it and the temporary are removed; the loop is now a single-line copy.
- **Missing Gameplay changes translations.** Three `#TR_CONFIG_*` keys (`BREWERY_REQUIRES_WATER`, `CARTPUSHERS_YIELD_BY_ID`, `PREVENT_DELETE_NEAR_BURNING_RUINS`) were referenced in `src/game/game_config.cpp` but not defined in `src/scripts/localization_en.js`, causing those three checkbox labels to render as raw keys. Added English text for each. My best-guess wording may need a review from someone more familiar with the underlying behaviors.

## Test plan
- [ ] Open the hotkey screen from the display options dialog; section headers (`Arrows`, `Global`, `City`, `Build`, `Advisors`, `Overlays`, `Bookmarks`, `Editor`), column headers (`Hotkey`, `Alternative`), and the `Reset defaults` / `Cancel` / `OK` buttons render in English. No `?TR` anywhere. Build-menu rows continue to render correctly (they use `lang_text_draw(group, id)`, unchanged).
- [ ] Click a row to open the hotkey editor popup. Title and the Cancel/OK buttons render in English.
- [ ] Scrollbar sits on the right edge of the dialog, aligned with the header strip. Up/down buttons, drag dot, and mouse-wheel scrolling all work.
- [ ] On first open, input boxes show real defaults (`Up`, `Down`, `P`, `F12`, `Enter+Alt`, etc.) — not blank.
- [ ] Rebind Toggle pause from `P` to `K`, click OK. `K` pauses the game. Reopen the screen — Toggle pause shows `K` and Arrow Up still shows `Up` (confirms `init()` no longer wipes other rows).
- [ ] Reset defaults restores the hardcoded bindings (`P` for Toggle pause, etc.) — not empty.
- [ ] Quit the exe, relaunch, reopen the hotkey screen — `K` is still bound. `%AppData%\Roaming\hotkeys.conf` contains `var game_hotkeys = { … toggle_pause: ["K", ""], … }`.
- [ ] Startup log: `!!! Cant find script at hotkeys.conf` no longer appears after the first save.
- [ ] Open the Gameplay changes menu; the three previously-raw labels now read in English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)