### PR TITLE
fix(crash): guard storage yard cart against destroyed home/destination

### DIFF
--- a/src/figuretype/figure_storageyard_cart.cpp
+++ b/src/figuretype/figure_storageyard_cart.cpp
@@ -60,13 +60,23 @@ void figure_storageyard_cart::do_retrieve(int action_done) {
     }
 
     building* dest = destination();
+    if (!dest->is_valid()) {
+        advance_action(action_done);
+        return;
+    }
+
     const bool is_storage = building_type_any_of(dest->type, { BUILDING_GRANARY, BUILDING_STORAGE_YARD, BUILDING_STORAGE_ROOM });
     if (!is_storage) {
         advance_action(action_done);
+        return;
     }
 
     building_storage *home_storage = home()->dcast_storage();
     building_storage *dest_storage = dest->dcast_storage();
+    if (!home_storage || !dest_storage) {
+        advance_action(action_done);
+        return;
+    }
 
     if (base.collecting_item_id == RESOURCE_NONE) {
         auto loads = acquire_resource_for_getting_deliveryman(destination(), home());
@@ -96,6 +106,11 @@ void figure_storageyard_cart::do_retrieve(int action_done) {
 void figure_storageyard_cart::figure_action() {
     OZZY_PROFILER_FUNCTION();
     int road_network_id = map_road_network_get(tile());
+
+    if (!home()->is_valid()) {
+        poof();
+        return;
+    }
 
     base.use_cart = true;
     switch (action_state()) {


### PR DESCRIPTION
Fixes #433.

`figure_storageyard_cart` ticked without checking that its `home()` / `destination()` were still alive. Demolishing the home yard while a cart was collecting goods from another yard/granary crashed in `do_retrieve` on `home()->dcast_storage()`.

Same class of bug as #364 (figure_docker dangling reference).

## Changes

- `figure_action()` — early `poof()` if `home()` is no longer valid (mirrors the pattern in `figure_bricklayer.cpp:17`).
- `do_retrieve()` — added three defensive checks:
  - `if (!dest->is_valid())` → `advance_action; return;`
  - missing `return` after `if (!is_storage) advance_action(...)` (the function used to fall through and crash)
  - null check on `home_storage` / `dest_storage` after `dcast_storage()`

## Verification

- Reproduced on a Behdet save by demolishing a storage yard with an active cart in `ACTION_58`.
- Before: `signal 11` crash with the stack above.
- After: cart `poof()`s cleanly, no crash, gameplay continues.