### PR TITLE
fix(monuments): keep bricklayer slot from being wiped each month

### DIFF
--- a/src/building/monument_mastaba.cpp
+++ b/src/building/monument_mastaba.cpp
@@ -749,8 +749,8 @@ void building_mastaba::update_month() {
 
     auto &monumentd = runtime_data();
     for (uint16_t &w_id : monumentd.workers) {
-        auto worker = figure_get<figure_worker>(w_id);
-        if (!worker || worker->is_alive() || worker->destination() != &base) {
+        figure* f = figure_get(w_id);
+        if (!f || !f->is_alive() || f->destination() != &base) {
             w_id = 0;
         }
     }

--- a/src/building/monument_pyramid.cpp
+++ b/src/building/monument_pyramid.cpp
@@ -1095,8 +1095,8 @@ void building_stepped_pyramid::update_month() {
 
     auto &monumentd = runtime_data();
     for (uint16_t &w_id : monumentd.workers) {
-        auto worker = figure_get<figure_worker>(w_id);
-        if (!worker || worker->is_alive() || worker->destination() != &base) {
+        figure* f = figure_get(w_id);
+        if (!f || !f->is_alive() || f->destination() != &base) {
             w_id = 0;
         }
     }


### PR DESCRIPTION
Mastaba/pyramid stuck at `1/5` workers on phase 3+ even with multiple bricklayer's guilds nearby and idle workforce.

### Cause

Commit `ac95a8eac1` ("Fix bricklayers guild logic to match original Pharaoh 1999 behavior", 2025-11-17) made `building_bricklayers_guild::spawn_figure` register the spawned bricklayer into `monument->workers[]` via `add_workers(f->id)`. But `update_month` was not updated: it casts each slot id to `figure_worker`, and `figure_bricklayer` does not inherit `figure_worker`, so the cast returns `nullptr` → slot is wiped every month. The bricklayer's guild then refuses to spawn a replacement until its existing bricklayer dies (`get_figures_number(FIGURE_BRICKLAYER) >= max_workers`), so the slot sits at 0/N most of the time.

The same line also had an inverted `is_alive()` check that wiped alive figures and kept dead ones — applies to phase <3 work_camp laborers as well.

### Fix

Drop the obsolete `figure_worker` cast and fix the boolean. Restores the pre-refactor logic that matched original Pharaoh: keep the slot iff the figure is alive and still destined for this monument — regardless of figure subtype.

```cpp
figure* f = figure_get(w_id);
if (!f || !f->is_alive() || f->destination() != &base) {
    w_id = 0;
}
```

### Scope

- 4 lines total (`monument_mastaba.cpp` + `monument_pyramid.cpp`), `update_month` slot-keep check only.
- No gameplay parameter changes (slot count, `max_workers`, spawn timers, `needs_bricklayers` — all unchanged).
- No new strings / bindings / UI changes.

### Verification

Mission 6 (Behdet), small mastaba phase 3, two bricklayer's guilds in radius:
- Before: slot oscillates 0/5 ↔ 2/5 on month tick, brick delivery extremely slow.
- After: slot stably reflects active bricklayers in field (1 guild = 1 slot, 5 guilds → 5/5).