### PR TITLE
fix(advisor): bind city.personal_savings

### DIFF
--- a/src/scripts/city.js
+++ b/src/scripts/city.js
@@ -2,6 +2,7 @@ log_info("akhenaten: city.js started")
 
 city {
     @population { get: __city_population }
+    @personal_savings { get: function() { return __city_kingdome.personal_savings } }
     @health_rating { get: __city_health_rating }
     @workers_diff { get: __city_workers_diff }
     @player_rank { get: __city_player_rank }


### PR DESCRIPTION
Fixes #387.

`ui_advisor_imperial.js` reads `city.personal_savings`, but the property was never declared on `city`. Add a getter that reads from `__city_kingdome.personal_savings` (where the field actually lives).