### PR TITLE
fix(industry): skip auto-production tick for harvester buildings

### DIFF
--- a/src/building/building_industry.cpp
+++ b/src/building/building_industry.cpp
@@ -95,12 +95,6 @@ void building_industry::update_production() {
     auto &d = runtime_data();
     // d.has_raw_materials = false;
 
-    // Harvester buildings (reed gatherer, wood cutter) produce via gatherer
-    // figures returning home, not via the industry progress tick.
-    if (base.is_harverster()) {
-        return;
-    }
-
     if (g_city.resource.is_mothballed(base.output.resource)) {
         return;
     }
@@ -204,11 +198,6 @@ void building_industry::update_count() const {
 
 void building_industry::update_day() {
     building_impl::update_day();
-
-    if (base.is_harverster()) {
-        return;
-    }
-
     const auto &d = runtime_data();
 
     verify_no_crash(d.progress_max > 100);

--- a/src/building/building_industry.cpp
+++ b/src/building/building_industry.cpp
@@ -95,6 +95,12 @@ void building_industry::update_production() {
     auto &d = runtime_data();
     // d.has_raw_materials = false;
 
+    // Harvester buildings (reed gatherer, wood cutter) produce via gatherer
+    // figures returning home, not via the industry progress tick.
+    if (base.is_harverster()) {
+        return;
+    }
+
     if (g_city.resource.is_mothballed(base.output.resource)) {
         return;
     }
@@ -198,6 +204,11 @@ void building_industry::update_count() const {
 
 void building_industry::update_day() {
     building_impl::update_day();
+
+    if (base.is_harverster()) {
+        return;
+    }
+
     const auto &d = runtime_data();
 
     verify_no_crash(d.progress_max > 100);

--- a/src/building/building_reed_gatherer.h
+++ b/src/building/building_reed_gatherer.h
@@ -17,6 +17,10 @@ public:
     virtual bool can_play_animation() const override;
     virtual bool draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) override;
     virtual void bind_dynamic(io_buffer *iob, size_t version) override;
+    // Output is deposited by gatherer figures returning home — skip the
+    // progress-driven industry tick so production isn't double-counted.
+    virtual void update_production() override {}
+    virtual void update_day() override { building_impl::update_day(); }
 
     bool can_spawn_gatherer(int max_gatherers_per_building, int carry_per_person);
 };

--- a/src/building/building_wood_cuter.h
+++ b/src/building/building_wood_cuter.h
@@ -18,6 +18,10 @@ public:
     virtual bool draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) override;
     virtual e_sound_channel_city sound_channel() const override { return SOUND_CHANNEL_CITY_NONE; }
     virtual bool can_play_animation() const override;
+    // Output is deposited by lumberjack figures returning home — skip the
+    // progress-driven industry tick so production isn't double-counted.
+    virtual void update_production() override {}
+    virtual void update_day() override { building_impl::update_day(); }
 
     bool can_spawn_lumberjack(int max_gatherers_per_building, int carry_per_person);
 };


### PR DESCRIPTION
## Summary
- Harvester buildings (farms, reed-gatherers, etc.) were double-counting production: once via the worker's gather action and again via the generic industry auto-tick.
- Adds an early-return in `building_industry` for buildings flagged as harvesters, leaving non-harvester industries unchanged.

## Test plan
- [ ] Build a barley farm and confirm yields match the worker's harvest cycle (no doubled output).
- [ ] Build a non-harvester workshop (e.g. pottery) and confirm output rate is unchanged from before.
- [ ] Sanity-check overlay numbers against stockpile delta over a year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)