### PR TITLE
Fix trader info window crash and display issues

### DIFF
--- a/src/figure/figure_impl.cpp
+++ b/src/figure/figure_impl.cpp
@@ -298,7 +298,7 @@ static const fproperty fproperties[] = {
     { tags().figure, tags().name, [] (figure &f, const xstring &) { return bvariant(f.name.c_str()); }},
     { tags().figure, tags().class_name, [] (figure &f, const xstring &) { bstring64 clname("#", f.params().name); return bvariant(lang_text_from_key(clname)); }},
     { tags().figure, tags().city_name, [] (figure &f, const xstring &) { return bvariant(f.dcast()->empire_city().name()); }},
-    { tags().figure, tags().action_tip, [] (figure &f, const xstring &) { return bvariant(f.action_tip()); }},
+    { tags().figure, tags().action_tip, [] (figure &f, const xstring &) { return bvariant(lang_text_from_key(f.action_tip().c_str())); }},
     { tags().figure, tags().home, [] (figure &f, const xstring &) { return bvariant(ui::str(41, f.home()->type)); }},
 };
 

--- a/src/graphics/elements/rich_text.cpp
+++ b/src/graphics/elements/rich_text.cpp
@@ -265,11 +265,13 @@ void rich_text_t::draw_line(painter &ctx, pcstr str, int x, int y, color clr, bo
                     }
 
                     const image_t* img = image_letter(glyph.imagid);
-                    if (!measure_only) {
-                        int height = def->image_y_offset((const uint8_t *)str, img->height, def->line_height);
-                        ctx.img_letter(img, def->font, glyph.imagid, x, y - height - glyph.bearing.y, clr);
+                    if (img) {
+                        if (!measure_only) {
+                            int height = def->image_y_offset((const uint8_t *)str, img->height, def->line_height);
+                            ctx.img_letter(img, def->font, glyph.imagid, x, y - height - glyph.bearing.y, clr);
+                        }
+                        x += img->width + def->letter_spacing;
                     }
-                    x += img->width + def->letter_spacing;
                 }
             }
 

--- a/src/graphics/font.cpp
+++ b/src/graphics/font.cpp
@@ -163,11 +163,17 @@ static uint32_t utf8_decode(const uint8_t* str, int* out_bytes) {
 
 const font_definition* font_definition_for(e_font font) {
     auto& data = g_font_data;
+    if (font < 0 || font >= FONT_TYPES_MAX) {
+        font = FONT_NORMAL_BLACK_ON_LIGHT;
+    }
     return &data.font_definitions[font];
 }
 
 font_definition *font_definition_ref(e_font font) {
     auto &data = g_font_data;
+    if (font < 0 || font >= FONT_TYPES_MAX) {
+        font = FONT_NORMAL_BLACK_ON_LIGHT;
+    }
     return &data.font_definitions[font];
 }
 

--- a/src/scripts/ui_figure_trader_window.js
+++ b/src/scripts/ui_figure_trader_window.js
@@ -14,10 +14,10 @@ figure_trader_info_window {
         capacity: text({ pos[92, 130], text: "${loc.trader_capacity} ${figure.capacity}", font: FONT_NORMAL_BLACK_ON_DARK })
 
         buy: text({ pos[92, 150], text: "${loc.trader_bought}", font: FONT_NORMAL_BLACK_ON_DARK })
-        buy_text: text({ pos[150, 150], rich: true, scroll: false })
+        buy_text: text({ pos[150, 150], font: FONT_NORMAL_BLACK_ON_DARK, rich: true, scroll: false })
 
         sell: text({ pos[92, 170], text: "${loc.trader_sold}", font: FONT_NORMAL_BLACK_ON_DARK })
-        sell_text: text({ pos[150, 170], rich: true, scroll: false })
+        sell_text: text({ pos[150, 170], font: FONT_NORMAL_BLACK_ON_DARK, rich: true, scroll: false })
 
         phrase: text({ pos[90, 200], font: FONT_NORMAL_BLACK_ON_DARK, wrap: px(21), multiline: true, scroll: false })
 

--- a/src/window/window_figure_trader_info.cpp
+++ b/src/window/window_figure_trader_info.cpp
@@ -49,7 +49,7 @@ void figure_trader_info_window::init(object_info &c) {
             int amount = trader.bought_resources(r);
             if (amount > 0) {
                 int image_id = image_id_resource_icon(r);
-                bought_items.append_fmt(" @I%u& %u", image_id, amount);
+                bought_items.append_fmt(" @I%u& %u  ", image_id, amount);
             }
         }
         ui["buy_text"] = bought_items;
@@ -60,7 +60,7 @@ void figure_trader_info_window::init(object_info &c) {
             int amount = trader.sold_resources(r);
             if (amount > 0) {
                 int image_id = image_id_resource_icon(r);
-                sold_items.append_fmt(" @I%u& %u", image_id, amount);
+                sold_items.append_fmt(" @I%u& %u  ", image_id, amount);
             }
         }
         ui["sell_text"] = sold_items;
@@ -73,7 +73,7 @@ void figure_trader_info_window::init(object_info &c) {
         for (e_resource r = RESOURCES_MIN; r < RESOURCES_MAX; ++r) {
             if (city.buys_resource(r)) {
                 int image_id = image_id_resource_icon(r);
-                buy_items.append_fmt("@I%u& ", image_id);
+                buy_items.append_fmt("@I%u&   ", image_id);
             }
         }
         ui["buy_text"] = buy_items;
@@ -83,7 +83,7 @@ void figure_trader_info_window::init(object_info &c) {
         for (e_resource r = RESOURCES_MIN; r < RESOURCES_MAX; ++r) {
             if (city.sells_resource(r)) {
                 int image_id = image_id_resource_icon(r);
-                sell_items.append_fmt("@I%u& ", image_id);
+                sell_items.append_fmt("@I%u&   ", image_id);
             }
         }
         ui["sell_text"] = sell_items;


### PR DESCRIPTION
Fixes #412 

## Summary

Right-clicking a land trader or trader ship would crash the game. Investigation revealed several related issues in the trader info window:

- **Crash root cause** (`font.cpp`): `font_definition_for(FONT_INVALID)` indexed past the size-10 `font_definitions` array (FONT_INVALID = 0xff = 255), returning a wild pointer. Calling `def->image_y_offset` then jumped to garbage memory. The trigger was the trader window's `buy_text` / `sell_text` JS elements omitting the `font:` attribute, which defaults to `FONT_INVALID` in `elabel::load`. Bound-checked the lookup so any out-of-range font falls back to `FONT_NORMAL_BLACK_ON_LIGHT`.
- **Action tip showing raw key** (`figure_impl.cpp`): `${figure.action_tip}` substitution returned the raw `#trader_ship_sailing_dock` key, which displayed as `?trader ship sailing dock` (no glyph for `#` falls back to `?`, and `_` renders as space). Wrapped in `lang_text_from_key()` like the sibling `${figure.class_name}` substitution.
- **Crowded resource icons** (`window_figure_trader_info.cpp`): added two extra spaces between items.
- **Missing fonts in JS** (`ui_figure_trader_window.js`): gave `buy_text` / `sell_text` an explicit `font:` so they don't rely on the (now bound-checked) `FONT_INVALID` fallback.
- **Defensive null-check** (`rich_text.cpp`): `image_letter()` can legitimately return `nullptr` (cache miss with no fallback). Added the same null check already present in the sister code in `text.cpp`.

## Test plan

- [x] Right-click a land trader (caravan) — info window opens, no crash
- [x] Right-click a trader ship — info window opens, no crash
- [x] Action tip displays localized text (e.g. "Sailing to city Docks") instead of `?trader ship sailing dock`
- [x] Resource icons in bought/sold rows are visually spaced out
- [x] Debug build is clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)