### PR TITLE
Add bug-report form that posts to GitHub Issues via a Cloudflare Worker

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,242 @@
+# Bug-report worker — deployment guide
+
+This folder ships a single-file Cloudflare Worker that powers the
+"Report a bug" page at `docs/reportbug.html`. It receives a JSON POST
+from the page and opens an issue on `dalerank/Akhenaten` via the GitHub
+REST API.
+
+The page already builds and previews bug reports in your browser. To
+actually post them as GitHub issues, the Worker must be deployed once
+and the page wired to its URL. The whole process takes ~10 minutes and
+fits comfortably in Cloudflare's free tier (100k requests/day).
+
+---
+
+## What's included
+
+| File | Purpose |
+| --- | --- |
+| `api/report-bug.js` | The Worker. Validates input, runs spam checks, calls GitHub. |
+| `wrangler.toml` (repo root) | Worker name, entry file, and non-secret env vars. |
+| `package.json` (repo root) | Pins `wrangler` as a dev dependency and provides `npm run …` shortcuts. |
+| `docs/reportbug.html` | The form. Has an `ENDPOINT` constant near the top of its `<script>` that you point at the deployed Worker. |
+
+## Spam protection
+
+Two lightweight, server-side checks — no third-party captcha:
+
+1. **Honeypot**: a hidden `website` input. Real users never see or fill
+   it; bots autofill every field. Any non-empty value → reject.
+2. **Form age**: the page records `Date.now()` on load and sends it
+   with the submission. The Worker rejects anything that arrives less
+   than 3 seconds or more than 24 hours after page load.
+
+If real spam ever appears, see [Adding Turnstile later](#adding-turnstile-later)
+at the bottom of this file.
+
+---
+
+## Prerequisites
+
+- A Cloudflare account — free tier is fine. Sign up at
+  https://dash.cloudflare.com/sign-up if needed.
+- Node.js (LTS) — https://nodejs.org/. Provides `npm` / `npx`.
+- A GitHub fine-grained personal access token with permission to file
+  issues on `dalerank/Akhenaten`. See step 1 below.
+
+> **Note on issue authorship.** The Worker authenticates to the GitHub
+> API with a single token, so every issue it opens will appear authored
+> by that token's owner. The reporter's name and email (when given) are
+> placed in the issue body, not as the author. If `dalerank` deploys
+> with their own PAT, issues author as `dalerank`; if someone else
+> deploys, issues author as them. Either is fine — the body always
+> identifies the real reporter.
+
+---
+
+## 1. Create the GitHub token
+
+1. Open https://github.com/settings/personal-access-tokens/new.
+2. **Token name**: `akhenaten-bug-form` (or whatever).
+3. **Expiration**: pick a reasonable max — you'll rotate it later with
+   the same `npm run secret:github` command.
+4. **Repository access** → **Only select repositories** → tick
+   `dalerank/Akhenaten`.
+5. **Permissions** → **Repository permissions** → **Issues**: set to
+   **Read and write**.
+6. Click **Generate token**. Copy the `github_pat_…` string. You'll
+   paste it once in step 3; GitHub never shows it again.
+
+---
+
+## 2. Configure the docs origin
+
+Open `wrangler.toml` and check that `ALLOWED_ORIGIN` matches where the
+docs site is actually served from. For GitHub Pages on this repo, that's:
+
+```toml
+[vars]
+ALLOWED_ORIGIN = "https://dalerank.github.io"
+```
+
+If you serve the docs from a custom domain (e.g. `akhenaten.dev`), set
+that instead. The Worker rejects POSTs from any other origin, so this
+must exactly match the scheme + host of the deployed page (no trailing
+slash, no path).
+
+> For local browser testing against `python -m http.server 8000`, set
+> this to `http://localhost:8000` temporarily.
+
+---
+
+## 3. Deploy the Worker
+
+From the **repo root** (not `api/`):
+
+```bash
+npm install            # one-time: pulls wrangler into node_modules/
+npm run login          # one-time: opens a browser for Cloudflare auth
+npm run secret:github  # paste the PAT from step 1 when prompted
+npm run deploy         # publishes the Worker
+```
+
+On success, `wrangler` prints a URL like:
+
+```
+Published akhenaten-bug-report (1.2 sec)
+  https://akhenaten-bug-report.<your-subdomain>.workers.dev
+```
+
+**Copy that URL.** You'll paste it in step 4.
+
+---
+
+## 4. Wire the page to the Worker
+
+Edit `docs/reportbug.html`. Near the top of the inline `<script>`,
+find:
+
+```js
+// TODO: set after deploying the serverless function (see api/report-bug.js)
+const ENDPOINT = '';
+```
+
+Set it to the URL from step 3:
+
+```js
+const ENDPOINT = 'https://akhenaten-bug-report.<your-subdomain>.workers.dev';
+```
+
+Commit and deploy `docs/` (push to whichever branch GitHub Pages serves).
+
+---
+
+## 5. Smoke-test
+
+1. Open the live `reportbug.html` in a browser.
+2. Type a title and at least 20 characters of body. Watch the preview
+   render the markdown live.
+3. Click **Submit report**.
+4. You should see "Reported! View on GitHub →". Click the link — the
+   issue should be live on `dalerank/Akhenaten` with `bug` and
+   `from-website` labels and a footer crediting the reporter.
+
+If something fails, see [Troubleshooting](#troubleshooting).
+
+---
+
+## Day-to-day commands
+
+| Need to… | Run | Notes |
+| --- | --- | --- |
+| Iterate on the Worker locally | `npm run dev` | Serves on `http://localhost:8787`. Point `ENDPOINT` there to test. |
+| Push a code change live | `npm run deploy` | After editing `api/report-bug.js`. |
+| Tail live logs | `npm run tail` | Streams real-time logs from the deployed Worker. |
+| Rotate the GitHub PAT | `npm run secret:github` | Paste the new token when prompted. |
+| Change `ALLOWED_ORIGIN` | edit `wrangler.toml` then `npm run deploy` | |
+
+---
+
+## Troubleshooting
+
+### Browser console: "blocked by CORS policy"
+`ALLOWED_ORIGIN` doesn't match where the page is served from. Fix
+`wrangler.toml` and `npm run deploy` again. Remember: scheme + host,
+no path, no trailing slash.
+
+### Submission returns 502 "GitHub rejected the issue"
+Most often the PAT has lost `Issues: write` on `dalerank/Akhenaten` or
+expired. Regenerate (step 1) and run `npm run secret:github` to update
+the secret. No redeploy needed — secrets take effect immediately.
+
+### Submission returns 400 "Spam detected"
+Either:
+- The honeypot was filled. Check the form's hidden `website` input
+  isn't being autofilled by a password manager (it has
+  `autocomplete="off"` already, so this is rare).
+- The submission arrived <3 s or >24 h after page load. Refresh and
+  try again.
+
+### `npm run deploy` errors before publishing
+Usually missing/invalid `wrangler.toml` or not logged in. Run
+`npm run login` first if you skipped it.
+
+### I want to see what got submitted before GitHub posted it
+Run `npm run tail` in another terminal while submitting. The Worker
+doesn't log payloads by default (privacy), but you can add a
+`console.log(payload)` in `api/report-bug.js` temporarily and redeploy
+if you need to debug.
+
+---
+
+## Adding Turnstile later
+
+Honeypot + time-check stops dumb spam but is bypassable by motivated
+bots. If real spam appears, swap in [Cloudflare Turnstile][turnstile]
+— a free, privacy-friendly captcha alternative.
+
+[turnstile]: https://dash.cloudflare.com/?to=/:account/turnstile
+
+1. **Create the Turnstile site**: in the Cloudflare dashboard →
+   Turnstile → **Add site**.
+   - Domain: `dalerank.github.io` (and `localhost` if you want to test
+     locally).
+   - Widget mode: **Managed** (recommended).
+   - Copy the **site key** (public) and **secret key** (private).
+
+2. **Add the secret to the Worker**:
+   ```bash
+   npx wrangler secret put TURNSTILE_SECRET
+   ```
+   Paste the secret key.
+
+3. **Add the widget to `docs/reportbug.html`**:
+   - In `<head>`, add:
+     ```html
+     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+     ```
+   - In the form, just before `<div class="form-actions">`, add:
+     ```html
+     <div class="cf-turnstile" data-sitekey="YOUR_REAL_SITE_KEY"></div>
+     ```
+   - In the submit handler, add the token to the payload:
+     ```js
+     const turnstileEl = document.querySelector('[name="cf-turnstile-response"]');
+     data.turnstileToken = turnstileEl ? turnstileEl.value : '';
+     ```
+   - And reset the widget on success/error:
+     ```js
+     if (window.turnstile) window.turnstile.reset();
+     ```
+
+4. **Add server-side verification to `api/report-bug.js`**: extract
+   `payload.turnstileToken`, reject if empty, then POST to
+   `https://challenges.cloudflare.com/turnstile/v0/siteverify` with
+   `secret=env.TURNSTILE_SECRET` and `response=token`. Reject if
+   `success !== true`.
+
+5. **Deploy**: `npm run deploy`. Test the form. Done.
+
+The git history of this branch contains the original Turnstile
+implementation — `git log --all -- api/report-bug.js` will surface it
+if you'd rather copy-paste the exact code than rewrite it.

--- a/api/report-bug.js
+++ b/api/report-bug.js
@@ -1,0 +1,160 @@
+/**
+ * Bug-report serverless function for the Akhenaten docs site.
+ *
+ * Receives a JSON POST from docs/reportbug.html and opens an issue on
+ * dalerank/Akhenaten via the GitHub REST API.
+ *
+ * Spam protection is intentionally lightweight:
+ *   - hidden honeypot field ("website") — must be empty
+ *   - submission must arrive at least MIN_FORM_AGE_MS after page load
+ *     (bots typically POST instantly)
+ *
+ * The handler is platform-agnostic: it takes a standard `Request` and
+ * returns a `Response`. It runs unchanged on:
+ *
+ *   Cloudflare Workers
+ *     wrangler.toml + this file's default export.
+ *     Set secret: wrangler secret put GITHUB_TOKEN
+ *     Set var:    ALLOWED_ORIGIN (e.g. https://dalerank.github.io)
+ *
+ *   Netlify Functions (under netlify/functions/report-bug.js)
+ *     Import the named `handle` export and pass `process.env` as env.
+ *
+ *   Vercel Edge Functions (under api/report-bug.js)
+ *     Add `export const config = { runtime: 'edge' };` and wrap `handle`.
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN   - fine-grained PAT with Issues: write on
+ *                    dalerank/Akhenaten. Issues will be authored by
+ *                    the token's owner.
+ *   ALLOWED_ORIGIN - exact origin of the deployed docs site
+ *                    (default: https://dalerank.github.io).
+ */
+
+const REPO = 'dalerank/Akhenaten';
+const TITLE_MAX = 120;
+const BODY_MIN = 20;
+const BODY_MAX = 8000;
+const NAME_MAX = 80;
+const EMAIL_MAX = 200;
+const MIN_FORM_AGE_MS = 3000;
+const MAX_FORM_AGE_MS = 24 * 60 * 60 * 1000;
+
+export default {
+  fetch: (request, env, ctx) => handle(request, env),
+};
+
+export async function handle(request, env) {
+  const e = env || (typeof process !== 'undefined' ? process.env : {}) || {};
+  const allowedOrigin = e.ALLOWED_ORIGIN || 'https://dalerank.github.io';
+
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders(allowedOrigin) });
+  }
+
+  if (request.method !== 'POST') {
+    return json({ ok: false, error: 'Method not allowed.' }, 405, allowedOrigin);
+  }
+
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return json({ ok: false, error: 'Invalid JSON body.' }, 400, allowedOrigin);
+  }
+
+  const title = stripControl((payload.title || '').toString()).trim();
+  const body = (payload.body || '').toString();
+  const name = stripControl((payload.name || '').toString()).trim();
+  const email = stripControl((payload.email || '').toString()).trim();
+  const honeypot = (payload.website || '').toString();
+  const loadedAt = Number(payload.loadedAt);
+
+  if (honeypot) {
+    return json({ ok: false, error: 'Spam detected.' }, 400, allowedOrigin);
+  }
+  if (!Number.isFinite(loadedAt)) {
+    return json({ ok: false, error: 'Spam detected.' }, 400, allowedOrigin);
+  }
+  const formAge = Date.now() - loadedAt;
+  if (formAge < MIN_FORM_AGE_MS || formAge > MAX_FORM_AGE_MS) {
+    return json({ ok: false, error: 'Spam detected.' }, 400, allowedOrigin);
+  }
+  if (!title || title.length > TITLE_MAX) {
+    return json({ ok: false, error: 'Title is required (1-' + TITLE_MAX + ' chars).' }, 400, allowedOrigin);
+  }
+  if (body.trim().length < BODY_MIN || body.length > BODY_MAX) {
+    return json(
+      { ok: false, error: 'Description must be ' + BODY_MIN + '-' + BODY_MAX + ' characters.' },
+      400,
+      allowedOrigin
+    );
+  }
+  if (name.length > NAME_MAX || email.length > EMAIL_MAX) {
+    return json({ ok: false, error: 'Name or email too long.' }, 400, allowedOrigin);
+  }
+
+  const githubToken = e.GITHUB_TOKEN;
+  if (!githubToken) {
+    return json({ ok: false, error: 'Server is not configured.' }, 500, allowedOrigin);
+  }
+
+  const reporter = name || 'anonymous';
+  const emailLine = email ? ' <' + email + '>' : '';
+  const issueBody =
+    body.trimEnd() +
+    '\n\n---\n' +
+    '*Submitted via the Akhenaten website bug-report form.*\n' +
+    '*Reporter: ' + reporter + emailLine + '*\n';
+
+  const ghResponse = await fetch('https://api.github.com/repos/' + REPO + '/issues', {
+    method: 'POST',
+    headers: {
+      'Authorization': 'Bearer ' + githubToken,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      'User-Agent': 'akhenaten-bug-form',
+    },
+    body: JSON.stringify({
+      title: title,
+      body: issueBody,
+      labels: ['bug', 'from-website'],
+    }),
+  });
+
+  if (ghResponse.status !== 201) {
+    return json(
+      { ok: false, error: 'GitHub rejected the issue (status ' + ghResponse.status + ').' },
+      502,
+      allowedOrigin
+    );
+  }
+
+  const issue = await ghResponse.json();
+  return json({ ok: true, url: issue.html_url }, 201, allowedOrigin);
+}
+
+function stripControl(s) {
+  return s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+}
+
+function corsHeaders(origin) {
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+    'Vary': 'Origin',
+  };
+}
+
+function json(payload, status, origin) {
+  return new Response(JSON.stringify(payload), {
+    status: status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      ...corsHeaders(origin),
+    },
+  });
+}

--- a/docs/about.html
+++ b/docs/about.html
@@ -17,6 +17,7 @@
         <li><a href="downloads.html">Downloads</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Join us</a></li>
+        <li><a href="reportbug.html">Report Bug</a></li>
       </ul>
     </nav>
   </header>

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -17,6 +17,7 @@
         <li><a href="downloads.html">Downloads</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html" class="active">Join us</a></li>
+        <li><a href="reportbug.html">Report Bug</a></li>
       </ul>
     </nav>
   </header>

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -17,6 +17,7 @@
         <li><a href="downloads.html">Downloads</a></li>
         <li><a href="contributors.html" class="active">Contributors</a></li>
         <li><a href="contact.html">Join us</a></li>
+        <li><a href="reportbug.html">Report Bug</a></li>
       </ul>
     </nav>
   </header>

--- a/docs/devblog.html
+++ b/docs/devblog.html
@@ -17,6 +17,7 @@
         <li><a href="downloads.html">Downloads</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Join us</a></li>
+        <li><a href="reportbug.html">Report Bug</a></li>
       </ul>
     </nav>
   </header>

--- a/docs/downloads.html
+++ b/docs/downloads.html
@@ -17,6 +17,7 @@
         <li><a href="downloads.html" class="active">Downloads</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Join us</a></li>
+        <li><a href="reportbug.html">Report Bug</a></li>
       </ul>
     </nav>
   </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
         <li><a href="downloads.html">Downloads</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Join us</a></li>
+        <li><a href="reportbug.html">Report Bug</a></li>
       </ul>
     </nav>
   </header>

--- a/docs/reportbug.html
+++ b/docs/reportbug.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Report a bug — Akhenaten</title>
+  <link rel="stylesheet" href="style.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/github-markdown-css@5.5.1/github-markdown-dark.min.css"
+  />
+  <style>
+    .report-form {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .field label {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      letter-spacing: 0.03em;
+    }
+
+    .field input,
+    .field textarea {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--text);
+      font-family: 'Consolas', 'Courier New', monospace;
+      font-size: 0.95rem;
+      padding: 0.65rem 0.8rem;
+      line-height: 1.5;
+      transition: border-color 0.2s, box-shadow 0.2s;
+    }
+
+    .field input:focus,
+    .field textarea:focus {
+      outline: none;
+      border-color: var(--gold);
+      box-shadow: 0 0 0 2px rgba(201, 168, 76, 0.25);
+    }
+
+    .field textarea {
+      min-height: 320px;
+      resize: vertical;
+    }
+
+    .honeypot {
+      position: absolute;
+      left: -10000px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    .form-actions {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .btn[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    #status {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      min-height: 1.4em;
+    }
+
+    #status.error {
+      color: #d97a4a;
+    }
+
+    #status.success {
+      color: var(--gold);
+    }
+
+    .preview-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .preview-label {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .markdown-body {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1.5rem;
+      height: 320px;
+      min-height: 120px;
+      overflow: auto;
+      resize: vertical;
+      color: var(--text);
+      color-scheme: dark;
+    }
+
+    .markdown-body:empty::before {
+      content: 'Preview will appear here as you type.';
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
+    .cheatsheet {
+      margin-top: 3rem;
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1.25rem 1.5rem;
+    }
+
+    .cheatsheet > summary {
+      cursor: pointer;
+      color: var(--gold);
+      font-size: 1.05rem;
+      letter-spacing: 0.03em;
+      list-style: none;
+    }
+
+    .cheatsheet > summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .cheatsheet > summary::before {
+      content: '▸ ';
+      color: var(--text-muted);
+    }
+
+    .cheatsheet[open] > summary::before {
+      content: '▾ ';
+    }
+
+    .cheatsheet-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem 2rem;
+      margin-top: 1rem;
+    }
+
+    @media (max-width: 700px) {
+      .cheatsheet-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .cheatsheet-grid h3 {
+      color: var(--accent);
+      font-size: 0.95rem;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.5rem;
+    }
+
+    .cheatsheet-grid pre {
+      background: rgba(201, 168, 76, 0.06);
+      border: 1px solid rgba(201, 168, 76, 0.15);
+      border-radius: 3px;
+      padding: 0.75rem 1rem;
+      font-family: 'Consolas', 'Courier New', monospace;
+      font-size: 0.85em;
+      line-height: 1.6;
+      color: var(--text);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .privacy-note {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      margin-top: 0.25rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html" class="nav-logo">Akhenaten</a>
+      <ul>
+        <li><a href="about.html">About</a></li>
+        <li><a href="devblog.html">Devblog</a></li>
+        <li><a href="screenshots.html">Screenshots</a></li>
+        <li><a href="downloads.html">Downloads</a></li>
+        <li><a href="contributors.html">Contributors</a></li>
+        <li><a href="contact.html">Join us</a></li>
+        <li><a href="reportbug.html" class="active">Report Bug</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="page-content">
+    <h1>Report a bug</h1>
+    <p class="section-intro">
+      Found a problem in Akhenaten? Fill out the form below and your report will
+      be posted as an issue on
+      <a href="https://github.com/dalerank/Akhenaten/issues" target="_blank">github.com/dalerank/Akhenaten</a>.
+      Use Markdown to format your description &mdash; the live preview below
+      shows exactly how it will render on GitHub. Spam reports are filtered out
+      automatically.
+    </p>
+
+    <form id="bug-form" class="report-form" novalidate>
+        <div class="field">
+          <label for="title">Title</label>
+          <input
+            id="title"
+            name="title"
+            type="text"
+            required
+            maxlength="120"
+            placeholder="Short summary of the bug"
+          />
+        </div>
+
+        <div class="field">
+          <label for="body">Description (Markdown)</label>
+          <textarea
+            id="body"
+            name="body"
+            required
+            minlength="20"
+            maxlength="8000"
+            placeholder="Steps to reproduce, expected vs. actual behaviour, OS, version, screenshots..."
+          ></textarea>
+        </div>
+
+        <div class="field">
+          <label for="name">Your name <span style="color:var(--text-muted)">(optional)</span></label>
+          <input id="name" name="name" type="text" maxlength="80" />
+        </div>
+
+        <div class="field">
+          <label for="email">Your email <span style="color:var(--text-muted)">(optional, for follow-up)</span></label>
+          <input id="email" name="email" type="email" maxlength="200" />
+          <p class="privacy-note">Your email is included in the issue body so maintainers can reach out. Leave blank to stay anonymous.</p>
+        </div>
+
+        <div class="preview-wrap">
+          <div class="preview-label">Preview</div>
+          <div id="preview" class="markdown-body"></div>
+        </div>
+
+        <!-- Honeypot: real users never fill this in -->
+        <div class="honeypot" aria-hidden="true">
+          <label for="website">Website</label>
+          <input id="website" name="website" type="text" tabindex="-1" autocomplete="off" />
+        </div>
+
+        <div class="form-actions">
+          <button type="submit" class="btn btn-primary" id="submit-btn">Submit report</button>
+          <div id="status" role="status" aria-live="polite"></div>
+        </div>
+      </form>
+
+    <details class="cheatsheet">
+      <summary>Markdown cheatsheet</summary>
+      <div class="cheatsheet-grid">
+        <div>
+          <h3>Headings</h3>
+<pre># Heading 1
+## Heading 2
+### Heading 3</pre>
+        </div>
+
+        <div>
+          <h3>Emphasis</h3>
+<pre>**bold**  *italic*  ~~strikethrough~~</pre>
+        </div>
+
+        <div>
+          <h3>Lists</h3>
+<pre>- bullet
+- another bullet
+  - nested
+
+1. first
+2. second</pre>
+        </div>
+
+        <div>
+          <h3>Task lists</h3>
+<pre>- [x] done
+- [ ] not done</pre>
+        </div>
+
+        <div>
+          <h3>Inline &amp; fenced code</h3>
+<pre>Use `inline code` like this.
+
+```cpp
+int main() {
+    return 0;
+}
+```</pre>
+        </div>
+
+        <div>
+          <h3>Links &amp; images</h3>
+<pre>[link text](https://example.com)
+![alt text](https://example.com/img.png)</pre>
+        </div>
+
+        <div>
+          <h3>Blockquotes</h3>
+<pre>&gt; A blockquote
+&gt; spans multiple lines.</pre>
+        </div>
+
+        <div>
+          <h3>Tables</h3>
+<pre>| Column A | Column B |
+| -------- | -------- |
+| value 1  | value 2  |
+| value 3  | value 4  |</pre>
+        </div>
+
+        <div>
+          <h3>Horizontal rule</h3>
+<pre>---</pre>
+        </div>
+
+        <div>
+          <h3>Auto-links</h3>
+<pre>https://github.com/dalerank/Akhenaten
+
+Issue refs: #123
+Mentions:   @username</pre>
+        </div>
+      </div>
+    </details>
+  </main>
+
+  <footer>
+    <p>Akhenaten is an open-source, non-commercial project. All rights to Pharaoh, its mechanics and setting belong to their respective copyright owners.</p>
+    <p><a href="https://github.com/dalerank/Akhenaten" target="_blank">github.com/dalerank/Akhenaten</a></p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.11/dist/purify.min.js"></script>
+  <script>
+    // TODO: set after deploying the serverless function (see api/report-bug.js)
+    const ENDPOINT = '';
+
+    // Used by the spam filter — bots usually submit within milliseconds.
+    const loadedAt = Date.now();
+
+    marked.setOptions({ gfm: true, breaks: true });
+
+    const bodyEl = document.getElementById('body');
+    const previewEl = document.getElementById('preview');
+    const statusEl = document.getElementById('status');
+    const submitBtn = document.getElementById('submit-btn');
+    const form = document.getElementById('bug-form');
+
+    let renderTimer = null;
+    function renderPreview() {
+      const md = bodyEl.value;
+      if (!md) {
+        previewEl.innerHTML = '';
+        return;
+      }
+      const html = marked.parse(md);
+      previewEl.innerHTML = DOMPurify.sanitize(html);
+    }
+
+    bodyEl.addEventListener('input', () => {
+      clearTimeout(renderTimer);
+      renderTimer = setTimeout(renderPreview, 150);
+    });
+
+    function setStatus(message, kind) {
+      statusEl.textContent = message;
+      statusEl.className = kind || '';
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      const data = {
+        title: document.getElementById('title').value.trim(),
+        body: bodyEl.value,
+        name: document.getElementById('name').value.trim(),
+        email: document.getElementById('email').value.trim(),
+        website: document.getElementById('website').value,
+        loadedAt: loadedAt,
+      };
+
+      if (!data.title) {
+        setStatus('Please enter a title.', 'error');
+        return;
+      }
+      if (data.body.trim().length < 20) {
+        setStatus('Please write at least 20 characters describing the bug.', 'error');
+        return;
+      }
+      if (!ENDPOINT) {
+        setStatus('Bug-report endpoint is not configured yet. Please open an issue on GitHub directly.', 'error');
+        return;
+      }
+
+      submitBtn.disabled = true;
+      setStatus('Submitting…');
+
+      try {
+        const response = await fetch(ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        });
+        const payload = await response.json().catch(() => ({}));
+
+        if (response.ok && payload.ok && payload.url) {
+          statusEl.innerHTML =
+            'Reported! <a href="' + payload.url + '" target="_blank">View on GitHub →</a>';
+          statusEl.className = 'success';
+          form.reset();
+          previewEl.innerHTML = '';
+        } else {
+          const msg = payload.error || ('Submission failed (' + response.status + ').');
+          setStatus(msg, 'error');
+        }
+      } catch (err) {
+        setStatus('Network error: ' + err.message, 'error');
+      } finally {
+        submitBtn.disabled = false;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/docs/screenshots.html
+++ b/docs/screenshots.html
@@ -17,6 +17,7 @@
         <li><a href="downloads.html">Downloads</a></li>
         <li><a href="contributors.html">Contributors</a></li>
         <li><a href="contact.html">Join us</a></li>
+        <li><a href="reportbug.html">Report Bug</a></li>
       </ul>
     </nav>
   </header>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "akhenaten-bug-report",
+  "version": "1.0.0",
+  "description": "Cloudflare Worker that receives bug reports from the Akhenaten docs site and opens GitHub issues.",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "login": "wrangler login",
+    "secret:github": "wrangler secret put GITHUB_TOKEN",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "wrangler": "^3.90.0"
+  }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,26 @@
+# Cloudflare Workers config for the bug-report function.
+# Required by wrangler — defines the worker name, entry file, and env vars.
+#
+# Deploy steps (assuming you've run `npm install`):
+#   1. npm run login                   (one-time browser auth)
+#   2. npm run secret:github           (paste your GitHub PAT)
+#   3. npm run deploy                  (publishes the worker)
+#
+# After step 3, wrangler prints a URL like
+#   https://akhenaten-bug-report.<your-subdomain>.workers.dev
+# Paste that URL into the ENDPOINT constant in docs/reportbug.html.
+#
+# To run the worker locally with hot reload:
+#   npm run dev
+# Then point ENDPOINT at http://localhost:8787 (the default dev port).
+
+name = "akhenaten-bug-report"
+main = "api/report-bug.js"
+compatibility_date = "2025-01-15"
+
+# Plain (non-secret) env vars. Override per-environment if you need to.
+# Use the docs origin you actually serve from. For local testing against
+# `python -m http.server 8000`, change this to "http://localhost:8000"
+# (or set it via `wrangler deploy --var ALLOWED_ORIGIN:...`).
+[vars]
+ALLOWED_ORIGIN = "https://dalerank.github.io"


### PR DESCRIPTION
- New static page docs/reportbug.html with title/description fields, live GitHub-styled markdown preview (marked + DOMPurify + github-markdown-css), expandable preview pane, and an inline GFM cheatsheet.
- New Cloudflare Worker api/report-bug.js that validates input, runs a honeypot + form-age spam check, and opens an issue on dalerank/Akhenaten via the GitHub REST API.
- wrangler.toml + package.json for the worker deploy + dev workflow.
- api/README.md walks through prereqs, deploy, smoke-test, troubleshooting, and how to add Cloudflare Turnstile later if spam becomes a problem.
- "Report Bug" nav link added to every top-level docs page.