### PR TITLE
ui(sidebar): keep extra panel visible after build menu action

### DIFF
--- a/src/scripts/ui_sidebar_extra.js
+++ b/src/scripts/ui_sidebar_extra.js
@@ -105,7 +105,7 @@ function sidebar_extra_embed_height_px(collapsed, mask) {
 [es=(sidebar_window_expanded, ui_draw_extra)]
 function sidebar_window_extra_ui_draw_foreground(window) {
     var sidebarOn = !!game_features.gameui_sidebar_info
-    var collapsed = window.opened_menu !== 0
+    var collapsed = false
 
     var fullHeight = 0
     if (!collapsed && sidebarOn) {


### PR DESCRIPTION
Fixes #413.

After `bcb4220b8b`, the bottom of the expanded sidebar (speed / unemployment / ratings) is hidden as soon as the player picks a build category and places a building, and only comes back on right-click cancel.

## Cause

`sidebar_window_extra_ui_draw_foreground` runs only via `[es=(sidebar_window_expanded, ui_draw_extra)]`, i.e. only while the expanded sidebar is drawn. Inside this handler `collapsed` is by definition `false`. The condition `var collapsed = window.opened_menu !== 0` was carried over from the old `widget_sidebar_extra.cpp` (`if (is_collapsed) return;`), but in the old C++ `is_collapsed` meant "sidebar is folded into the narrow strip" — not "a build category is active". After the refactor the variable kept its name but switched meaning, so `mask` becomes `SIDEBAR_EXTRA_DISPLAY_NONE` and `apply_visibility` disables every extra element.

## Change

`var collapsed = window.opened_menu !== 0` → `var collapsed = false`. One line, no behaviour change while the dropdown is actually open (the dropdown overlays the area visually anyway).

## Verification

- Loaded a Behdet save, picked Religion / Industry / Distribution categories, placed buildings — speed arrows / unemployment / rating goals stay visible the whole time.
- Right-click cancel still works as before.
- Collapsed sidebar (narrow strip) is unaffected since this handler is only registered for `sidebar_window_expanded`.