### PR TITLE
fix(buildings): temple destroy cleanup and figure crash guards

### DIFF
--- a/src/building/building_temple_complex.cpp
+++ b/src/building/building_temple_complex.cpp
@@ -566,18 +566,30 @@ void building_temple_complex::update_count() const {
 }
 
 void building_temple_complex::on_destroy() {
-    if (!is_main()) {
-        return;
-    }
-
-    // remove decorative elements (statues, tiles, etc.) using saved list
     auto &tiles = *runtime_data().decorative_tiles;
-    verify_no_crash(!tiles.empty());
-    for (auto &t : tiles) {
-        tile2i tile_pos(t);
-        map_terrain_remove(t, TERRAIN_BUILDING);
-        map_tiles_update_region_empty_land(true, tile_pos, tile_pos.shifted(1, 1));
+    if (is_main() && !tiles.empty()) {
+        // Per-tile reset matches what map_building_tiles_remove() does for a
+        // building's footprint — without it the decorative sprites stay drawn
+        // and the cursor-to-building grid keeps stale ids on those tiles.
+        for (auto &t : tiles) {
+            map_building_tile_clear_at(t, /*building_type*/ 0);
+        }
+
+        tile2i first(tiles[0]);
+        int xmin = first.x(), xmax = xmin;
+        int ymin = first.y(), ymax = ymin;
+        for (auto &t : tiles) {
+            tile2i tp(t);
+            xmin = std::min(xmin, tp.x());
+            xmax = std::max(xmax, tp.x());
+            ymin = std::min(ymin, tp.y());
+            ymax = std::max(ymax, tp.y());
+        }
+        map_tiles_update_region_empty_land(true,
+            tile2i(xmin - 2, ymin - 2),
+            tile2i(xmax + 2, ymax + 2));
     }
 
     get_decorative_tiles_pool().destroy(runtime_data().decorative_tiles);
+    runtime_data().decorative_tiles = nullptr;
 }

--- a/src/figure/action.cpp
+++ b/src/figure/action.cpp
@@ -209,7 +209,9 @@ void figure::action_perform() {
             {
                 auto *impl = dcast();
                 impl->figure_action();
-                impl->update_animation();
+                if (state != FIGURE_STATE_DEAD) {
+                    impl->update_animation();
+                }
             }
             break;
         }

--- a/src/figuretype/festival_guy.cpp
+++ b/src/figuretype/festival_guy.cpp
@@ -9,6 +9,10 @@ REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_festival_guy);
 
 void figure_festival_guy::update_animation() {
     building* temple = home();
+    if (!temple->is_valid()) {
+        return;
+    }
+
     xstring animkey = {};
     switch (temple->type) {
     case BUILDING_TEMPLE_OSIRIS:
@@ -47,7 +51,7 @@ void figure_festival_guy::update_animation() {
         break;
 
     default:
-        assert(false);
+        return;
     }
 
     image_set_animation(animkey);

--- a/src/figuretype/figure_priest.cpp
+++ b/src/figuretype/figure_priest.cpp
@@ -35,7 +35,7 @@ sound_key figure_priest::phrase_key() const {
     case BUILDING_TEMPLE_BAST: case BUILDING_TEMPLE_COMPLEX_BAST: god = GOD_BAST;  god_prefix = "bast"; break;
 
     default:
-        assert(false);
+        return {};
     }
 
     svector<sound_key, 10> keys;
@@ -175,14 +175,16 @@ e_overlay figure_priest::get_overlay() const {
     case BUILDING_SHRINE_BAST: case BUILDING_TEMPLE_BAST: case BUILDING_TEMPLE_COMPLEX_BAST: return OVERLAY_RELIGION_BAST;
 
     default:
-        assert(false);
+        return OVERLAY_NONE;
     }
-
-    return OVERLAY_NONE;
 }
 
 void figure_priest::update_animation() {
     building* temple = home();
+    if (!temple->is_valid()) {
+        return;
+    }
+
     xstring animkey = {};
     switch (temple->type) {
     case BUILDING_TEMPLE_OSIRIS:
@@ -211,7 +213,7 @@ void figure_priest::update_animation() {
         break;
 
     default:
-        assert(false);
+        return;
     }
 
     image_set_animation(animkey);

--- a/src/grid/building_tiles.cpp
+++ b/src/grid/building_tiles.cpp
@@ -185,32 +185,34 @@ void map_building_tiles_remove(int building_id, tile2i tile) {
     for (int dy = 0; dy < size; dy++) {
         for (int dx = 0; dx < size; dx++) {
             int grid_offset = MAP_OFFSET(x + dx, y + dy);
-            //            if (building_id && map_building_at(grid_offset) != building_id)
-            //                continue;
-
-            if (building_id && b->type != BUILDING_BURNING_RUIN)
-                map_set_rubble_building_type(grid_offset, b->type);
-
-            map_property_clear_constructing(grid_offset);
-            map_property_set_multi_tile_size(grid_offset, 1);
-            map_property_clear_multi_tile_xy(grid_offset);
-            map_property_mark_draw_tile(grid_offset);
-            map_canal_set(grid_offset, 0);
-            map_building_set(grid_offset, 0);
-            map_building_damage_clear(grid_offset);
-            map_sprite_clear_tile(grid_offset);
-            if (map_terrain_is(grid_offset, TERRAIN_WATER)) {
-                map_terrain_set(grid_offset, TERRAIN_WATER); // clear other flags
-                map_tiles_set_water(MAP_OFFSET(x + dx, y + dy));
-            } else {
-                map_image_set(grid_offset, image_id_from_group(GROUP_TERRAIN_UGLY_GRASS) + (map_random_get(grid_offset) & 7));
-                map_terrain_remove(grid_offset, TERRAIN_CLEARABLE - TERRAIN_ROAD);
-            }
+            map_building_tile_clear_at(grid_offset, building_id ? b->type : 0);
         }
     }
     map_tiles_update_region_empty_land(true, tile2i(x - 2, y - 2), tile2i(x + size + 2, y + size + 2));
     map_tiles_update_region_meadow(x - 2, y - 2, x + size + 2, y + size + 2);
     map_tiles_update_region_rubble(x, y, x + size, y + size);
+}
+
+void map_building_tile_clear_at(int grid_offset, int building_type) {
+    if (building_type != 0 && building_type != BUILDING_BURNING_RUIN) {
+        map_set_rubble_building_type(grid_offset, building_type);
+    }
+
+    map_property_clear_constructing(grid_offset);
+    map_property_set_multi_tile_size(grid_offset, 1);
+    map_property_clear_multi_tile_xy(grid_offset);
+    map_property_mark_draw_tile(grid_offset);
+    map_canal_set(grid_offset, 0);
+    map_building_set(grid_offset, 0);
+    map_building_damage_clear(grid_offset);
+    map_sprite_clear_tile(grid_offset);
+    if (map_terrain_is(grid_offset, TERRAIN_WATER)) {
+        map_terrain_set(grid_offset, TERRAIN_WATER); // clear other flags
+        map_tiles_set_water(grid_offset);
+    } else {
+        map_image_set(grid_offset, image_id_from_group(GROUP_TERRAIN_UGLY_GRASS) + (map_random_get(grid_offset) & 7));
+        map_terrain_remove(grid_offset, TERRAIN_CLEARABLE - TERRAIN_ROAD);
+    }
 }
 
 void map_building_tiles_set_rubble(int building_id, tile2i tile, int size) {

--- a/src/grid/building_tiles.h
+++ b/src/grid/building_tiles.h
@@ -9,6 +9,13 @@ void map_building_tiles_add(int building_id, tile2i tile, int size, int image_id
 void map_add_venue_plaza_tiles(int building_id, int size, tile2i tile, int image_id, bool update_only);
 
 void map_building_tiles_remove(int building_id, tile2i tile);
+
+// Resets one tile's building-grid pointer, image, sprite and properties to
+// "empty land" — mirrors the per-tile work map_building_tiles_remove() does
+// inside its inner loop. Pass building_type = 0 (BUILDING_NONE) when the
+// caller has no associated building (e.g. clearing decorative tiles), so the
+// rubble marker is skipped.
+void map_building_tile_clear_at(int grid_offset, int building_type);
 void map_building_tiles_set_rubble(int building_id, tile2i tile, int size);
 void map_building_tiles_mark_deleting(int grid_offset);
 bool map_building_tiles_mark_construction(tile2i tile, int size_x, int size_y, int terrain, bool absolute_xy);


### PR DESCRIPTION
## Summary
- Rewrites `building_temple_complex::on_destroy()` to use a new `map_building_tile_clear_at()` helper per decorative tile so visuals and the cursor-to-building grid are reset; previously left ghost statues/paths and stale building ids that caused unrelated buildings to highlight on hover.
- Frees the `decorative_tiles` pool entry unconditionally to fix a per-altar/oracle leak across save/load.
- Extracts the per-tile cleanup helper in `grid/building_tiles`, shared with `map_building_tiles_remove()` so the demolition contract is single-sourced.
- Guards `figure_priest` / `figure_festival_guy::update_animation()` and `figure::action_perform()` against running on figures whose home temple was just destroyed (early-return instead of asserting or dereferencing freed building).

## Test plan
- [ ] Build a temple complex with all decorative tiles, then demolish it; confirm no ghost statues remain and hovering nearby buildings no longer highlights stale ids.
- [ ] Build / demolish a temple complex multiple times and watch save-file size / pool counters for the decorative_tiles leak.
- [ ] Demolish a temple while priests / festival guys are walking from it; confirm no crash and figures despawn cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)