### PR TITLE
fix(mission_6, mission_7): port Pharaoh bricks gifts to JS

### DIFF
--- a/src/scenario/request_js.cpp
+++ b/src/scenario/request_js.cpp
@@ -12,6 +12,12 @@ void ANK_FUNCTION_UNIFIED(__city_create_good_request)(const bvariant_map &args) 
     );
 }
 
+void ANK_FUNCTION_UNIFIED(__city_create_pharaoh_gift)(const bvariant_map &args) {
+    g_scenario.events.create_pharaoh_gift(
+        args.n("tag_id"), (e_resource)args.n("resource"), args.n("amount")
+    );
+}
+
 void ANK_FUNCTION_UNIFIED(__city_event_create_foreign_army_attack_warning)(const bvariant_map &args) {
     g_scenario.events.create_foreign_army_attack_warning(args.n("tag_id"), args.n("sender_faction"));
 }

--- a/src/scenario/scenario_event_manager.cpp
+++ b/src/scenario/scenario_event_manager.cpp
@@ -15,6 +15,7 @@
 #include "request.h"
 #include "js/js_game.h"
 #include "city/city.h"
+#include "city/city_resource.h"
 #include "dev/debug.h"
 #include "scenario/distant_battle.h"
 #include "graphics/elements/lang_text.h"
@@ -136,6 +137,22 @@ void event_manager_t::create_good_request(int tag, e_resource r, int amount, int
     request.event_id = event_id;
     //process_event(event_id, false, -1);
     //process_active_request(event_id);
+    g_scenario_events.event_list.front().num_total_header = g_scenario_events.event_list.size();
+}
+
+void event_manager_t::create_pharaoh_gift(int tag, e_resource r, int amount) {
+    auto& event = g_scenario_events.event_list.emplace_back();
+    int event_id = g_scenario_events.event_list.size() - 1;
+    memset(&event, 0, sizeof(event_ph_t));
+    event.type = EVENT_TYPE_GIFT_FROM_PHARAOH;
+    event.time.year = game.simtime.years_since_start();
+    event.time.month = game.simtime.month;
+    event.item.value = r;
+    event.sender_faction = 1;
+    event.amount.value = amount;
+    event.tag_id = tag;
+    event.location_fields = { -1, -1, -1, -1 };
+    event.event_id = event_id;
     g_scenario_events.event_list.front().num_total_header = g_scenario_events.event_list.size();
 }
 
@@ -560,6 +577,9 @@ void event_manager_t::process_event(int id, bool via_event_trigger, int chain_ac
         break;
 
     case EVENT_TYPE_GIFT_FROM_PHARAOH:
+        if (event.item.value != RESOURCE_NONE && event.amount.value > 0) {
+            events::emit(event_storageyards_add_resource{ (e_resource)event.item.value, event.amount.value * 100 });
+        }
         city_message_post_full(true, "message_template_general", &event, caller_event_id,
             PHRASE_rating_change_title_I, PHRASE_rating_change_initial_announcement_I, PHRASE_rating_change_reason_I_A,
             id, 0);

--- a/src/scenario/scenario_event_manager.h
+++ b/src/scenario/scenario_event_manager.h
@@ -220,6 +220,7 @@ struct event_manager_t {
     void load_mission_metadata(const mission_id_t &missionid);
 
     void create_good_request(int tag, e_resource r, int amount, int months_initial);
+    void create_pharaoh_gift(int tag, e_resource r, int amount);
     void create_trade_city_under_siege(int tag, int months_initial);
     void create_foreign_army_attack_warning(int tag, int8_t sender_faction);
     void create_distant_battle(int tag, pcstr city, vec2i pos);

--- a/src/scripts/city.js
+++ b/src/scripts/city.js
@@ -354,6 +354,14 @@ city.create_good_request = function(obj) {
     }
 }
 
+city.create_pharaoh_gift = function(obj) {
+    __city_create_pharaoh_gift(obj)
+    return {
+        tag_id: obj.tag_id
+        execute: function() { __city_request_execute(this.tag_id) }
+    }
+}
+
 city.create_trade_city_under_siege = function(tag_id, months_initial) {
     __city_event_create_trade_city_under_siege(tag_id, months_initial)
     return {

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -42,23 +42,6 @@ mission6 = { // Behdet
 		kingdom    {enabled : true, goal : 45 }
 	}
 
-	enable_scenario_events : false
-	events [
-		{
-			time { year : 2684, month : 1 }
-			resource : "pottery",
-			amount { value : 1400 }
-			deadline : 9
-		}
-
-		{
-			time { year : 2683, month : 1 }
-			resource : "beer",
-			amount { value : 1100 }
-			deadline : 12
-		}
-	]
-
 	cities [
 		{
 			name : "Byblos"
@@ -103,4 +86,45 @@ mission6 = { // Behdet
 			pos [640, 480]
 		}
 	]
+
+	vars {
+		pharaoh_pottery_requested : false
+		pharaoh_beer_requested : false
+	}
+}
+
+[es=event_advance_month, mission=mission6]
+function mission6_pharaoh_request_pottery(ev) {
+	if (mission.pharaoh_pottery_requested) {
+		return
+	}
+
+	if (ev.year < -2684) {
+		return
+	}
+	if (ev.year == -2684 && ev.month < 1) {
+		return
+	}
+
+	mission.pharaoh_pottery_requested = true
+	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_POTTERY, amount: 1400, months_initial: 9 })
+	request.execute()
+}
+
+[es=event_advance_month, mission=mission6]
+function mission6_pharaoh_request_beer(ev) {
+	if (mission.pharaoh_beer_requested) {
+		return
+	}
+
+	if (ev.year < -2683) {
+		return
+	}
+	if (ev.year == -2683 && ev.month < 1) {
+		return
+	}
+
+	mission.pharaoh_beer_requested = true
+	var request = city.create_good_request({ tag_id: 2, resource: RESOURCE_BEER, amount: 1100, months_initial: 12 })
+	request.execute()
 }

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -111,7 +111,7 @@ function mission6_pharaoh_request_pottery(ev) {
 	}
 
 	mission.pharaoh_pottery_requested = true
-	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_POTTERY, amount: 1400, months_initial: 9 })
+	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_POTTERY, amount: 14, months_initial: 9 })
 	request.execute()
 }
 
@@ -126,6 +126,6 @@ function mission6_pharaoh_request_beer(ev) {
 	}
 
 	mission.pharaoh_beer_requested = true
-	var request = city.create_good_request({ tag_id: 2, resource: RESOURCE_BEER, amount: 1100, months_initial: 12 })
+	var request = city.create_good_request({ tag_id: 2, resource: RESOURCE_BEER, amount: 11, months_initial: 12 })
 	request.execute()
 }

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -94,10 +94,6 @@ mission6 = { // Behdet
 	}
 }
 
-// Values mirror the original Pharaoh mission1.pak data for Behdet.
-// Additional events from the legacy binary (other requests, gift of bricks,
-// invasions, demand/reputation changes) are not migrated here.
-
 [es=event_advance_month, mission=mission6]
 function mission6_pharaoh_request_pottery(ev) {
 	if (mission.pharaoh_pottery_requested) {

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -90,6 +90,7 @@ mission6 = { // Behdet
 	vars {
 		pharaoh_pottery_requested : false
 		pharaoh_beer_requested : false
+		pharaoh_bricks_gift_sent : false
 	}
 }
 
@@ -128,4 +129,19 @@ function mission6_pharaoh_request_beer(ev) {
 	mission.pharaoh_beer_requested = true
 	var request = city.create_good_request({ tag_id: 2, resource: RESOURCE_BEER, amount: 11, months_initial: 12 })
 	request.execute()
+}
+
+[es=event_advance_month, mission=mission6]
+function mission6_pharaoh_bricks_gift(ev) {
+	if (mission.pharaoh_bricks_gift_sent) {
+		return
+	}
+
+	if (ev.years_since_start < 1) {
+		return
+	}
+
+	mission.pharaoh_bricks_gift_sent = true
+	var gift = city.create_pharaoh_gift({ tag_id: 3, resource: RESOURCE_BRICKS, amount: 28 })
+	gift.execute()
 }

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -93,16 +93,20 @@ mission6 = { // Behdet
 	}
 }
 
+// Values mirror the original Pharaoh mission1.pak data for Behdet.
+// Additional events from the legacy binary (other requests, gift of bricks,
+// invasions, demand/reputation changes) are not migrated here.
+
 [es=event_advance_month, mission=mission6]
 function mission6_pharaoh_request_pottery(ev) {
 	if (mission.pharaoh_pottery_requested) {
 		return
 	}
 
-	if (ev.year < -2684) {
+	if (ev.years_since_start < 1) {
 		return
 	}
-	if (ev.year == -2684 && ev.month < 1) {
+	if (ev.years_since_start == 1 && ev.month < 7) {
 		return
 	}
 
@@ -117,10 +121,7 @@ function mission6_pharaoh_request_beer(ev) {
 		return
 	}
 
-	if (ev.year < -2683) {
-		return
-	}
-	if (ev.year == -2683 && ev.month < 1) {
+	if (ev.years_since_start < 2) {
 		return
 	}
 

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -47,27 +47,6 @@ mission7 { // Abydos
 		kingdom    {enabled : true, goal : 60 }
 	}
 
-	enable_scenario_events : false
-	events [
-		{
-			type: EVENT_TYPE_REQUEST
-			time { year : 2684, month : 1 }
-			resource : RESOURCE_POTTERY
-			amount { value : 1400 }
-			deadline : 9
-		}
-
-		{
-			type: EVENT_TYPE_INVASION
-			time { year : 2670, month : 2 }
-		}
-
-		{
-			type: "pharaoh_gift" //EVENT_TYPE_INVASION,
-			time { year : 2670, month : 8 }
-		}
-	]
-
 	cities [
 		{
 			name : "Byblos"
@@ -104,4 +83,30 @@ mission7 { // Abydos
 			pos [640, 480]
 		}
 	]
+
+	vars {
+		pharaoh_pottery_requested : false
+	}
+}
+
+// TODO: invasion (BC 2670 m2) and pharaoh_gift (BC 2670 m8) from the original
+// Abydos scenario are not ported yet — invasion lacks an enemy spec in the
+// legacy data, and there is no JS API for pharaoh_gift events.
+
+[es=event_advance_month, mission=mission7]
+function mission7_pharaoh_request_pottery(ev) {
+	if (mission.pharaoh_pottery_requested) {
+		return
+	}
+
+	if (ev.year < -2684) {
+		return
+	}
+	if (ev.year == -2684 && ev.month < 1) {
+		return
+	}
+
+	mission.pharaoh_pottery_requested = true
+	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_POTTERY, amount: 1400, months_initial: 9 })
+	request.execute()
 }

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -107,6 +107,6 @@ function mission7_pharaoh_request_beer(ev) {
 	}
 
 	mission.pharaoh_beer_requested = true
-	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_BEER, amount: 900, months_initial: 12 })
+	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_BEER, amount: 9, months_initial: 12 })
 	request.execute()
 }

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -90,10 +90,6 @@ mission7 { // Abydos
 	}
 }
 
-// Values mirror the original Pharaoh mission1.pak data for Abedju (Abydos).
-// Additional events from the legacy binary (city request for fish, gift of
-// bricks, invasions, demand/reputation changes) are not migrated here.
-
 [es=event_advance_month, mission=mission7]
 function mission7_pharaoh_request_beer(ev) {
 	if (mission.pharaoh_beer_requested) {

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -86,6 +86,7 @@ mission7 { // Abydos
 
 	vars {
 		pharaoh_beer_requested : false
+		pharaoh_bricks_gift_sent : false
 	}
 }
 
@@ -109,4 +110,22 @@ function mission7_pharaoh_request_beer(ev) {
 	mission.pharaoh_beer_requested = true
 	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_BEER, amount: 9, months_initial: 12 })
 	request.execute()
+}
+
+[es=event_advance_month, mission=mission7]
+function mission7_pharaoh_bricks_gift(ev) {
+	if (mission.pharaoh_bricks_gift_sent) {
+		return
+	}
+
+	if (ev.years_since_start < 3) {
+		return
+	}
+	if (ev.years_since_start == 3 && ev.month < 4) {
+		return
+	}
+
+	mission.pharaoh_bricks_gift_sent = true
+	var gift = city.create_pharaoh_gift({ tag_id: 2, resource: RESOURCE_BRICKS, amount: 21 })
+	gift.execute()
 }

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -85,28 +85,28 @@ mission7 { // Abydos
 	]
 
 	vars {
-		pharaoh_pottery_requested : false
+		pharaoh_beer_requested : false
 	}
 }
 
-// TODO: invasion (BC 2670 m2) and pharaoh_gift (BC 2670 m8) from the original
-// Abydos scenario are not ported yet — invasion lacks an enemy spec in the
-// legacy data, and there is no JS API for pharaoh_gift events.
+// Values mirror the original Pharaoh mission1.pak data for Abedju (Abydos).
+// Additional events from the legacy binary (city request for fish, gift of
+// bricks, invasions, demand/reputation changes) are not migrated here.
 
 [es=event_advance_month, mission=mission7]
-function mission7_pharaoh_request_pottery(ev) {
-	if (mission.pharaoh_pottery_requested) {
+function mission7_pharaoh_request_beer(ev) {
+	if (mission.pharaoh_beer_requested) {
 		return
 	}
 
-	if (ev.year < -2684) {
+	if (ev.years_since_start < 2) {
 		return
 	}
-	if (ev.year == -2684 && ev.month < 1) {
+	if (ev.years_since_start == 2 && ev.month < 2) {
 		return
 	}
 
-	mission.pharaoh_pottery_requested = true
-	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_POTTERY, amount: 1400, months_initial: 9 })
+	mission.pharaoh_beer_requested = true
+	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_BEER, amount: 900, months_initial: 12 })
 	request.execute()
 }


### PR DESCRIPTION
Split off from #390. Depends on #393 and #394.

Adds the Pharaoh-side bricks gifts that the original `mission1.pak` ships for these two missions. Uses the new `city.create_pharaoh_gift` API from #394.

- mission_6: 28 carts bricks at year+1 m+0.
- mission_7: 21 carts bricks at year+3 m+4.

Verified in-game on Behdet — bricks land in storage on schedule.