### PR TITLE
feat(scenario): mission_6 events — fish/late beer requests, reputation chains, save-load fix

### DIFF
--- a/src/building/building_storage_room.cpp
+++ b/src/building/building_storage_room.cpp
@@ -70,13 +70,18 @@ void building_storage_room::add_import(e_resource resource) {
 }
 
 void building_storage_room::remove_export(e_resource resource) {
-    consume_resource(resource, 100);
+    if (base.stored_first().type != resource || base.stored_first().value <= 0) {
+        return;
+    }
+
+    int amount = std::min<int>(100, base.stored_first().value);
+    base.stored_first().value -= amount;
     if (base.stored_first().value <= 0) {
         base.stored_first().type = RESOURCE_NONE;
     }
 
     int price = trade_price_sell(resource);
-    events::emit(event_stats_remove_resource{ resource, 100 });
+    events::emit(event_stats_remove_resource{ resource, amount });
     events::emit(event_finance_request{ efinance_request_export, price });
 
     set_image(base.stored_first().type);

--- a/src/building/building_storage_room.cpp
+++ b/src/building/building_storage_room.cpp
@@ -51,10 +51,19 @@ void building_storage_room::set_image(e_resource resource) {
 }
 
 void building_storage_room::add_import(e_resource resource) {
-    store_resource(resource, 100);
+    if (base.stored_first().type != RESOURCE_NONE && base.stored_first().type != resource) {
+        return;
+    }
+    if (base.stored_first().value >= 400) {
+        return;
+    }
+
+    int amount = std::min<int>(100, 400 - base.stored_first().value);
+    base.stored_first().type = resource;
+    base.stored_first().value += amount;
 
     int price = trade_price_buy(resource);
-    events::emit(event_stats_append_resource{ resource, 100 });
+    events::emit(event_stats_append_resource{ resource, amount });
     events::emit(event_finance_request{ efinance_request_import, price });
 
     set_image(resource);

--- a/src/io/gamestate/boilerplate.cpp
+++ b/src/io/gamestate/boilerplate.cpp
@@ -192,12 +192,13 @@ static void post_load() {
     g_scenario.set_campaign_rank(mission_rank);
 
     // Clear mission variables when starting a new mission (not when loading from save)
-    if (game.session.last_loaded == e_session_mission) {
+    bool is_new_mission = (game.session.last_loaded == e_session_mission);
+    if (is_new_mission) {
         g_scenario.vars.clear();
     }
 
     mission_id_t missionid(scenario_id);
-    g_scenario.load_metadata(missionid);
+    g_scenario.load_metadata(missionid, is_new_mission);
     js_register_mission_vars(g_scenario.vars);
     g_empire.load_mission_metadata(missionid);
     js_register_game_handlers(missionid.value());

--- a/src/scenario/request.cpp
+++ b/src/scenario/request.cpp
@@ -64,6 +64,9 @@ void scenario_request_handle(event_ph_t &event, int caller_event_id, e_event_act
         }
         event.event_state = e_event_state_received;
         event.is_active = false;
+        if (event.on_completed_action >= 0) {
+            g_scenario.events.process_event(event.on_completed_action, true, EVENT_ACTION_COMPLETED, event.event_id);
+        }
         break;
 
     case e_event_state_finished_late:
@@ -72,6 +75,9 @@ void scenario_request_handle(event_ph_t &event, int caller_event_id, e_event_act
         g_city.kingdome.increase_success_request(1);
         event.event_state = e_event_state_received;
         event.is_active = false;
+        if (event.on_too_late_action >= 0) {
+            g_scenario.events.process_event(event.on_too_late_action, true, EVENT_ACTION_TOOLATE, event.event_id);
+        }
         break;
 
     case e_event_state_initial:
@@ -79,7 +85,7 @@ void scenario_request_handle(event_ph_t &event, int caller_event_id, e_event_act
         // go to show message
 
     case e_event_state_in_progress:
-        if (!event.can_comply_dialog_shown && g_city.resource.stored(request.resource) >= request.amount) {
+        if (!event.can_comply_dialog_shown && g_city.resource.stored(request.resource) >= request.resource_amount()) {
             event.can_comply_dialog_shown = true;
             city_message &message = g_message_manager.post_common(true, "message_storage_yards_ready_to_fulfill_request", event.event_id, 0, GOD_UNKNOWN, 0);
             message.req_amount = request.resource_amount();
@@ -134,6 +140,9 @@ void scenario_request_handle(event_ph_t &event, int caller_event_id, e_event_act
             event.event_state = e_event_state_failed;
             event.is_active = false;
             next_action = EVENT_ACTION_REFUSED;
+            if (event.on_refusal_action >= 0) {
+                g_scenario.events.process_event(event.on_refusal_action, true, EVENT_ACTION_REFUSED, event.event_id);
+            }
         }
         break;
     }

--- a/src/scenario/request_js.cpp
+++ b/src/scenario/request_js.cpp
@@ -62,6 +62,25 @@ void __city_request_set_param(int tag, pcstr name, int param1) {
 }
 ANK_FUNCTION_3(__city_request_set_param)
 
+void ANK_FUNCTION_UNIFIED(__city_create_chain_event)(const bvariant_map &args) {
+    g_scenario.events.create_chain_event(args.n("tag_id"), (e_event_type)args.n("type"), args.n("amount"));
+}
+
+void __city_request_set_completed_action(int master_tag, int slave_tag) {
+    g_scenario.events.set_request_completed_action(master_tag, slave_tag);
+}
+ANK_FUNCTION_2(__city_request_set_completed_action)
+
+void __city_request_set_refusal_action(int master_tag, int slave_tag) {
+    g_scenario.events.set_request_refusal_action(master_tag, slave_tag);
+}
+ANK_FUNCTION_2(__city_request_set_refusal_action)
+
+void __city_request_set_too_late_action(int master_tag, int slave_tag) {
+    g_scenario.events.set_request_too_late_action(master_tag, slave_tag);
+}
+ANK_FUNCTION_2(__city_request_set_too_late_action)
+
 void ANK_FUNCTION_UNIFIED(__city_start_foreign_army_invasion)(const bvariant_map &args) {
     invasion_opts_t opts;
     opts.mode = ATTACK_TYPE_ENEMIES;

--- a/src/scenario/scenario.cpp
+++ b/src/scenario/scenario.cpp
@@ -20,7 +20,7 @@ scenario_data_t g_scenario;
 void ANK_REGISTER_CONFIG_ITERATOR(config_load_scenario_load_meta_data) {
     mission_id_t missionid(g_scenario.settings.campaign_scenario_id);
 
-    g_scenario.load_metadata(missionid);
+    g_scenario.load_metadata(missionid, /*is_new_mission*/ true);
     js_register_mission_vars(g_scenario.vars);
 }
 
@@ -70,7 +70,7 @@ int scenario_data_t::house_tax_multiplier(int v) const {
     return difficulty.house_tax_multiplier(v);
 }
 
-void scenario_data_t::load_metadata(const mission_id_t &missionid) {
+void scenario_data_t::load_metadata(const mission_id_t &missionid, bool is_new_mission) {
     g_config_arch.r_section(missionid, [this] (archive arch) {
         arch.r(meta);
         arch.r("env", env);
@@ -98,7 +98,9 @@ void scenario_data_t::load_metadata(const mission_id_t &missionid) {
         vars.insert(newvars);
     });
 
-    events.load_mission_metadata(missionid);
+    if (is_new_mission) {
+        events.load_mission_metadata(missionid);
+    }
 }
 
 void scenario_data_t::bind_data(io_buffer *iob, size_t version, size_t size) {

--- a/src/scenario/scenario.h
+++ b/src/scenario/scenario.h
@@ -287,7 +287,7 @@ struct scenario_data_t {
     int rescue_loan() const;
     int house_tax_multiplier(int v) const;
 
-    void load_metadata(const mission_id_t &missionid);
+    void load_metadata(const mission_id_t &missionid, bool is_new_mission);
     void bind_data(io_buffer *iob, size_t version, size_t size);
     void init();
     void init_mission();

--- a/src/scenario/scenario_event_manager.cpp
+++ b/src/scenario/scenario_event_manager.cpp
@@ -222,6 +222,53 @@ void event_manager_t::win_distant_battle(int tag, pcstr city, vec2i pos) {
     g_scenario_events.event_list.front().num_total_header = g_scenario_events.event_list.size();
 }
 
+void event_manager_t::create_chain_event(int tag, e_event_type type, int amount) {
+    auto& event = g_scenario_events.event_list.emplace_back();
+    int event_id = g_scenario_events.event_list.size() - 1;
+    memset(&event, 0, sizeof(event_ph_t));
+    event.type = type;
+    event.amount.value = amount;
+    event.tag_id = tag;
+    event.event_trigger_type = EVENT_TRIGGER_ONLY_VIA_EVENT;
+    event.event_id = event_id;
+    event.location_fields = { -1, -1, -1, -1 };
+    event.on_completed_action = -1;
+    event.on_refusal_action = -1;
+    event.on_too_late_action = -1;
+    event.on_defeat_action = -1;
+    g_scenario_events.event_list.front().num_total_header = g_scenario_events.event_list.size();
+}
+
+static event_ph_t *find_event_by_tag(int tag) {
+    auto it = std::find_if(g_scenario_events.event_list.begin(), g_scenario_events.event_list.end(),
+                           [tag] (auto &p) { return p.tag_id == tag; });
+    return (it == g_scenario_events.event_list.end()) ? nullptr : &*it;
+}
+
+void event_manager_t::set_request_completed_action(int master_tag, int slave_tag) {
+    event_ph_t *master = find_event_by_tag(master_tag);
+    event_ph_t *slave = find_event_by_tag(slave_tag);
+    if (master && slave) {
+        master->on_completed_action = slave->event_id;
+    }
+}
+
+void event_manager_t::set_request_refusal_action(int master_tag, int slave_tag) {
+    event_ph_t *master = find_event_by_tag(master_tag);
+    event_ph_t *slave = find_event_by_tag(slave_tag);
+    if (master && slave) {
+        master->on_refusal_action = slave->event_id;
+    }
+}
+
+void event_manager_t::set_request_too_late_action(int master_tag, int slave_tag) {
+    event_ph_t *master = find_event_by_tag(master_tag);
+    event_ph_t *slave = find_event_by_tag(slave_tag);
+    if (master && slave) {
+        master->on_too_late_action = slave->event_id;
+    }
+}
+
 void event_manager_t::execute_event(int tag) {
     auto it = std::find_if(g_scenario_events.event_list.begin(), g_scenario_events.event_list.end(), [tag] (auto &p) { return p.tag_id == tag; });
 
@@ -477,8 +524,12 @@ void event_manager_t::process_event(int id, bool via_event_trigger, int chain_ac
     }
 
     // check if the trigger time has come, if not return.
-    // for ACTIVE EVENTS (requests?): ignore specific time of the year IF quest is active
-    const bool should_handle = !event.is_active && event.date() == game.simtime.date();
+    // for ACTIVE EVENTS (requests?): ignore specific time of the year IF quest is active.
+    // ACTIVATED_8/12 are children spawned by chain propagation — their date copies the master's
+    // creation date which is in the past, so fire immediately instead of waiting for date match.
+    const bool activated_child = event.event_trigger_type == EVENT_TRIGGER_ACTIVATED_8
+                              || event.event_trigger_type == EVENT_TRIGGER_ACTIVATED_12;
+    const bool should_handle = !event.is_active && (activated_child || event.date() == game.simtime.date());
     if (!(should_handle)) {
         return;
     }
@@ -494,6 +545,13 @@ void event_manager_t::process_event(int id, bool via_event_trigger, int chain_ac
         // TODO
         break;
 
+    case EVENT_TYPE_REPUTATION_INCREASE:
+        g_city.kingdome.change(event.amount.value);
+        city_message_post_full(true, "message_template_general", &event, caller_event_id,
+                               PHRASE_rating_change_title_I, PHRASE_rating_change_initial_announcement_I, PHRASE_rating_change_reason_I_A,
+                               id, 0);
+        break;
+
     case EVENT_TYPE_SEA_TRADE_PROBLEM:
     case EVENT_TYPE_LAND_TRADE_PROBLEM:
     case EVENT_TYPE_WAGE_INCREASE:
@@ -505,7 +563,6 @@ void event_manager_t::process_event(int id, bool via_event_trigger, int chain_ac
     case EVENT_TYPE_DEMAND_DECREASE:
     case EVENT_TYPE_PRICE_INCREASE:
     case EVENT_TYPE_PRICE_DECREASE:
-    case EVENT_TYPE_REPUTATION_INCREASE:
         city_message_post_full(true, "message_template_general", &event, caller_event_id,
                                PHRASE_rating_change_title_I, PHRASE_rating_change_initial_announcement_I, PHRASE_rating_change_reason_I_A,
                                id, 0);
@@ -537,6 +594,12 @@ void event_manager_t::process_event(int id, bool via_event_trigger, int chain_ac
         break;
 
     case EVENT_TYPE_REPUTATION_DECREASE:
+        g_city.kingdome.change(-event.amount.value);
+        city_message_post_full(true, "message_template_general", &event, caller_event_id,
+                               PHRASE_rating_change_title_I, PHRASE_rating_change_initial_announcement_I, PHRASE_rating_change_reason_I_A,
+                               id, 0);
+        break;
+
     case EVENT_TYPE_CITY_STATUS_CHANGE:
         break;
 
@@ -606,7 +669,9 @@ void event_manager_t::process_event(int id, bool via_event_trigger, int chain_ac
     }
 
     // disable if already done
-    if (event.event_trigger_type == EVENT_TRIGGER_ONCE) {
+    if (event.event_trigger_type == EVENT_TRIGGER_ONCE
+     || event.event_trigger_type == EVENT_TRIGGER_ACTIVATED_8
+     || event.event_trigger_type == EVENT_TRIGGER_ACTIVATED_12) {
         event.event_trigger_type = EVENT_TRIGGER_ALREADY_FIRED;
     }
 }

--- a/src/scenario/scenario_event_manager.h
+++ b/src/scenario/scenario_event_manager.h
@@ -225,10 +225,14 @@ struct event_manager_t {
     void create_foreign_army_attack_warning(int tag, int8_t sender_faction);
     void create_distant_battle(int tag, pcstr city, vec2i pos);
     void win_distant_battle(int tag, pcstr city, vec2i pos);
-    
+    void create_chain_event(int tag, e_event_type type, int amount);
+
     void set_request_location_fields(int tag, int16_t l1, int16_t l2, int16_t l3, int16_t l4);
     void set_request_reasons(int tag, uint16_t r1, uint16_t r2, uint16_t r3, uint16_t r4);
     void set_request_image(int tag, xstring image);
     void set_request_sender_faction(int tag, int8_t sender_faction);
     void set_request_param(int tag, pcstr name, int param);
+    void set_request_completed_action(int master_tag, int slave_tag);
+    void set_request_refusal_action(int master_tag, int slave_tag);
+    void set_request_too_late_action(int master_tag, int slave_tag);
 };

--- a/src/scripts/city.js
+++ b/src/scripts/city.js
@@ -357,7 +357,17 @@ city.create_good_request = function(obj) {
     __city_create_good_request(obj)
     return {
         tag_id: obj.tag_id
+        set_completed_action_tag: function(slave_tag) { __city_request_set_completed_action(this.tag_id, slave_tag) }
+        set_refusal_action_tag: function(slave_tag) { __city_request_set_refusal_action(this.tag_id, slave_tag) }
+        set_too_late_action_tag: function(slave_tag) { __city_request_set_too_late_action(this.tag_id, slave_tag) }
         execute: function() { __city_request_execute(this.tag_id) }
+    }
+}
+
+city.create_chain_event = function(obj) {
+    __city_create_chain_event(obj)
+    return {
+        tag_id: obj.tag_id
     }
 }
 

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -111,6 +111,10 @@ function mission6_pharaoh_request_pottery(ev) {
 
 	mission.pharaoh_pottery_requested = true
 	var request = city.create_good_request({ tag_id: 1, resource: RESOURCE_POTTERY, amount: 14, months_initial: 9 })
+	city.create_chain_event({ tag_id: 101, type: EVENT_TYPE_REPUTATION_INCREASE, amount: 6 })
+	city.create_chain_event({ tag_id: 102, type: EVENT_TYPE_REPUTATION_DECREASE, amount: 6 })
+	request.set_completed_action_tag(101)
+	request.set_refusal_action_tag(102)
 	request.execute()
 }
 
@@ -126,6 +130,10 @@ function mission6_pharaoh_request_beer(ev) {
 
 	mission.pharaoh_beer_requested = true
 	var request = city.create_good_request({ tag_id: 2, resource: RESOURCE_BEER, amount: 11, months_initial: 12 })
+	city.create_chain_event({ tag_id: 201, type: EVENT_TYPE_REPUTATION_INCREASE, amount: 12 })
+	city.create_chain_event({ tag_id: 202, type: EVENT_TYPE_REPUTATION_DECREASE, amount: 3 })
+	request.set_completed_action_tag(201)
+	request.set_refusal_action_tag(202)
 	request.execute()
 }
 
@@ -144,6 +152,10 @@ function mission6_pharaoh_request_fish(ev) {
 
 	mission.pharaoh_fish_requested = true
 	var request = city.create_good_request({ tag_id: 4, resource: RESOURCE_FISH, amount: 13, months_initial: 12 })
+	city.create_chain_event({ tag_id: 401, type: EVENT_TYPE_REPUTATION_INCREASE, amount: 7 })
+	city.create_chain_event({ tag_id: 402, type: EVENT_TYPE_REPUTATION_DECREASE, amount: 10 })
+	request.set_completed_action_tag(401)
+	request.set_refusal_action_tag(402)
 	request.execute()
 }
 
@@ -159,6 +171,10 @@ function mission6_pharaoh_request_beer_late(ev) {
 
 	mission.pharaoh_beer_late_requested = true
 	var request = city.create_good_request({ tag_id: 5, resource: RESOURCE_BEER, amount: 21, months_initial: 16 })
+	city.create_chain_event({ tag_id: 501, type: EVENT_TYPE_REPUTATION_INCREASE, amount: 12 })
+	city.create_chain_event({ tag_id: 502, type: EVENT_TYPE_REPUTATION_DECREASE, amount: 7 })
+	request.set_completed_action_tag(501)
+	request.set_refusal_action_tag(502)
 	request.execute()
 }
 

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -89,7 +89,9 @@ mission6 = { // Behdet
 
 	vars {
 		pharaoh_pottery_requested : false
+		pharaoh_fish_requested : false
 		pharaoh_beer_requested : false
+		pharaoh_beer_late_requested : false
 		pharaoh_bricks_gift_sent : false
 	}
 }
@@ -124,6 +126,39 @@ function mission6_pharaoh_request_beer(ev) {
 
 	mission.pharaoh_beer_requested = true
 	var request = city.create_good_request({ tag_id: 2, resource: RESOURCE_BEER, amount: 11, months_initial: 12 })
+	request.execute()
+}
+
+[es=event_advance_month, mission=mission6]
+function mission6_pharaoh_request_fish(ev) {
+	if (mission.pharaoh_fish_requested) {
+		return
+	}
+
+	if (ev.years_since_start < 3) {
+		return
+	}
+	if (ev.years_since_start == 3 && ev.month < 3) {
+		return
+	}
+
+	mission.pharaoh_fish_requested = true
+	var request = city.create_good_request({ tag_id: 4, resource: RESOURCE_FISH, amount: 13, months_initial: 12 })
+	request.execute()
+}
+
+[es=event_advance_month, mission=mission6]
+function mission6_pharaoh_request_beer_late(ev) {
+	if (mission.pharaoh_beer_late_requested) {
+		return
+	}
+
+	if (ev.years_since_start < 17) {
+		return
+	}
+
+	mission.pharaoh_beer_late_requested = true
+	var request = city.create_good_request({ tag_id: 5, resource: RESOURCE_BEER, amount: 21, months_initial: 16 })
 	request.execute()
 }
 


### PR DESCRIPTION
## Summary

Brings mission 6 (Behdet) to a fully working state matching the original Pharaoh's `mission1.pak` data, and fixes three engine bugs encountered along the way.

## What changed

### mission_6 content (JS)
Two pharaoh requests from the binary that hadn't been ported yet, plus reputation chains for all four:

| Request | When | Amount | On completed (rep+) | On refusal (rep-) |
|---|---|---|---|---|
| pottery | y1 m7 | 14 carts | +6 | -6 |
| beer (early) | y2 m0 | 11 carts | +12 | -3 |
| fish | y3 m3 | 13 carts | +7 | -10 |
| beer (late) | y17 m0 | 21 carts | +12 | -7 |

Values match `mission1.pak` slave events.

### Engine fixes
1. **`scenario_request_handle` scale bug**: `g_city.resource.stored() >= request.amount` compared units to carts. The "ready to fulfill" popup fired when the player had only 14 units (= 0.14 cart) on hand. Now uses `request.resource_amount()` (1400 units = 14 carts).
2. **Chain didn't fire on success / failure / late dispatch**: `scenario_request_handle` updated state but never called `process_event(on_*_action, ...)`. Reputation effects never ran. Added the calls for `e_event_state_finished`, `_finished_late`, and the overdue→failed transition.
3. **Chain child date was always in the past**: when a master triggers a slave, `create()` clones the slave with `EVENT_TRIGGER_ACTIVATED_8/12` and copies `time` from the master's *creation* date. By the time the chain fires (months later), the master's date is in the past, so `process_event(child)` saw `event.date() != simtime.date()` and returned. Bypassed the date-check for `ACTIVATED_8/12` triggers and added them to the `ALREADY_FIRED` set so they fire exactly once.
4. **`REPUTATION_INCREASE` / `REPUTATION_DECREASE` side-effect**: were grouped under "post a message and break" / empty `break;`. Now both call `g_city.kingdome.change(±event.amount.value)` so reputation actually moves.

### Save/load
`post_load()` always called `g_scenario.load_metadata(missionid)`, which in turn called `events.load_mission_metadata(missionid)`, which **clears `event_list`**. After save load this wiped the event list that `iob_scenario_events` had just restored — every active request and slave-chain event vanished. Same pattern as the existing mission-vars guard (line 195): only do the JS-side mission-events init when actually starting a new mission.

### New API
- `event_manager_t::create_chain_event(tag, type, amount)` — creates a slave event with `EVENT_TRIGGER_ONLY_VIA_EVENT`.
- `event_manager_t::set_request_completed_action(master_tag, slave_tag)` (and `_refusal_action`, `_too_late_action`) — wires the master to the slave by tag.
- JS-side: `city.create_chain_event({tag_id, type, amount})` and `request.set_completed_action_tag(slave_tag)` etc.

## Verification

- mission_6 fresh start, played through y1 m7 → pottery request popup (1400 carts).
- Played to y3 m3 → fish request popup (1300 carts).
- Saved + reloaded mid-quest → request still present in Imperial Advisor (previously vanished).
- Dispatched pottery once supplies were ready → about a tick later, "ваша ценность повысилась" message + Kingdom rating bumped by ~+9 (3 base from `increase_success_request` + 6 from chain).

Out of scope (filed as #404 roadmap): `EVENT_TYPE_INVASION` (still `// TODO`), flood / demand / wage / contaminated_water / locusts / hailstorm side effects.