### PR TITLE
fix(monument): set sled puller destination tile (inverted null check)

### DIFF
--- a/src/figuretype/figure_sled.cpp
+++ b/src/figuretype/figure_sled.cpp
@@ -93,7 +93,7 @@ void figure_sled_puller::figure_action() {
             advance_action(ACTION_51_SLED_PULLER_DELIVERING_RESOURCE);
             auto monument = destination()->dcast_monument();
             assert(monument);
-            if (!monument) {
+            if (monument) {
                 base.destination_tile = monument->center_point();
             }
         }


### PR DESCRIPTION
Fixes #429.

`figure_sled.cpp:106` had `if (!monument)` where it should be `if (monument)`. As a result `base.destination_tile` was never set on the normal path, so puller "arrived" right next to the storage yard, died, and the sled it led `poof()`'d outside `monument->get_area()` without calling `do_deliver`. Every shipment of bricks/stone/granite/etc. to every monument (mastaba, pyramid, …) silently vanished.

## Verification

- Loaded a Behdet save with a small mastaba blocked at phase 2.
- Before: sleds dispatched from storage yards; logs showed `[DBG SLED] leader_dead ... inside=0` on every shipment, `resources_pct[]` stayed at 0, bricklayers idle.
- After: sleds reach the monument, `do_deliver` runs, `resources_pct[bricks]` increases, bricklayers transition to `ACTION_14_BRICKLAYER_LAY_BRICKS`, mastaba progresses past phase 2.