### PR TITLE
fix(mastaba): restore image_stick id 8, broken path renders as black square

### DIFF
--- a/src/scripts/building_mastaba.js
+++ b/src/scripts/building_mastaba.js
@@ -8,7 +8,7 @@ building_small_mastaba {
       base_bricks { id:1, offset:0 }
       base_grounded { path:"mastaba/pyramid_phase_one_00013" }
       clear_land { id:2, offset:12 }
-      image_stick { path:"mastaba/pyramid_phase_one_00021" }
+      image_stick { id:8 }
       empty_land { path:"mastaba/mastaba_00109" }
       enter { id:114 }
     }
@@ -69,7 +69,7 @@ building_small_mastaba {
       base_bricks { id:1, offset:0 }
       base_grounded { path:"mastaba/pyramid_phase_one_00013" }
       clear_land { id:2, offset:12 }
-      image_stick { path:"mastaba/pyramid_phase_one_00021" }
+      image_stick { id:8 }
       empty_land {path:"mastaba/mastaba_00109"}
       enter {id:114}
     }


### PR DESCRIPTION
Fixes #431.

`image_stick { path:"mastaba/pyramid_phase_one_00021" }` references a file that does not exist in `PACK_MASTABA` — it's a pyramid pack asset (`stepped_pyramid/pyramid_phase_one_00021`). Image lookup returns 0 → renderer draws a black square on the delivery tile next to the mastaba foundation.

Restored the working `id:8` value used before commit `5e3f7ffdd9` (2026-01-18, "mastaba: fixed drawing stick over land"). Both occurrences (small mastaba north and east orientations).

## Verification

- Loaded a Behdet save with a small mastaba in construction.
- Before: black square next to the foundation entrance.
- After: tile rendered correctly with the stick image.