### PR TITLE
fix(missions): correct goal tooltip function name in missions 2, 3, 4

### DIFF
--- a/src/scripts/mission_2_perwadjyt.js
+++ b/src/scripts/mission_2_perwadjyt.js
@@ -45,7 +45,7 @@ function mission2_handle_population_cap(ev) {
     migration.set_population_cap("pottery_not_produced_population_cap", max_pop)
 }
 
-function mission2_update_goal(ev) {
+function mission2_get_goal_tooltip() {
 	if (!mission.figs_stored_handled) {
 		return "#mission2_store_figs"
 	}

--- a/src/scripts/mission_3_nekhen.js
+++ b/src/scripts/mission_3_nekhen.js
@@ -39,7 +39,7 @@ mission3 {
 	}
 }
 
-function mission3_update_goal() {
+function mission3_get_goal_tooltip() {
 	if (!mission.modest_houses_reached) {
 		return "#reach_modest_houses_number"
 	}

--- a/src/scripts/mission_4_mennefer.js
+++ b/src/scripts/mission_4_mennefer.js
@@ -63,7 +63,7 @@ mission4 {
 	}
 }
 
-function mission4_update_goal() {
+function mission4_get_goal_tooltip() {
 	if (!mission.spacious_apartment_built) {
 		return "#tutorial_goal_education"
 	}


### PR DESCRIPTION
## Summary

- Missions 2, 3, and 4 each assign `mission*_get_goal_tooltip` to `city.goal_tooltip` in their `on_start` handler, but the function is defined as `mission*_update_goal`. Loading any of those missions and opening the briefing throws a `ReferenceError` and aborts `mission*_on_start`:

  ```
  !!! ReferenceError: 'mission2_get_goal_tooltip' is not defined
  !!!     at mission2_on_start (mission_2_perwadjyt.js:96)
  ```

- Renames the function in each of the three scripts to match the assignment, consistent with missions 0 and 1 which already use `*_get_goal_tooltip`.
- Also drops the unused `ev` parameter from the renamed mission 2 function (`city.goal_tooltip` is invoked with no arguments per `ui_mission_briefing_window.js:82` and `city.js:185`).

## Test plan

- [ ] Start mission 2, open the mission briefing — no `ReferenceError`, goal tooltip text appears.
- [ ] Repeat for mission 3 and mission 4.
- [ ] Confirm missions 0 and 1 (untouched) still load and show their goal tooltips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)