### PR TITLE
ui: fix Send Gift handlers and top menu screen.is_fullscreen_only

### DIFF
--- a/src/scripts/ui_send_gift_window.js
+++ b/src/scripts/ui_send_gift_window.js
@@ -55,30 +55,30 @@ function gift_to_kingdome_window_init(window) {
     log_info("akhenaten: cant_send_gifts.enabled = " + window.cant_send_gifts.enabled)
     window.send_gift.readonly = !can_send
     window.send_gift.darkened = !can_send
-    window.send_gift.onclick = gift_to_kingdome_window_on_send_gift
 
     gift_to_kingdome_apply_link_state(window)
 }
 
 [es=(gift_to_kingdome_window, link_modest)]
-function gift_to_kingdome_window_on_link_modest(ev) {
+function gift_to_kingdome_window_on_link_modest(window) {
     city.kingdome.selected_size = gift_type.MODEST
     gift_to_kingdome_apply_link_state(window)
 }
 
 [es=(gift_to_kingdome_window, link_generous)]
-function gift_to_kingdome_window_on_link_generous(ev) {
+function gift_to_kingdome_window_on_link_generous(window) {
     city.kingdome.selected_size = gift_type.GENEROUS
     gift_to_kingdome_apply_link_state(window)
 }
 
 [es=(gift_to_kingdome_window, link_lavish)]
-function gift_to_kingdome_window_on_link_lavish(ev) {
+function gift_to_kingdome_window_on_link_lavish(window) {
     city.kingdome.selected_size = gift_type.LAVISH
     gift_to_kingdome_apply_link_state(window)
 }
 
-function gift_to_kingdome_window_on_send_gift(ev) {
+[es=(gift_to_kingdome_window, send_gift)]
+function gift_to_kingdome_window_on_send_gift(window) {
     if (!city.kingdome.can_send_gift(city.kingdome.selected_size))
         return
 

--- a/src/scripts/ui_top_menu_widget.js
+++ b/src/scripts/ui_top_menu_widget.js
@@ -167,7 +167,7 @@ top_menu_widget {
 [es=top_menu_widget_init]
 function top_menu_widget_open_submenu(window) {
 	window.new_game.enabled = !game_features.gameui_hide_new_game_top_menu
-	window.display_options.enabled = !game.screen.is_fullscreen_only
+	window.display_options.enabled = !screen.is_fullscreen_only
 }
 
 [es=top_menu_widget_background_draw]


### PR DESCRIPTION
Fixes #427.

## `ui_send_gift_window.js` (regression from `a2fa9f7190`)

- Renamed `(ev)` → `(window)` in three link handlers — body uses `window` (mujs ReferenceError otherwise).
- Promoted `gift_to_kingdome_window_on_send_gift` to `[es=(gift_to_kingdome_window, send_gift)]` to match the button's `onclick_event: "send_gift"`. Dropped the dead `window.send_gift.onclick = …` line in init.

## `ui_top_menu_widget.js` (regression from `ddc93a1b07`)

- `game.screen.is_fullscreen_only` → `screen.is_fullscreen_only`. Same commit removed `game.screen` and moved the property to the new global `screen` object; sibling function was updated, this one was missed.

## Verification

- Imperial Advisor → Send gift → Modest/Generous/Lavish select without crash; Send gift now closes the dialog and emits the event.
- Top menu opens without `TypeError: cannot convert undefined to object`.