### PR TITLE
feat(scenario): pharaoh_gift API for delivering goods

### DIFF
--- a/src/scenario/request_js.cpp
+++ b/src/scenario/request_js.cpp
@@ -12,6 +12,12 @@ void ANK_FUNCTION_UNIFIED(__city_create_good_request)(const bvariant_map &args) 
     );
 }
 
+void ANK_FUNCTION_UNIFIED(__city_create_pharaoh_gift)(const bvariant_map &args) {
+    g_scenario.events.create_pharaoh_gift(
+        args.n("tag_id"), (e_resource)args.n("resource"), args.n("amount")
+    );
+}
+
 void ANK_FUNCTION_UNIFIED(__city_event_create_foreign_army_attack_warning)(const bvariant_map &args) {
     g_scenario.events.create_foreign_army_attack_warning(args.n("tag_id"), args.n("sender_faction"));
 }

--- a/src/scenario/scenario_event_manager.cpp
+++ b/src/scenario/scenario_event_manager.cpp
@@ -15,6 +15,7 @@
 #include "request.h"
 #include "js/js_game.h"
 #include "city/city.h"
+#include "city/city_resource.h"
 #include "dev/debug.h"
 #include "scenario/distant_battle.h"
 #include "graphics/elements/lang_text.h"
@@ -136,6 +137,22 @@ void event_manager_t::create_good_request(int tag, e_resource r, int amount, int
     request.event_id = event_id;
     //process_event(event_id, false, -1);
     //process_active_request(event_id);
+    g_scenario_events.event_list.front().num_total_header = g_scenario_events.event_list.size();
+}
+
+void event_manager_t::create_pharaoh_gift(int tag, e_resource r, int amount) {
+    auto& event = g_scenario_events.event_list.emplace_back();
+    int event_id = g_scenario_events.event_list.size() - 1;
+    memset(&event, 0, sizeof(event_ph_t));
+    event.type = EVENT_TYPE_GIFT_FROM_PHARAOH;
+    event.time.year = game.simtime.years_since_start();
+    event.time.month = game.simtime.month;
+    event.item.value = r;
+    event.sender_faction = 1;
+    event.amount.value = amount;
+    event.tag_id = tag;
+    event.location_fields = { -1, -1, -1, -1 };
+    event.event_id = event_id;
     g_scenario_events.event_list.front().num_total_header = g_scenario_events.event_list.size();
 }
 
@@ -560,6 +577,9 @@ void event_manager_t::process_event(int id, bool via_event_trigger, int chain_ac
         break;
 
     case EVENT_TYPE_GIFT_FROM_PHARAOH:
+        if (event.item.value != RESOURCE_NONE && event.amount.value > 0) {
+            events::emit(event_storageyards_add_resource{ (e_resource)event.item.value, event.amount.value * 100 });
+        }
         city_message_post_full(true, "message_template_general", &event, caller_event_id,
             PHRASE_rating_change_title_I, PHRASE_rating_change_initial_announcement_I, PHRASE_rating_change_reason_I_A,
             id, 0);

--- a/src/scenario/scenario_event_manager.h
+++ b/src/scenario/scenario_event_manager.h
@@ -220,6 +220,7 @@ struct event_manager_t {
     void load_mission_metadata(const mission_id_t &missionid);
 
     void create_good_request(int tag, e_resource r, int amount, int months_initial);
+    void create_pharaoh_gift(int tag, e_resource r, int amount);
     void create_trade_city_under_siege(int tag, int months_initial);
     void create_foreign_army_attack_warning(int tag, int8_t sender_faction);
     void create_distant_battle(int tag, pcstr city, vec2i pos);

--- a/src/scripts/city.js
+++ b/src/scripts/city.js
@@ -354,6 +354,14 @@ city.create_good_request = function(obj) {
     }
 }
 
+city.create_pharaoh_gift = function(obj) {
+    __city_create_pharaoh_gift(obj)
+    return {
+        tag_id: obj.tag_id
+        execute: function() { __city_request_execute(this.tag_id) }
+    }
+}
+
 city.create_trade_city_under_siege = function(tag_id, months_initial) {
     __city_event_create_trade_city_under_siege(tag_id, months_initial)
     return {


### PR DESCRIPTION
Split off from #390.

Adds the missing scripted API for Pharaoh-gift events: `event_manager_t::create_pharaoh_gift` (C++) + `__city_create_pharaoh_gift` (JS binding) + `city.create_pharaoh_gift({tag_id, resource, amount}).execute()` wrapper, mirroring the existing `create_good_request` shape.

`EVENT_TYPE_GIFT_FROM_PHARAOH = 23` was already in the event-type enum and `process_event` posted a message for it, but nothing ever delivered the goods. Extended that case to emit `event_storageyards_add_resource` so the resource lands in storage when the event fires.

Mission-side data using this API will follow in a separate PR.