### PR TITLE
core: enlarge fixed buffers used by widget::event dispatch

### DIFF
--- a/src/core/variant.h
+++ b/src/core/variant.h
@@ -278,7 +278,7 @@ struct bvariant_map_val {
 
 struct bvariant_map {
     using PairT = std::pair<xstring, bvariant>;
-    using ValuesT = hvector<PairT, 32>;
+    using ValuesT = hvector<PairT, 64>;
 
     bvariant_map() = default;
 

--- a/src/js/js_game.cpp
+++ b/src/js/js_game.cpp
@@ -224,7 +224,7 @@ void js_call_event_handlers(const xstring &event_name, const bvariant_map &objec
         js_newobject(J);
 
         // First pass: add regular properties and collect UI element IDs
-        hvector<bstring64, 32> ui_element_ids;
+        hvector<bstring64, 64> ui_element_ids;
         for (const auto &kv : object) {
             const xstring &key = kv.first;
             const bvariant &val = kv.second;


### PR DESCRIPTION
Fixes #415.

Two `hvector<..., 32>` buffers in the C++→JS event dispatch path overflow on every expanded-sidebar draw since `bcb4220b8b` raised the element count of `sidebar_window_expanded` to 39. The heap fallback still works, but each overflow goes through the `printf` warning in `fixed_memory_resource::do_allocate`, flooding stdout and adding a heap alloc per frame.

## Change

- `src/core/variant.h`: `using ValuesT = hvector<PairT, 32>;` → `64`. This is the storage of `bvariant_map`, which `widget::event` fills with one entry per named UI element of the current widget.
- `src/js/js_game.cpp`: `hvector<bstring64, 32> ui_element_ids;` → `64`. This is the JS-side collector for those ids during dispatch.

`64` is enough headroom for the current expanded sidebar (39 elements) and any near-term growth; smaller widgets keep the same constant-time stack-buffer behaviour they had before.

## Verification

- Before: stdout shows continuous `Local stack buffer exceeded - Max:1312 Free:32 Alloc:2560` and `Max:2080 Free:32 Alloc:4096` while in city view.
- After: both messages disappear during normal play; only the unrelated rare `Max:32544 Free:32 Alloc:65024` (a separate path) remains.
- No behaviour change for callers — `hvector` already heap-fallbacks transparently, this just keeps the fast path on stack.