### PR TITLE
fix(monuments): need_bricklayers must hold for any phase that needs bricks

### DIFF
--- a/src/building/monuments.cpp
+++ b/src/building/monuments.cpp
@@ -529,7 +529,7 @@ bool building_monument::need_bricklayers() {
         works_bricklayers += (f && f->type == FIGURE_BRICKLAYER) ? 1 : 0;
     }
 
-    return (phase >= 2 && phase <= 5 && works_bricklayers < needs_bricklayers(d.phase));
+    return (needs_resource(RESOURCE_BRICKS, phase) > 0 && works_bricklayers < needs_bricklayers(phase));
 }
 
 bool building_monument::is_unfinished() const {


### PR DESCRIPTION
Small/medium mastaba freezes at phase 6: all bricks/clay delivered (e.g. 1600/1600 + 800/800 for small), worker slot stays at 0/5, no bricklayer ever shows up. Same on phase 7. Monument never finishes.

### Cause

Regression introduced by commit \`ca05968f27\` (2024-01-07, _\"monuments: correct draw mastaba for levels 2-8\"_). That commit expanded the small-mastaba phase config from 6 phases (brick phases 2-5, finalize at 6) to **9 phases (brick phases 2-7, finalize at 8)** to match the rendering for **levels 2-8** as the title states. But the existing gate in `need_bricklayers()` was not updated:

\`src/building/monuments.cpp:532\`:

\`\`\`cpp
return (phase >= 2 && phase <= 5 && works_bricklayers < needs_bricklayers(d.phase));
\`\`\`

The hard cap `phase <= 5` was correct for the original 6-phase config but was left in place when phases 6 and 7 were added.

So at phase 6 / 7 the bricks arrive (storage yard → cart-pusher) but `need_bricklayers()` returns `false` due to the stale cap. `building_bricklayers_guild::spawn_figure()` consequently sees no monument needing bricklayers and spawns nothing. Tiles stay at progress=2 (deliverable) and never reach 200 (built). Phase doesn't advance — the mastaba is stuck forever.

### Fix

Replace the now-incorrect magic-number cap with a content-aware check — does the monument actually need bricks on this phase?

\`\`\`cpp
return (needs_resource(RESOURCE_BRICKS, phase) > 0 && works_bricklayers < needs_bricklayers(phase));
\`\`\`

This adapts to whatever phase config is registered, so future config changes don't reintroduce the same drift. Aligns with the explicit intent in the original phase-expansion commit (\"levels 2-8\").

Side benefit: pyramid uses STONE/TIMBER, not bricks. Before this fix `need_bricklayers()` returned true for pyramid phases 2-5 (cap was the only gate), causing bricklayer guilds to send bricklayers to a stone monument. After the fix `needs_resource(BRICKS, phase) > 0` is false for pyramid → bricklayer guilds correctly ignore it.

### Scope

- 1 line in \`src/building/monuments.cpp\`.
- No gameplay parameter changes (slot count, max_workers, spawn timers — all unchanged).
- Just \`need_bricklayers\` logic — gate by \"this phase actually requires bricks\" instead of a stale phase number.

### Verification

Mission 6 (Behdet), small mastaba, four bricklayer's guilds in radius:
- Before: monument freezes at phase 6, slot 0/5, no bricklayers spawn — same well-documented bug players hit on every mastaba run.
- After (combined with #445): phases 6 → 7 → 8 (finished) all complete; first successful end-to-end mastaba build on this branch.

### Related

- #445 (slot wipe on month tick) is required for phases 2-5 to actually progress; this PR fixes the gate that prevents phases 6-7 from being requested at all. Independent fixes — neither subsumes the other.