### PR TITLE
fix(advisor): use real god_state field names in religion advisor

### DIFF
--- a/src/scripts/city.js
+++ b/src/scripts/city.js
@@ -179,9 +179,6 @@ city {
                 @wrath_bolts {}
                 @happy_ankhs {}
                 @months_since_festival {}
-                @status {}
-                @mood {}
-                @happy_anks {}
             }
         }
 

--- a/src/scripts/ui_advisor_religion.js
+++ b/src/scripts/ui_advisor_religion.js
@@ -44,7 +44,7 @@ function advisor_religion_gods_list_on_render_item(p) {
 	var row = p.user_data
 	var g = gods[row]
 	var gs = city.gods.at(g.type)
-	var st = gs.status
+	var st = gs.is_known
 	var font = (st === 0) ? FONT_NORMAL_WHITE_ON_DARK : FONT_NORMAL_YELLOW
 	var lx = p.x
 	var ly = p.y
@@ -77,7 +77,7 @@ function advisor_religion_gods_list_on_render_item(p) {
 	ui.label(activeTemples + " (" + totalTemples + ")", [lx + 227, ly], font)
 	ui.label(String(city.count_active_buildings(g.shrine_type)), [lx + 292, ly], font)
 	ui.label(String(gs.months_since_festival), [lx + 352, ly], font)
-	ui.label(__loc(59, 20 + ((gs.happiness / 10) | 0)), [lx + 422, ly], font)
+	ui.label(__loc(59, 20 + ((gs.mood / 10) | 0)), [lx + 422, ly], font)
 
 	var imgs = advisor_religion_get_bolt_angel_images()
 	var boltY = ly - 3
@@ -87,7 +87,7 @@ function advisor_religion_gods_list_on_render_item(p) {
 	for (i = 0; i < ((wrath / 20) | 0); i++) {
 		ui.image(imgs.bolt, { x: boltX + i * 10, y: boltY })
 	}
-	var happy = gs.happy_angels
+	var happy = gs.happy_ankhs
 	var j = 0
 	for (j = 0; j < ((happy / 20) | 0); j++) {
 		ui.image(imgs.angel, { x: boltX + j * 10, y: boltY })


### PR DESCRIPTION
## Summary

Religion advisor showed every god as "Unknown" / "Enraged" with no wrath-bolt or happy-ankh icons. Three field names in `ui_advisor_religion.js` did not match the C++ `ANK_CONFIG_PROPERTY(god_state, ...)` declarations:

| JS used | Real C++ field |
|---|---|
| `gs.status` | `is_known` |
| `gs.happiness` | `mood` |
| `gs.happy_angels` | `happy_ankhs` |

All three returned `undefined` → coerced to `0` → group 187 id 0 ("Unknown"), group 59 id 20 ("Enraged"), zero icons.

## Changes

- `src/scripts/ui_advisor_religion.js` — three reads renamed.
- `src/scripts/city.js` — drop stale placeholders in `gods.at(...)`: `@status {}`, duplicate `@mood {}`, typo `@happy_anks {}`. They had no getter and were the trail that produced the original mismatch.

## Verification

Mission 6 (Behdet), open Religion advisor:
- Before: all 5 gods read "Неизвестно / -/-/-/- / Разъярён", no icons.
- After: each god shows correct status (Local Deity / Patron), real complex/temple/shrine counts, mood per group 59 id 20..30, wrath bolts and happy ankhs render per `wrath_bolts/20` and `happy_ankhs/20`.

Fixes #397.