### PR TITLE
fix: campaign mission goals not loading (win_criteria + is_open_play)

### DIFF
--- a/src/scripts/game.js
+++ b/src/scripts/game.js
@@ -50,7 +50,7 @@ game {
 scenario {
     has_animals: __scenario_has_animals
     flotsam_enabled: __scenario_flotsam_enabled
-    is_open_play: __scenario_is_open_play
+    @is_open_play { get: __scenario_is_open_play }
     building_allowed: __scenario_building_allowed
     kingdom_supplies_grain: __scenario_kingdom_supplies_grain
     @start_year { get: __scenario_start_year }

--- a/src/scripts/mission_0_nubt.js
+++ b/src/scripts/mission_0_nubt.js
@@ -21,6 +21,11 @@ mission0 { // Nubt
 		BUILDING_HOUSE_VACANT_LOT, BUILDING_CLEAR_LAND, BUILDING_ROAD
 	]
 
+	win_criteria {
+		housing_count {enabled : true, goal : 6 }
+		housing_level {enabled : true, goal : 2 }
+	}
+
 	vars {
 		granary_open_population : 150
 		population_cap_firstfire : 0

--- a/src/scripts/mission_1_thinis.js
+++ b/src/scripts/mission_1_thinis.js
@@ -20,6 +20,11 @@ mission1 {
 					BUILDING_GOLD_MINE, BUILDING_VILLAGE_PALACE, BUILDING_HUNTING_LODGE,
 				]
 
+	win_criteria {
+		housing_count {enabled : true, goal : 10 }
+		housing_level {enabled : true, goal : 5 }
+	}
+
 	vars {
 		gold_mined : 500
 		victory_last_action_delay : 4

--- a/src/scripts/mission_2_perwadjyt.js
+++ b/src/scripts/mission_2_perwadjyt.js
@@ -19,6 +19,12 @@ mission2 {
 				BUILDING_TEMPLE_OSIRIS, BUILDING_SHRINE_OSIRIS, BUILDING_FESTIVAL_SQUARE
 			  ]
 
+	win_criteria {
+		population    {enabled : true, goal : 600 }
+		housing_count {enabled : true, goal : 10 }
+		housing_level {enabled : true, goal : 6 }
+	}
+
 	vars {
 		figs_stored : 800
 		pottery_step1_stored : 100

--- a/src/scripts/mission_3_nekhen.js
+++ b/src/scripts/mission_3_nekhen.js
@@ -22,6 +22,12 @@ mission3 {
 					BUILDING_BREWERY_WORKSHOP
 				]
 
+	win_criteria {
+		population    {enabled : true, goal : 1000 }
+		housing_count {enabled : true, goal : 10 }
+		housing_level {enabled : true, goal : 8 }
+	}
+
 	vars {
 		beer_stored : 300
 		victory_last_action_delay : 3

--- a/src/scripts/mission_4_mennefer.js
+++ b/src/scripts/mission_4_mennefer.js
@@ -26,6 +26,14 @@ mission4 {
 					BUILDING_BULLFIGHT_SCHOOL, BUILDING_MUD_GATEHOUSE, BUILDING_TOWER_GATEHOUSE, BUILDING_MUD_TOWER,
 				]
 
+	win_criteria {
+		population {enabled : true, goal : 1500 }
+		culture    {enabled : true, goal : 15 }
+		prosperity {enabled : true, goal : 20 }
+		monuments  {enabled : true, goal : 9 }
+		kingdom    {enabled : true, goal : 40 }
+	}
+
 	cities [
 		{
 			name : "Nekhen"

--- a/src/scripts/mission_5_timna.js
+++ b/src/scripts/mission_5_timna.js
@@ -28,6 +28,13 @@ mission5 { // Timna
 
 					BUILDING_MORTUARY, BUILDING_STONEMASONS_GUILD, BUILDING_CARPENTERS_GUILD
 				]
+
+	win_criteria {
+		population {enabled : true, goal : 2000 }
+		prosperity {enabled : true, goal : 15 }
+		kingdom    {enabled : true, goal : 70 }
+	}
+
 	stages {
 		tutorial_irrigation { buildings: [BUILDING_WATER_LIFT, BUILDING_IRRIGATION_DITCH, ] }
 		tutorial_guilds { buildings: [BUILDING_STORAGE_YARD, BUILDING_TAX_COLLECTOR, BUILDING_BOOTH, BUILDING_JUGGLER_SCHOOL] }

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -34,6 +34,14 @@ mission6 = { // Behdet
 					BUILDING_FESTIVAL_SQUARE, BUILDING_BOOTH, BUILDING_JUGGLER_SCHOOL, BUILDING_BANDSTAND, BUILDING_CONSERVATORY, BUILDING_PAVILLION, BUILDING_DANCE_SCHOOL,
 				]
 
+	win_criteria {
+		population {enabled : true, goal : 2500 }
+		culture    {enabled : true, goal : 15 }
+		prosperity {enabled : true, goal : 20 }
+		monuments  {enabled : true, goal : 11 }
+		kingdom    {enabled : true, goal : 45 }
+	}
+
 	enable_scenario_events : false
 	events [
 		{

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -39,6 +39,14 @@ mission7 { // Abydos
 					BUILDING_PAVILLION, BUILDING_DANCE_SCHOOL, BUILDING_SENET_HOUSE
 				]
 
+	win_criteria {
+		population {enabled : true, goal : 2500 }
+		culture    {enabled : true, goal : 25 }
+		prosperity {enabled : true, goal : 25 }
+		monuments  {enabled : true, goal : 17 }
+		kingdom    {enabled : true, goal : 60 }
+	}
+
 	enable_scenario_events : false
 	events [
 		{


### PR DESCRIPTION
Fixes #383.

## Summary

Campaign missions 0..7 had broken goals: ratings advisor and sidebar showed `0 Требуется` for all metrics, Pharaoh milestone messages didn't trigger, missions could not be won. Two independent causes — both fixed here.

## Changes

**1. `fix(missions)`** — added `win_criteria { ... }` block to 8 mission JS files. The mission JS files are read by `scenario_data_t::load_metadata` (`scenario.cpp:94`) inside `post_load`, and the absent block resulted in `g_scenario.win_criteria` being overwritten with zeros. Pattern follows `mission_8_selima.js:37` and `mission_10_saqqara.js:47`. Values copied from each mission's briefing window.

**2. `fix(js)`** — `scenario.is_open_play` is now bound as a property getter (`@is_open_play { get: __scenario_is_open_play }`) instead of a function reference. The recent ratings advisor refactor reads it as a value (`var openPlay = scenario.is_open_play; var enabled = !openPlay && goal`); with a function reference `!openPlay` was always `false`, so `enabled` was always `false` and the rendered goal was always `0`. Pattern matches `@start_year { get: ... }` on the same scenario object.

Both fixes are needed together to produce a visible result — missing JS criteria leave the C++ struct at zero; correct C++ struct with broken JS binding still renders zeros.

## Verification

- Started a fresh mission_6 (Behdet) from "История династии → Изучить историю".
- Briefing shows correct goals (2500 / 15 / 20 / 11 / 45) — unchanged.
- Ratings advisor now shows `15 Требуется` / `20 Требуется` / `11 Требуется` / `45 Требуется`; sidebar shows `(2500)` / `(15)` / `(20)` / `(11)` / `(45)`.
- Pharaoh tutorial popup ("Войска и форты") now triggers — milestone events flow.

## Scope

mission_9 (Abu) also lacks `win_criteria` but is campaign-locked at the test point — values not captured. Will be addressed in a follow-up PR once the briefing is reachable. Mentioned in #383.