### PR TITLE
fix(monuments): make yearly rating tick actually fire

### DIFF
--- a/src/scripts/city_monuments.js
+++ b/src/scripts/city_monuments.js
@@ -1,7 +1,10 @@
 log_info("akhenaten: city_monuments.js started")
 
-[es=(city_monuments, advance_year)]
-function city_update_yearly_monument_rating() {
+[es=event_advance_month]
+function city_update_yearly_monument_rating(ev) {
+	if (ev.month != 0) {
+		return
+	}
 	var y = city.rating.monument_years_of_monument
 	var ncr = city.rating.monument_num_criminals
 	var nri = city.rating.monument_num_rioters

--- a/src/scripts/city_monuments.js
+++ b/src/scripts/city_monuments.js
@@ -38,5 +38,6 @@ function city_update_yearly_monument_rating() {
 		new_m = monument_ratings_cap
 	}
 
+	var expl = city.rating.get_monument_explanation()
 	__city_ratings_apply_monument_yearly(new_m, new_years, expl)
 }


### PR DESCRIPTION
Monument rating in the Ratings Overseer stays at **0** for the entire game and never grows even after many years. The yearly tick formula in \`src/scripts/city_monuments.js\` exists and looks correct, but is dead in two ways.

### Cause #1 — subscription syntax doesn't register

\`\`\`js
[es=(city_monuments, advance_year)]
function city_update_yearly_monument_rating() { ... }
\`\`\`

The tuple form \`(namespace, event)\` is not parsed as a registerable subscription by Akhenaten's JS handler loader. Verified empirically in \`akhenaten-log.txt\` — many \"JS: Registered handler '…' for event '…'\" lines appear at startup, but **none** for \`city_update_yearly_monument_rating\`. The function is loaded into the VM but never wired to any event, so it never executes.

### Cause #2 — undefined \`expl\` would crash the function on the first execution

\`\`\`js
__city_ratings_apply_monument_yearly(new_m, new_years, expl)
\`\`\`

\`expl\` is never declared. mujs throws \`ReferenceError\` on first access, the function aborts and \`__city_ratings_apply_monument_yearly\` never gets called. (Hidden behind cause #1, but would have surfaced as soon as #1 was fixed.)

### Fix

Switch the subscription to \`event_advance_month\` with a \`month == 0\` guard — the same pattern used by \`mission_6_behdet.js\` and friends. \`event_advance_month\` is emitted by \`game.cpp:192\` **after** \`game_t::advance_year()\` runs (line 184), so the firing point is identical to the originally intended yearly tick.

Declare \`expl\` via the existing helper \`city.rating.get_monument_explanation()\` (also used in \`ui_advisor_ratings.js:88\`).

\`\`\`js
[es=event_advance_month]
function city_update_yearly_monument_rating(ev) {
    if (ev.month != 0) {
        return
    }
    // ... existing formula unchanged
    var expl = city.rating.get_monument_explanation()
    __city_ratings_apply_monument_yearly(new_m, new_years, expl)
}
\`\`\`

### Scope

- 1 file (\`src/scripts/city_monuments.js\`), 2 small edits.
- No formula / cap / event-payload changes.
- Yearly tick formula (originally written by the prior author) is unchanged.

### Verification

Mission 6 (Behdet), live save where Monument rating had been 0 for 21+ in-game years:
- **Before:** rating 0 forever; \`MONUMENT_TICK\` log lines never appear.
- **After:** rating climbs +2/year for the first two stable years and +5/year afterwards as the formula dictates; user playthrough went 0 → 30 within ~7 in-game years (cap = 50 at population 2500).

Empirical verification in \`akhenaten-log.txt\`: with debug logging temporarily added, \`MONUMENT_TICK\` lines appear once per game year.