### PR TITLE
fix(input): suppress global hotkeys while a text field is capturing input

### DIFF
--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -162,6 +162,10 @@ int keyboard_input_is_accepted(void) {
     }
 }
 
+int keyboard_is_capturing(void) {
+    return g_input_keyboard_data.capture;
+}
+
 int keyboard_is_insert(void) {
     auto &data = g_input_keyboard_data;
     return data.insert;

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -14,6 +14,7 @@ void keyboard_start_capture_numeric(void (*callback)(int));
 void keyboard_stop_capture_numeric(void);
 
 int keyboard_input_is_accepted(void);
+int keyboard_is_capturing(void);
 int keyboard_is_insert(void);
 int keyboard_cursor_position(void);
 int keyboard_offset_start(void);

--- a/src/platform/keyboard_input.cpp
+++ b/src/platform/keyboard_input.cpp
@@ -376,6 +376,14 @@ void platform_handle_key_down(SDL_KeyboardEvent* event) {
     }
     e_key key = (e_key)platform.get_key_from_scancode(event->keysym.scancode);
     e_key_mode mod = get_modifier(event->keysym.mod);
+
+    // when a text field is capturing input, suppress global hotkeys so typing
+    // characters like digits or '-' doesn't trigger advisor/menu shortcuts.
+    // Escape is allowed through so dialogs can still be cancelled.
+    if (keyboard_is_capturing() && key != KEY_ESCAPE) {
+        return;
+    }
+
     hotkey_key_pressed(key, mod, event->repeat);
 
     // handle cheats: special case since they ARE layout dependent


### PR DESCRIPTION
Fixes #418 

## Summary

- Add `keyboard_is_capturing()` helper exposing the existing capture flag from `g_input_keyboard_data`.
- In `platform_handle_key_down`, return early before `hotkey_key_pressed` when capture is active so typing characters doesn't fire global hotkeys.
- Allow `KEY_ESCAPE` through so the user can still cancel the dialog.

## Why

When a text input has focus (e.g. the Save Game filename dialog), pressing characters like `1`–`8`, `D`, `-`, etc. would fire global hotkeys — opening advisor menus, toggling overlays, triggering camera rotation — while the user was just trying to type a filename.

## Test plan

- [x] Open Save Game, type a filename containing digits (`1`–`8`) and `-`. Confirm no advisor windows open and no overlays toggle while typing.
- [ ] Confirm `ESC` still closes the save dialog.
- [ ] Confirm hotkeys still work normally when no text input is focused (open advisor with `1`, toggle overlays, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)