### PR TITLE
fix(storage): cap kingdom-trader imports to 400 per slot

### DIFF
--- a/src/empire/trader_handler.cpp
+++ b/src/empire/trader_handler.cpp
@@ -117,7 +117,7 @@ e_resource empire_trader_handle::get_sell_resource(building* b, empire_city_hand
     // add to existing bay with room
     building_storage_room* space = warehouse->room();
     while (space) {
-        if (space->stored_amount(resource_to_import) > 0) {
+        if (space->stored_amount(resource_to_import) > 0 && space->stored_amount(resource_to_import) < 400) {
             space->add_import(resource_to_import);
             city_trade_next_caravan_import_resource();
             return resource_to_import;


### PR DESCRIPTION
## Summary

Storage yard slots overflow past their 400-per-slot cap because the kingdom-trader path adds 100 per cycle without bounds-checking. Over a long mission_6 game in the attached save, a single slot reaches 61691 of beer; the rendered tile shows a black square because `set_image()` indexes far past the resource image-pak.

Three add-resource paths exist; two cap correctly:

| Path | File | `< 400` check |
|---|---|---|
| Cart pusher → yard | `building_storage_yard::add_resource` | yes |
| Docker → yard | `figure_docker.cpp:48` | yes |
| Kingdom-trader → yard | `trader_handler.cpp:120` | **missing** |

## Changes

`src/empire/trader_handler.cpp:120` — add the same `< 400` check used by `figure_docker.cpp:48` and the backup-resource branch on line 144.

## Verification

`savegame5.svx` (mission_6 Behdet, attached on issue): before the fix, each in-game month adds another 100 to whichever slot already holds the resource, regardless of size. After the fix, slots stop accumulating at 400; existing oversized values stay (no save migration) but trend down as houses/markets consume them. Confirmed in-game: beer slot dropped from 61691 → 55091 over a few months with no further increases. Other yards render normally — the black tile only appears on slots whose value already exceeded 400.

Fixes #399.