### PR TITLE
fix(advisor): return scenario_request by value to avoid dangling reference

### DIFF
--- a/src/window/advisor/scenario_request_js.cpp
+++ b/src/window/advisor/scenario_request_js.cpp
@@ -9,12 +9,10 @@
 
 #include <cstdio>
 
-static scenario_request dummy_request;
-
-static scenario_request& imperial_request_at(int index) {
+static scenario_request imperial_request_at(int index) {
     auto v = scenario_get_visible_requests();
     if (index < 0 || index >= static_cast<int>(v.size())) {
-        return dummy_request;
+        return {};
     }
     return v[index];
 }
@@ -39,32 +37,32 @@ static void def_readonly_prop(js_State *J, js_CFunction get, const char *name) {
 }
 
 static void scenario_request_get_valid(js_State* J) {
-    const auto& r = imperial_request_at(scenario_request_this_index(J));
+    const auto r = imperial_request_at(scenario_request_this_index(J));
     js_pushboolean(J, r.is_valid() ? 1 : 0);
 }
 
 static void scenario_request_get_resource_id(js_State* J) {
-    const auto& r = imperial_request_at(scenario_request_this_index(J));
+    const auto r = imperial_request_at(scenario_request_this_index(J));
     js_pushnumber(J, static_cast<int>(r.resource));
 }
 
 static void scenario_request_get_raw_amount(js_State* J) {
-    const auto& r = imperial_request_at(scenario_request_this_index(J));
+    const auto r = imperial_request_at(scenario_request_this_index(J));
     js_pushnumber(J, r.amount);
 }
 
 static void scenario_request_get_amount_total(js_State* J) {
-    const auto& r = imperial_request_at(scenario_request_this_index(J));
+    const auto r = imperial_request_at(scenario_request_this_index(J));
     js_pushnumber(J, r.resource_amount());
 }
 
 static void scenario_request_get_months(js_State* J) {
-    const auto& r = imperial_request_at(scenario_request_this_index(J));
+    const auto r = imperial_request_at(scenario_request_this_index(J));
     js_pushnumber(J, r.months_to_comply);
 }
 
 static void scenario_request_get_event_id(js_State* J) {
-    const auto& r = imperial_request_at(scenario_request_this_index(J));
+    const auto r = imperial_request_at(scenario_request_this_index(J));
     js_pushnumber(J, r.event_id);
 }
 


### PR DESCRIPTION
## Summary

`imperial_request_at()` returned a reference into a local `std::vector` that was destroyed on return. Every JS-accessor on a `ScenarioRequest` then read from freed memory — usually zeros, sometimes garbage that left `is_valid()` true. As a result the Imperial advisor showed every active request as "0 Nothing / 0 stored / Month 0", but the click handler still dispatched the real underlying event and granted Kingdom rating.

## Changes

`src/window/advisor/scenario_request_js.cpp` — return `scenario_request` by value; drop the unused static `dummy_request`. Default-constructed `scenario_request` has `event_id = -1`, so out-of-range indices still report `is_valid() == false` and the JS view returns `null`.

## Verification

mission_6 (Behdet) save attached on issue. Before: advisor renders "0 Nothing" for the pottery request and clicking it raises Kingdom rating without sending goods. After: advisor renders "1400 Pottery / X stored / Month 7 to comply"; click is correctly disabled with "Cannot dispatch" until the player has the goods.

Fixes #401.