### PR TITLE
fix(top-menu): use global screen for is_fullscreen_only check

### DIFF
--- a/src/scripts/ui_top_menu_widget.js
+++ b/src/scripts/ui_top_menu_widget.js
@@ -167,7 +167,7 @@ top_menu_widget {
 [es=top_menu_widget_init]
 function top_menu_widget_open_submenu(window) {
 	window.new_game.enabled = !game_features.gameui_hide_new_game_top_menu
-	window.display_options.enabled = !game.screen.is_fullscreen_only
+	window.display_options.enabled = !screen.is_fullscreen_only
 }
 
 [es=top_menu_widget_background_draw]


### PR DESCRIPTION
## Summary

One-character fix in `top_menu_widget_open_submenu` to access the global `screen` object instead of the non-existent `game.screen`. Without this, every top-menu header click crashed the game with `TypeError: cannot convert undefined to object`.

## Root cause

Commit ddc93a1b0 (`refactor: redesign screen class`) moved the screen object from `game.screen` to a global `screen`. That commit updated most JS usages in this file (e.g. `game.screen.w` → `screen.width` at line 182), but missed updating the `game.screen.is_fullscreen_only` reference at line 170. Since `game.screen` is now `undefined`, accessing `.is_fullscreen_only` on it throws.

## Fix

```diff
- window.display_options.enabled = !game.screen.is_fullscreen_only
+ window.display_options.enabled = !screen.is_fullscreen_only
```

## Test plan

- [x] Launch the game and load a savegame.
- [x] Click each top-menu header (File, Options, Help, Advisors, Debug, Render).
- [x] Confirm each submenu opens without the `cannot convert undefined to object` fatal.
- [x] Confirm Options → "Display options" remains correctly enabled in windowed-capable builds and disabled in fullscreen-only builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)