### PR TITLE
Responsive world map layout

### DIFF
--- a/src/empire/empire_map.cpp
+++ b/src/empire/empire_map.cpp
@@ -29,8 +29,8 @@ const static int EMPIRE_DATA_SIZE[2] = {12800, 15200};
 const char SCENARIO_FILE[2][2][100] = {{"c32.emp", "c3.emp"}, {"", "Pharaoh2.emp"}};
 
 void empire_map_t::check_scroll_boundaries() {
-    int max_x = EMPIRE_SIZE.x - viewport_width;
-    int max_y = EMPIRE_SIZE.y - viewport_height + 20;
+    int max_x = std::max(0, EMPIRE_SIZE.x - viewport_width);
+    int max_y = std::max(0, EMPIRE_SIZE.y - viewport_height);
 
     scroll_x = calc_bound(scroll_x, 0, max_x);
     scroll_y = calc_bound(scroll_y, 0, max_y);

--- a/src/scripts/ui_empire_window.js
+++ b/src/scripts/ui_empire_window.js
@@ -138,7 +138,7 @@ function empire_window_layout_ui(window) {
 
     window.button_help.pos = { x: sb.max_pos.x - 40, y: infoTop }
     window.button_close.pos = { x: sb.max_pos.x - 40, y: openTradeTop }
-    window.button_advisor.pos = { x: sb.min_pos.x + 5, y: infoTop }
+    window.button_advisor.pos = { x: sb.min_pos.x + 16, y: infoTop }
 
     window.button_open_trade.pos = { x: centerX - 220, y: openTradeTop }
     window.info_tooltip.pos = { x: centerX - 200, y: infoTooltipTop }

--- a/src/scripts/ui_empire_window.js
+++ b/src/scripts/ui_empire_window.js
@@ -23,28 +23,28 @@ empire_window {
 
     ui {
         background           : dummy({size[sw(0), sh(0)]})
-        city_name            : header({pos[0, -1], margin{bottom:-120}, size[sw(0), 20], align:"center"})
-        button_help          : help_button({margin{centerx:575, bottom:-120}})
-        button_close         : close_button({margin{centerx:575, bottom:-40}})
-        button_advisor       : advisor_button({margin{centerx:-595, bottom:-120}})
+        city_name            : header({pos[0, 0], size[100, 20], align:"center"})
+        button_help          : help_button({pos[0, 0]})
+        button_close         : close_button({pos[0, 0]})
+        button_advisor       : advisor_button({pos[0, 0]})
 
-        button_open_trade    : button({margin{centerx:-220, bottom:-40}, size:[440, 20]})
-        info_tooltip         : text({margin{centerx:-200, bottom:-60}, size:[400, 20], font:FONT_NORMAL_BLACK_ON_LIGHT, align:"center"})
+        button_open_trade    : button({pos[0, 0], size:[440, 20]})
+        info_tooltip         : text({pos[0, 0], size:[400, 20], font:FONT_NORMAL_BLACK_ON_LIGHT, align:"center"})
 
-        city_sell_title      : text({text[47, 11], margin{centerx:250, bottom:-120}, font: FONT_NORMAL_BLACK_ON_LIGHT })
-        city_sell_items      : dummy({pos[0, 100], size[200, 0], margin{centerx:100, bottom:-90}, ondraw_event: "draw_city_sell_items"})
+        city_sell_title      : text({text[47, 11], pos[0, 0], font: FONT_NORMAL_BLACK_ON_LIGHT })
+        city_sell_items      : dummy({pos[0, 0], size[200, 0], ondraw_event: "draw_city_sell_items"})
         city_sell_item       : dummy({size[120, 20], font:FONT_SMALL_PLAIN})
 
-        city_buy_title       : text({text[47, 10], margin{centerx:-300, bottom:-120}, font: FONT_NORMAL_BLACK_ON_LIGHT })
-        city_buy_items       : dummy({pos[0, 0], size[200, 0], margin{centerx:-430, bottom:-90}, ondraw_event: "draw_city_buy_items"})
+        city_buy_title       : text({text[47, 10], pos[0, 0], font: FONT_NORMAL_BLACK_ON_LIGHT })
+        city_buy_items       : dummy({pos[0, 0], size[200, 0], ondraw_event: "draw_city_buy_items"})
         city_buy_item        : dummy({size[120, 20], font:FONT_SMALL_PLAIN})
 
-        city_want_sell_title : text({text[47, 5], margin{centerx:-220, bottom:-90}, font: FONT_NORMAL_BLACK_ON_LIGHT })
-        city_want_sell_items : dummy({pos[0, 100], margin{centerx:-170, bottom:-90}, ondraw_event: "draw_city_want_sell_items"})
+        city_want_sell_title : text({text[47, 5], pos[0, 0], font: FONT_NORMAL_BLACK_ON_LIGHT })
+        city_want_sell_items : dummy({pos[0, 0], ondraw_event: "draw_city_want_sell_items"})
         city_want_sell_item  : dummy({size[110, 0], font:FONT_SMALL_PLAIN})
 
-        city_want_buy_title  : text({text[47, 4], margin{centerx:-220, bottom:-70}, font: FONT_NORMAL_BLACK_ON_LIGHT })
-        city_want_buy_items  : dummy({pos[0, 0], margin{centerx:-170, bottom:-70}, ondraw_event: "draw_city_want_buy_items"})
+        city_want_buy_title  : text({text[47, 4], pos[0, 0], font: FONT_NORMAL_BLACK_ON_LIGHT })
+        city_want_buy_items  : dummy({pos[0, 0], ondraw_event: "draw_city_want_buy_items"})
         city_want_buy_item   : dummy({size[110, 0], font:FONT_SMALL_PLAIN})
     }
 
@@ -105,18 +105,55 @@ function empire_window_draw_trade_resource_row(offset, flags, resource, tradeNow
 }
 
 function empire_window_screen_bounds() {
-    var map_img = get_image(empire_window.image)
-    var f = empire_window.finish_pos
-    var bottom_extra = 20
-    var ew = map_img ? (map_img.width + f.x) : (1200 + 32)
-    var eh = map_img ? (map_img.height + f.y + bottom_extra) : (1600 + 136 + 20)
-    var sw = screen.width
-    var sh = screen.height
-    var min_x = sw <= ew ? 0 : ((sw - ew) / 2) | 0
-    var max_x = sw <= ew ? sw : min_x + ew
-    var min_y = sh <= eh ? 0 : ((sh - eh) / 2) | 0
-    var max_y = sh <= eh ? sh : min_y + eh
-    return { min_pos: {x: min_x, y: min_y}, max_pos: {x: max_x, y: max_y} }
+    return { min_pos: {x: 0, y: 0}, max_pos: {x: screen.width, y: screen.height} }
+}
+
+function empire_window_map_scale() {
+    var sb = empire_window.screen_bounds
+    var viewport_w = Math.max(1, (sb.max_pos.x - sb.min_pos.x) - empire_window.finish_pos.x)
+    var viewport_h = Math.max(1, (sb.max_pos.y - sb.min_pos.y) - empire_window.finish_pos.y)
+    return Math.max(viewport_w / 1200, viewport_h / 1600)
+}
+
+function empire_window_map_point(draw_offset, pos) {
+    var s = empire_window_map_scale()
+    return {
+        x: draw_offset.x + Math.round(pos.x * s),
+        y: draw_offset.y + Math.round(pos.y * s)
+    }
+}
+
+function empire_window_layout_ui(window) {
+    var sb = empire_window.screen_bounds
+    var centerX = ((sb.min_pos.x + sb.max_pos.x) / 2) | 0
+    var width = sb.max_pos.x - sb.min_pos.x
+    var infoTop = sb.max_pos.y - 121
+    var openTradeTop = sb.max_pos.y - 40
+    var infoTooltipTop = sb.max_pos.y - 60
+    var sellItemsTop = sb.max_pos.y + 10
+    var buyItemsTop = sb.max_pos.y - 90
+
+    window.city_name.pos = { x: sb.min_pos.x, y: infoTop - 1 }
+    window.city_name.size = { x: width, y: 20 }
+
+    window.button_help.pos = { x: sb.max_pos.x - 40, y: infoTop }
+    window.button_close.pos = { x: sb.max_pos.x - 40, y: openTradeTop }
+    window.button_advisor.pos = { x: sb.min_pos.x + 5, y: infoTop }
+
+    window.button_open_trade.pos = { x: centerX - 220, y: openTradeTop }
+    window.info_tooltip.pos = { x: centerX - 200, y: infoTooltipTop }
+
+    window.city_sell_title.pos = { x: centerX + 250, y: infoTop }
+    window.city_sell_items.pos = { x: centerX + 100, y: sellItemsTop }
+
+    window.city_buy_title.pos = { x: centerX - 300, y: infoTop }
+    window.city_buy_items.pos = { x: centerX - 430, y: buyItemsTop }
+
+    window.city_want_sell_title.pos = { x: centerX - 220, y: buyItemsTop }
+    window.city_want_sell_items.pos = { x: centerX - 170, y: sellItemsTop }
+
+    window.city_want_buy_title.pos = { x: centerX - 220, y: buyItemsTop + 20 }
+    window.city_want_buy_items.pos = { x: centerX - 170, y: buyItemsTop + 20 }
 }
 
 function empire_window_clear_city_trade_ui(w) {
@@ -350,9 +387,9 @@ function empire_window_es_draw_city_buy_items(window) {
  }
 
 /** Sprites along one segment (spacing matches former C++ trade route / distant battle path). */
-function empire_window_route_segment_sprites(d, img, px, py, p2x, p2y) {
-    var dx = p2x - px
-    var dy = p2y - py
+function empire_window_route_segment_sprites(img, p1, p2) {
+    var dx = p2.x - p1.x
+    var dy = p2.y - p1.y
     var len = 0.2 * Math.sqrt(dx * dx + dy * dy)
     if (len <= 0) {
         return
@@ -362,8 +399,8 @@ function empire_window_route_segment_sprites(d, img, px, py, p2x, p2y) {
     var progress = 1.0
     while (progress < len) {
         ui.image(img, {
-            x: d.x + px + ((scaled_x * progress) | 0),
-            y: d.y + py + ((scaled_y * progress) | 0)
+            x: p1.x + ((scaled_x * progress) | 0),
+            y: p1.y + ((scaled_y * progress) | 0)
         })
         progress += 1.0
     }
@@ -397,19 +434,16 @@ function empire_window_draw_trade_route(ev) {
     if (!img) {
         return
     }
-    var d = vec2i(ev.draw_offset)
     for (var i = 0; i < n; i++) {
         var p = empire.trade_route_point(route_id, i)
-        var px = p.x
-        var py = p.y
-        var sx = d.x + px
-        var sy = d.y + py
-        ui.image(img, { x: sx, y: sy })
+        var sp = empire_window_map_point(ev.draw_offset, p)
+        ui.image(img, sp)
         if (i < n - 1) {
             var p2 = empire.trade_route_point(route_id, i + 1)
-            empire_window_route_segment_sprites(d, img, px, py, p2.x, p2.y)
+            var sp2 = empire_window_map_point(ev.draw_offset, p2)
+            empire_window_route_segment_sprites(img, sp, sp2)
             if (empire.route_debug_points) {
-                ui.fill_rect({ x: sx - 4, y: sy - 4 }, { x: 8, y: 8 }, COLOR_BLACK)
+                ui.fill_rect({ x: sp.x - 4, y: sp.y - 4 }, { x: 8, y: 8 }, COLOR_BLACK)
             }
         }
     }
@@ -424,10 +458,7 @@ function empire_window_draw_trader(ev) {
         return
     }
 
-    var map_pos = vec2i(empire_window.screen_bounds.min_pos).add(empire_window.start_pos)
-    var map_offset = empire_window.adjust_scroll(map_pos)
-
-    ui.image(img, vec2i(map_offset).add(t.current_position))
+    ui.image(img, empire_window_map_point(ev.draw_offset, t.current_position))
 }
 
 [es=(empire_window, draw_map, EMPIRE_OBJECT_DISTANT_BATTLE_ROUTE)]
@@ -446,19 +477,16 @@ function empire_window_draw_distant_battle_path(ev) {
         return
     }
 
-    var d = vec2i(ev.draw_offset)
     for (var i = 0; i < n; i++) {
         var p = empire.active_battle.path_point(i)
-        var px = p.x
-        var py = p.y
-        var sx = d.x + px
-        var sy = d.y + py
-        ui.image(img, { x: sx, y: sy })
+        var sp = empire_window_map_point(ev.draw_offset, p)
+        ui.image(img, sp)
         if (i < n - 1) {
             var p2 = empire.active_battle.path_point(i + 1)
-            empire_window_route_segment_sprites(d, img, px, py, p2.x, p2.y)
+            var sp2 = empire_window_map_point(ev.draw_offset, p2)
+            empire_window_route_segment_sprites(img, sp, sp2)
             if (empire.route_debug_points) {
-                ui.fill_rect({ x: sx - 4, y: sy - 4 }, { x: 8, y: 8 }, COLOR_BLACK)
+                ui.fill_rect({ x: sp.x - 4, y: sp.y - 4 }, { x: 8, y: 8 }, COLOR_BLACK)
             }
         }
     }
@@ -480,8 +508,7 @@ function empire_window_draw_distant_battle_icon(window) {
         return
     }
 
-    var battle_icon_pos = vec2i(window.draw_offset)
-                            .add(ecity.empire_object.pos)
+    var battle_icon_pos = vec2i(empire_window_map_point(window.draw_offset, ecity.empire_object.pos))
                             .add({x:-battle_icon.width / 2, y:-battle_icon.height / 2})
 
     ui.image(battle_icon, battle_icon_pos)
@@ -498,8 +525,7 @@ function empire_window_draw_dispatched_army_icon(window) {
         return
     }
 
-    var army_icon_pos = vec2i(window.draw_offset)
-                            .add(empire.dispatched_army.pos)
+    var army_icon_pos = vec2i(empire_window_map_point(window.draw_offset, empire.dispatched_army.pos))
                             .add({x:-army_icon.width / 2, y:-army_icon.height / 2})
 
     ui.image(army_icon, army_icon_pos)
@@ -510,6 +536,7 @@ function empire_window_draw_background(window) {
     var bounds = empire_window_screen_bounds()
     empire_window.screen_bounds = bounds
     __empire_window_set_map_bounds(bounds.min_pos.x, bounds.min_pos.y, bounds.max_pos.x, bounds.max_pos.y)
+    empire_window_layout_ui(window)
 }
 
 [es=(empire_window, draw_paneling)]

--- a/src/scripts/ui_empire_window.js
+++ b/src/scripts/ui_empire_window.js
@@ -130,7 +130,7 @@ function empire_window_layout_ui(window) {
     var infoTop = sb.max_pos.y - 121
     var openTradeTop = sb.max_pos.y - 40
     var infoTooltipTop = sb.max_pos.y - 60
-    var sellItemsTop = sb.max_pos.y + 10
+    var sellItemsTop = sb.max_pos.y - 90
     var buyItemsTop = sb.max_pos.y - 90
 
     window.city_name.pos = { x: sb.min_pos.x, y: infoTop - 1 }

--- a/src/window/window_empire.cpp
+++ b/src/window/window_empire.cpp
@@ -35,8 +35,11 @@
 #include "js/js_game.h"
 #include "graphics/elements/ui_js.h"
 #include "dev/debug.h"
+#include <cmath>
 
 uint16_t empire_images_remap[32000] = {0};
+
+static const vec2i EMPIRE_MAP_SIZE_PX{1200, 1600};
 
 using empire_object_tokens_t = token_holder<e_empire_object, EMPIRE_OBJECT_ORNAMENT, EMPIRE_OBJECT_COUNT>;
 const empire_object_tokens_t ANK_CONFIG_ENUM(empire_object_tokens);
@@ -214,11 +217,20 @@ void empire_window::determine_selected_object(const mouse* m) {
         return;
     }
 
-    g_empire_map.select_object(vec2i{m->x, m->y} - min_pos - vec2i{16, 16});
+    const vec2i origin = map_base_origin();
+    const float scale = map_scale();
+    const vec2i map_pos{
+        std::max(0, (int)std::lround((m->x - origin.x) / std::max(0.001f, scale))),
+        std::max(0, (int)std::lround((m->y - origin.y) / std::max(0.001f, scale)))
+    };
+
+    g_empire_map.select_object(map_pos);
 }
 
 bool empire_window::is_outside_map(int x, int y) {
-    return (x < min_pos.x + 16 || x >= max_pos.x - 16 || y < min_pos.y + 16 || y >= max_pos.y - 120);
+    const vec2i origin = map_clip_origin();
+    const vec2i size = map_area_size_pixels();
+    return x < origin.x || x >= origin.x + size.x || y < origin.y || y >= origin.y + size.y;
 }
 
 int empire_window::ui_handle_mouse(const mouse* m) {
@@ -227,7 +239,16 @@ int empire_window::ui_handle_mouse(const mouse* m) {
     vec2i position;
     last_mouse_pos = {m->x, m->y};
     if (scroll_get_delta(m, &position, SCROLL_TYPE_EMPIRE)) {
-        g_empire_map.scroll_map(position);
+        const float scale = map_scale();
+        g_empire_map.scroll_map({
+            (int)std::lround(position.x / std::max(0.001f, scale)),
+            (int)std::lround(position.y / std::max(0.001f, scale))
+        });
+    }
+
+    if (!!game_features::gameopt_middle_mouse_camera_pan
+        && m->middle.went_down && !is_outside_map(m->x, m->y)) {
+        scroll_drag_start(scroll_drag_source::middle_mouse_pan);
     }
 
     if (m->is_touch) {
@@ -264,6 +285,10 @@ int empire_window::ui_handle_mouse(const mouse* m) {
         return 0;
     }
 
+    if (m->middle.went_up) {
+        scroll_drag_end();
+    }
+
     ui.begin_widget({0, 0});
     ui.handle_mouse(m);
     ui.end_widget();
@@ -290,12 +315,24 @@ void empire_window::draw_empire_object(int object_index, const empire_object& ob
     }
 
     image_id = image_id_remap(image_id);
-    const vec2i draw_pos = draw_offset + pos;
+    const float scale = map_scale();
+    const vec2i draw_pos = map_to_screen(pos);
 
     if (obj.type == EMPIRE_OBJECT_CITY) {
-        const image_t* img = ui::eimage(image_id, draw_pos);
+        painter ctx = game.painter();
+        const image_t* img = image_get(image_id);
+        if (!img) {
+            return;
+        }
+        sprite spr;
+        spr.img = img;
+        ctx.draw(spr, draw_pos, COLOR_MASK_NONE, scale, scale);
         int empire_city_id = g_empire.get_city_for_object(object_index);
         const empire_city* city = g_empire.city(empire_city_id);
+        const vec2i scaled_img_size{
+            std::max(1, (int)std::lround(img->width * scale)),
+            std::max(1, (int)std::lround(img->height * scale))
+        };
 
         // draw siege icon if city is under siege
         if (city && city->is_sieged()) {
@@ -304,7 +341,7 @@ void empire_window::draw_empire_object(int object_index, const empire_object& ob
                 const image_t* siege_icon = image_get(siege_icon_desc);
                 if (siege_icon) {
                     vec2i siege_icon_pos
-                      = draw_pos + vec2i{img->width / 2 - siege_icon->width / 2, -siege_icon->height - 5};
+                      = draw_pos + vec2i{scaled_img_size.x / 2 - siege_icon->width / 2, -siege_icon->height - 5};
                     ui::eimage(siege_icon_desc, siege_icon_pos);
                 }
             }
@@ -314,7 +351,7 @@ void empire_window::draw_empire_object(int object_index, const empire_object& ob
         draw_trade_route(city, object_index, false);
 
         const int letter_height = font_definition_for(FONT_SMALL_PLAIN)->line_height;
-        vec2i text_pos = draw_offset + pos + vec2i{img->width, (img->height - letter_height) / 2};
+        vec2i text_pos = draw_pos + vec2i{scaled_img_size.x, (scaled_img_size.y - letter_height) / 2};
 
         tooltip_text = city->name_str;
 
@@ -341,7 +378,7 @@ void empire_window::draw_empire_object(int object_index, const empire_object& ob
 
     } else if (obj.type == EMPIRE_OBJECT_TEXT) {
         const full_empire_object* full = g_empire.get_full_object(object_index);
-        vec2i text_pos = draw_offset + pos;
+        vec2i text_pos = map_to_screen(pos);
 
         tooltip_text = ui::str(196, full->city_name_id);
         ui::label_colored(tooltip_text, text_pos - vec2i{5, 0}, FONT_SMALL_PLAIN, COLOR_FONT_SHITTY_BROWN, 100);
@@ -374,35 +411,70 @@ void empire_window::draw_empire_object(int object_index, const empire_object& ob
     }
 
     {
-        const image_t* img = ui::eimage(image_id, draw_pos);
-        if (last_mouse_pos.x > draw_pos.x && last_mouse_pos.y > draw_pos.y && last_mouse_pos.x < draw_pos.x + img->width
-            && last_mouse_pos.y < draw_pos.y + img->height) {
+        painter ctx = game.painter();
+        const image_t* img = image_get(image_id);
+        if (!img) {
+            return;
+        }
+        sprite spr;
+        spr.img = img;
+        ctx.draw(spr, draw_pos, COLOR_MASK_NONE, scale, scale);
+        const vec2i scaled_img_size{
+            std::max(1, (int)std::lround(img->width * scale)),
+            std::max(1, (int)std::lround(img->height * scale))
+        };
+        if (last_mouse_pos.x > draw_pos.x && last_mouse_pos.y > draw_pos.y && last_mouse_pos.x < draw_pos.x + scaled_img_size.x
+            && last_mouse_pos.y < draw_pos.y + scaled_img_size.y) {
             hovered_object_tooltip = tooltip_text;
         }
 
         if (img && img->animation.speed_id) {
             int new_animation = g_empire.update_animation(object_index, obj, image_id);
-            ui::eimage(image_id + new_animation, draw_pos + img->animation.sprite_offset);
+            const image_t* anim_img = image_get(image_id + new_animation);
+            if (anim_img) {
+                const vec2i anim_offset{
+                    (int)std::lround(img->animation.sprite_offset.x * scale),
+                    (int)std::lround(img->animation.sprite_offset.y * scale)
+                };
+                sprite spr_anim;
+                spr_anim.img = anim_img;
+                ctx.draw(spr_anim, draw_pos + anim_offset, COLOR_MASK_NONE, scale, scale);
+            }
         }
     }
 }
 
 void empire_window::draw_map() {
-    graphics_set_clip_rectangle(min_pos + start_pos, vec2i{max_pos - min_pos} - finish_pos);
+    const vec2i clip_origin = map_clip_origin();
+    const vec2i pixel_view = map_area_size_pixels();
+    const vec2i map_view = map_viewport_size();
+    const float scale = map_scale();
 
-    g_empire_map.set_viewport(max_pos - min_pos - finish_pos);
+    graphics_set_clip_rectangle(clip_origin, pixel_view);
 
-    draw_offset = min_pos + start_pos;
-    draw_offset = g_empire_map.adjust_scroll(draw_offset);
+    g_empire_map.set_viewport(map_view);
+
+    draw_offset = map_draw_origin();
     hovered_object_tooltip = "";
     deffer_city_route_id = -1;
 
-    ui::eimage(image, draw_offset);
+    painter ctx = game.painter();
+    if (const image_t* map_img = image_get(image)) {
+        sprite spr;
+        spr.img = map_img;
+        ctx.draw(spr, draw_offset, COLOR_MASK_NONE, scale, scale);
+    }
 
     g_empire.foreach_object(
       [this](int object_index, const empire_object& obj) { draw_empire_object(object_index, obj); });
 
-    scenario_invasion_foreach_warning([&](vec2i pos, int image_id) { ui::eimage(image_id, draw_offset + pos); });
+    scenario_invasion_foreach_warning([&](vec2i pos, int image_id) {
+        if (const image_t* warning_img = image_get(image_id)) {
+            sprite spr;
+            spr.img = warning_img;
+            ctx.draw(spr, map_to_screen(pos), COLOR_MASK_NONE, scale, scale);
+        }
+    });
 
     for (auto& trader : g_empire_traders.traders) {
         if (!trader.is_active) {
@@ -522,3 +594,61 @@ void __empire_window_set_map_bounds(int min_x, int min_y, int max_x, int max_y) 
     g_empire_window.max_pos = {max_x, max_y};
 }
 ANK_FUNCTION_4(__empire_window_set_map_bounds)
+
+vec2i empire_window::map_clip_origin() const {
+    return min_pos + start_pos;
+}
+
+vec2i empire_window::map_area_size_pixels() const {
+    return {
+        std::max(1, max_pos.x - min_pos.x - finish_pos.x),
+        std::max(1, max_pos.y - min_pos.y - finish_pos.y)
+    };
+}
+
+float empire_window::map_scale() const {
+    const vec2i size = map_area_size_pixels();
+    const float scale_x = size.x / static_cast<float>(EMPIRE_MAP_SIZE_PX.x);
+    const float scale_y = size.y / static_cast<float>(EMPIRE_MAP_SIZE_PX.y);
+    return std::max(scale_x, scale_y);
+}
+
+vec2i empire_window::map_viewport_size() const {
+    const vec2i pixel_size = map_area_size_pixels();
+    const float scale = map_scale();
+    return {
+        std::min(EMPIRE_MAP_SIZE_PX.x, std::max(1, (int)std::lround(pixel_size.x / std::max(0.001f, scale)))),
+        std::min(EMPIRE_MAP_SIZE_PX.y, std::max(1, (int)std::lround(pixel_size.y / std::max(0.001f, scale))))
+    };
+}
+
+vec2i empire_window::map_draw_origin() const {
+    const vec2i scroll = g_empire_map.get_scroll();
+    const float scale = map_scale();
+    return map_base_origin() - vec2i{
+        (int)std::lround(scroll.x * scale),
+        (int)std::lround(scroll.y * scale)
+    };
+}
+
+vec2i empire_window::map_base_origin() const {
+    const vec2i clip_origin = map_clip_origin();
+    const vec2i clip_size = map_area_size_pixels();
+    const float scale = map_scale();
+    const vec2i scaled_map_size{
+        std::max(1, (int)std::lround(EMPIRE_MAP_SIZE_PX.x * scale)),
+        std::max(1, (int)std::lround(EMPIRE_MAP_SIZE_PX.y * scale))
+    };
+    return clip_origin + vec2i{
+        std::max(0, (clip_size.x - scaled_map_size.x) / 2),
+        std::max(0, (clip_size.y - scaled_map_size.y) / 2)
+    };
+}
+
+vec2i empire_window::map_to_screen(vec2i map_pos) const {
+    const float scale = map_scale();
+    return map_draw_origin() + vec2i{
+        (int)std::lround(map_pos.x * scale),
+        (int)std::lround(map_pos.y * scale)
+    };
+}

--- a/src/window/window_empire.cpp
+++ b/src/window/window_empire.cpp
@@ -41,6 +41,14 @@ uint16_t empire_images_remap[32000] = {0};
 
 static const vec2i EMPIRE_MAP_SIZE_PX{1200, 1600};
 
+static int consume_scroll_remainder(float& remainder) {
+    const int step = (remainder >= 0.f)
+      ? (int)std::floor(remainder)
+      : (int)std::ceil(remainder);
+    remainder -= step;
+    return step;
+}
+
 using empire_object_tokens_t = token_holder<e_empire_object, EMPIRE_OBJECT_ORNAMENT, EMPIRE_OBJECT_COUNT>;
 const empire_object_tokens_t ANK_CONFIG_ENUM(empire_object_tokens);
 
@@ -118,6 +126,8 @@ ANK_REGISTER_STRUCT_WRITER(empire_window_object_info_enemy_army, distant_battle_
 void empire_window::init() {
     int selected_object = g_empire_map.selected_object();
     g_empire_map.selected_city = selected_object ? g_empire.get_city_for_object(selected_object - 1) : 0;
+    scroll_remainder_x = 0.f;
+    scroll_remainder_y = 0.f;
 
     ui.begin_widget(pos);
     ui.event(empire_window_init_event{pos}, get_section(), "init");
@@ -241,10 +251,15 @@ int empire_window::ui_handle_mouse(const mouse* m) {
     last_mouse_pos = {m->x, m->y};
     if (scroll_get_delta(m, &position, SCROLL_TYPE_EMPIRE)) {
         const float scale = map_scale();
-        g_empire_map.scroll_map({
-            (int)std::lround(position.x / std::max(0.001f, scale)),
-            (int)std::lround(position.y / std::max(0.001f, scale))
-        });
+        scroll_remainder_x += position.x / std::max(0.001f, scale);
+        scroll_remainder_y += position.y / std::max(0.001f, scale);
+        const vec2i map_delta{
+            consume_scroll_remainder(scroll_remainder_x),
+            consume_scroll_remainder(scroll_remainder_y)
+        };
+        if (map_delta.x || map_delta.y) {
+            g_empire_map.scroll_map(map_delta);
+        }
     }
 
     if (!!game_features::gameopt_middle_mouse_camera_pan
@@ -377,6 +392,27 @@ void empire_window::draw_empire_object(int object_index, const empire_object& ob
             vec2i siege_text_pos = text_pos + vec2i{0, letter_height + 2};
             ui::label_colored("under siege", siege_text_pos, FONT_SMALL_PLAIN, COLOR_FONT_RED, obj.width);
         }
+
+        if (last_mouse_pos.x > draw_pos.x && last_mouse_pos.y > draw_pos.y
+            && last_mouse_pos.x < draw_pos.x + scaled_img_size.x
+            && last_mouse_pos.y < draw_pos.y + scaled_img_size.y) {
+            hovered_object_tooltip = tooltip_text;
+        }
+
+        if (img->animation.speed_id) {
+            int new_animation = g_empire.update_animation(object_index, obj, image_id);
+            const image_t* anim_img = image_get(image_id + new_animation);
+            if (anim_img) {
+                const vec2i anim_offset{
+                    (int)std::lround(img->animation.sprite_offset.x * scale),
+                    (int)std::lround(img->animation.sprite_offset.y * scale)
+                };
+                sprite spr_anim;
+                spr_anim.img = anim_img;
+                ctx.draw(spr_anim, draw_pos + anim_offset, COLOR_MASK_NONE, scale, scale);
+            }
+        }
+        return;
 
     } else if (obj.type == EMPIRE_OBJECT_TEXT) {
         const full_empire_object* full = g_empire.get_full_object(object_index);

--- a/src/window/window_empire.cpp
+++ b/src/window/window_empire.cpp
@@ -78,9 +78,10 @@ struct empire_window_draw_trade_route {
 ANK_REGISTER_STRUCT_WRITER(empire_window_draw_trade_route, draw_offset, route_id, effect);
 
 struct empire_window_draw_trader {
+    vec2i draw_offset;
     int index;
 };
-ANK_REGISTER_STRUCT_WRITER(empire_window_draw_trader, index);
+ANK_REGISTER_STRUCT_WRITER(empire_window_draw_trader, draw_offset, index);
 
 struct empire_window_init_event {
     vec2i pos;
@@ -281,6 +282,7 @@ int empire_window::ui_handle_mouse(const mouse* m) {
             return 0;
         }
     } else if (input_go_back_requested(m, h)) {
+        scroll_drag_end();
         window_city_show();
         return 0;
     }
@@ -480,7 +482,7 @@ void empire_window::draw_map() {
         if (!trader.is_active) {
             continue;
         }
-        ui.event(empire_window_draw_trader{trader.id}, get_section(), __func__,
+        ui.event(empire_window_draw_trader{draw_offset, trader.id}, get_section(), __func__,
           empire_object_tokens.name(EMPIRE_OBJECT_TRADER));
     }
 

--- a/src/window/window_empire.h
+++ b/src/window/window_empire.h
@@ -16,6 +16,8 @@ struct empire_window : public autoconfig_window_t<empire_window> {
     vec2i min_pos, max_pos;
     vec2i draw_offset;
     vec2i last_mouse_pos;
+    float scroll_remainder_x = 0.f;
+    float scroll_remainder_y = 0.f;
     int is_scrolling;
     int finished_scroll;
     const int sell_res_group = 47;

--- a/src/window/window_empire.h
+++ b/src/window/window_empire.h
@@ -44,6 +44,13 @@ struct empire_window : public autoconfig_window_t<empire_window> {
     void draw_trade_route(const empire_city *city, int object_index, bool force);
     void draw_object_tooltip();
     void draw_tooltip(tooltip_context *c);
+    vec2i map_clip_origin() const;
+    vec2i map_area_size_pixels() const;
+    vec2i map_viewport_size() const;
+    vec2i map_base_origin() const;
+    vec2i map_draw_origin() const;
+    float map_scale() const;
+    vec2i map_to_screen(vec2i map_pos) const;
 };
 
 


### PR DESCRIPTION
## Summary
- make the empire/world map scale responsively while preserving aspect ratio
- keep the city information panel aligned to the resized window layout
- fix city hit testing after the new map transform
- add middle-mouse panning support for the world map

## Why
The empire map used a mostly fixed layout, which caused stretching, clipped areas, and mismatched interaction zones when the game window size changed. This update keeps the map responsive without distorting the artwork and keeps interaction aligned with the rendered view.

## Validation
- built the `akhenaten` target successfully in `RelWithDebInfo`
- verified a clean PR-only build from the isolated `worldmap-responsive` worktree
