### PR TITLE
fix(mastaba): restore info-window content from original Pharaoh layout

### DIFF
--- a/src/scripts/building_mastaba.js
+++ b/src/scripts/building_mastaba.js
@@ -16,7 +16,7 @@ building_small_mastaba {
     info_title_id[198, 18]
     fire_proof :  true
     damage_proof : true
-    meta { help_id:4, text_id:120 }
+    meta { help_id:4, text_id:178 }
     info_sound : "Wavs/rock3.wav"
     init_tiles [10, 4]
 
@@ -78,7 +78,7 @@ building_small_mastaba {
     info_title_id [198, 19]
     fire_proof :  true
     damage_proof : true
-    meta { help_id:4, text_id:120 }
+    meta { help_id:4, text_id:178 }
     info_sound : "Wavs/rock3.wav"
     init_tiles [14, 6]
 

--- a/src/scripts/building_pyramid.js
+++ b/src/scripts/building_pyramid.js
@@ -25,7 +25,7 @@ building_small_stepped_pyramid {
     info_title_id [198, 18]
     fire_proof :  true
     damage_proof : true
-    meta { help_id:375, text_id:120 }
+    meta { help_id:375, text_id:178 }
     init_tiles [8, 8]
 
     flags {
@@ -82,7 +82,7 @@ building_small_stepped_pyramid {
     info_title_id [198, 18]
     fire_proof :  true
     damage_proof : true
-    meta { help_id:375, text_id:120 }
+    meta { help_id:375, text_id:178 }
     init_tiles [12, 12]
 
     enter_offset : [2, 12]

--- a/src/scripts/ui_widgets.js
+++ b/src/scripts/ui_widgets.js
@@ -265,10 +265,12 @@ info_window_mastaba = {
         subtitle      : text({pos: [32, 46], text:"${text.12}", size: [px(27), -1], wrap:px(27), font : FONT_NORMAL_BLACK_ON_LIGHT, multiline:true }),
         progress_text : text({pos: [32, 66], size:[px(27), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
         warning_text  : text({pos: [32, 96], size:[px(27), -1], wrap:px(27), multiline:true, font : FONT_NORMAL_BLACK_ON_LIGHT }),
-        bricks_icon   : resource_icon({pos: [32, 220], resource: RESOURCE_BRICKS }),
-        bricks_text   : text({pos: [70, 224], size:[px(15), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
-        workers_img   : image({pack:PACK_GENERAL, id:134, offset:14, pos:[260, 220] }),
-        workers_text  : text({pos: [290, 224], size:[px(10), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
+        bricks_icon   : resource_icon({pos: [32, 200], resource: RESOURCE_BRICKS }),
+        bricks_text   : text({pos: [70, 204], size:[px(15), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
+        clay_icon     : resource_icon({pos: [32, 230], resource: RESOURCE_CLAY }),
+        clay_text     : text({pos: [70, 234], size:[px(15), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
+        workers_img   : image({pack:PACK_GENERAL, id:134, offset:14, pos:[260, 215] }),
+        workers_text  : text({pos: [290, 219], size:[px(10), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
     }
 }
 

--- a/src/scripts/ui_widgets.js
+++ b/src/scripts/ui_widgets.js
@@ -262,8 +262,13 @@ info_window_mastaba = {
     ui : {
         background    : outer_panel({size: [29, 18]}),
         title         : text({pos: [0, 16], text:"${building.name}", size: [px(29), 20], font : FONT_LARGE_BLACK_ON_LIGHT, align:"center"}),
-        subtitle      : text({pos: [32, 46], text:"${140.1}", size: [px(27), -1], wrap:px(27), font : FONT_NORMAL_BLACK_ON_LIGHT, multiline:true }),
-        warning_text  : text({pos: [32, 86], size:[px(27), -1], wrap:px(27), multiline:true, font : FONT_NORMAL_BLACK_ON_LIGHT }),
+        subtitle      : text({pos: [32, 46], text:"${text.12}", size: [px(27), -1], wrap:px(27), font : FONT_NORMAL_BLACK_ON_LIGHT, multiline:true }),
+        progress_text : text({pos: [32, 66], size:[px(27), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
+        warning_text  : text({pos: [32, 96], size:[px(27), -1], wrap:px(27), multiline:true, font : FONT_NORMAL_BLACK_ON_LIGHT }),
+        bricks_icon   : resource_icon({pos: [32, 220], resource: RESOURCE_BRICKS }),
+        bricks_text   : text({pos: [70, 224], size:[px(15), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
+        workers_img   : image({pack:PACK_GENERAL, id:134, offset:14, pos:[260, 220] }),
+        workers_text  : text({pos: [290, 224], size:[px(10), 20], font : FONT_NORMAL_BLACK_ON_LIGHT }),
     }
 }
 

--- a/src/window/window_mastaba_info.cpp
+++ b/src/window/window_mastaba_info.cpp
@@ -84,12 +84,24 @@ void info_window_mastaba::init(object_info &c) {
         progress_str.printf("%d / %d    %d%%", (int)d.phase, mastaba->phases(), min_pct);
         ui["progress_text"] = progress_str;
 
-        // bricks delivered / needed for current phase
-        int bricks_needed = mastaba->needs_resource(RESOURCE_BRICKS);
-        int bricks_delivered = bricks_needed * d.resources_pct[RESOURCE_BRICKS] / 100;
-        bstring64 bricks_str;
-        bricks_str.printf("%d / %d", bricks_delivered, bricks_needed);
-        ui["bricks_text"] = bricks_str;
+        // resource counts (delivered / needed) for current phase — mastaba uses
+        // bricks in phase 2+ and clay as a second material in phases 3-7. Hide
+        // the icon entirely when the current phase does not need that resource.
+        auto fill_resource_slot = [&](e_resource r, pcstr icon_key, pcstr text_key) {
+            int needed = mastaba->needs_resource(r);
+            if (needed <= 0) {
+                ui[text_key] = "";
+                ui[icon_key].set_enabled(false);
+                return;
+            }
+            ui[icon_key].set_enabled(true);
+            int delivered = std::min(needed * d.resources_pct[r] / 100, needed);
+            bstring64 s;
+            s.printf("%d / %d", delivered, needed);
+            ui[text_key] = s;
+        };
+        fill_resource_slot(RESOURCE_BRICKS, "bricks_icon", "bricks_text");
+        fill_resource_slot(RESOURCE_CLAY, "clay_icon", "clay_text");
 
         // workers slots
         bstring32 workers_str;
@@ -99,6 +111,9 @@ void info_window_mastaba::init(object_info &c) {
         ui["warning_text"] = textid{ 178, 41 };
         ui["progress_text"] = "";
         ui["bricks_text"] = "";
+        ui["clay_text"] = "";
         ui["workers_text"] = "";
+        ui["bricks_icon"].set_enabled(false);
+        ui["clay_icon"].set_enabled(false);
     }
 }

--- a/src/window/window_mastaba_info.cpp
+++ b/src/window/window_mastaba_info.cpp
@@ -63,7 +63,42 @@ void info_window_mastaba::init(object_info &c) {
         }
 
         ui["warning_text"] = reason;
+
+        // Phase X / Y    Z%  — same status line the monument advisor shows
+        // (data already exposed via __building_monument_phase_code/phases_total/material_pct_min).
+        int min_pct = 100;
+        bool any_resource = false;
+        for (int ri = (int)RESOURCES_MIN; ri <= (int)RESOURCES_MAX; ++ri) {
+            auto r = (e_resource)ri;
+            if (mastaba->needs_resource(r) <= 0) {
+                continue;
+            }
+            any_resource = true;
+            min_pct = std::min(min_pct, (int)d.resources_pct[r]);
+        }
+        if (!any_resource) {
+            min_pct = 100;
+        }
+
+        bstring64 progress_str;
+        progress_str.printf("%d / %d    %d%%", (int)d.phase, mastaba->phases(), min_pct);
+        ui["progress_text"] = progress_str;
+
+        // bricks delivered / needed for current phase
+        int bricks_needed = mastaba->needs_resource(RESOURCE_BRICKS);
+        int bricks_delivered = bricks_needed * d.resources_pct[RESOURCE_BRICKS] / 100;
+        bstring64 bricks_str;
+        bricks_str.printf("%d / %d", bricks_delivered, bricks_needed);
+        ui["bricks_text"] = bricks_str;
+
+        // workers slots
+        bstring32 workers_str;
+        workers_str.printf("%d / %d", workers_num, (int)d.workers.size());
+        ui["workers_text"] = workers_str;
     } else {
         ui["warning_text"] = textid{ 178, 41 };
+        ui["progress_text"] = "";
+        ui["bricks_text"] = "";
+        ui["workers_text"] = "";
     }
 }


### PR DESCRIPTION
## Summary

The mastaba info window subtitle showed the *ruins* description text (group 140 id 1) — a placeholder copied from `ruin_info_window` 5 months ago. Phase progress, brick counts and worker counts that the original Pharaoh info window has were missing.

## Changes

- `ui_widgets.js`: subtitle `${140.1}` → `${text.12}` (Construction Foreman); add phase progress, bricks and workers sections.
- `building_mastaba.js` / `building_pyramid.js`: `meta.text_id` 120 (Wood Cutter copy-paste) → 178 (monument-info group).
- `window_mastaba_info.cpp`: feed the new UI elements from existing monument runtime data.

No new localization keys.

## Verification

Tested in Behdet (mission 6) on a small mastaba at phase 2.