### PR TITLE
fix(guilds): add missing labor requirement to bricklayers_guild

### DIFF
--- a/src/scripts/buildings.js
+++ b/src/scripts/buildings.js
@@ -112,6 +112,7 @@ building_bricklayers_guild = {
   building_size : 2
   cost: [ 20, 40, 80, 120, 200 ]
   desirability : { value:[-6], step:[1], step_size:[1], range: [4] }
+  laborers:[10], fire_risk:[2], damage_risk: [2]
   max_workers : 1
   flags {
     is_guild: true


### PR DESCRIPTION
Fixes #391.

`building_bricklayers_guild` in `buildings.js` was missing the `laborers:[N]` field, so the labor system requested 0 workers and brick monuments could not progress past the foundation phase. Add `laborers:[10]` to match the original Pharaoh model.