### PR TITLE
fix(advisor): correct textid bases for all four ratings (Pharaoh group 53)

### DIFF
--- a/src/scripts/ui_advisor_ratings.js
+++ b/src/scripts/ui_advisor_ratings.js
@@ -88,7 +88,7 @@ function advisor_ratings_select_monument(window) {
 	var expl = city.rating.get_monument_explanation()
 	advisor_ratings_select_button(window, window.rating_monument)
 	window.advice_header.text = __loc(53, 3)
-	window.advice_text.text = (city.rating.monument <= 90) ? __loc(53, 41 + expl) : __loc(53, 52)
+	window.advice_text.text = (city.rating.monument <= 90) ? __loc(53, 55 + expl) : __loc(53, 67)
 }
 
 [es=(advisor_ratings_window, select_kingdom)]

--- a/src/scripts/ui_advisor_ratings.js
+++ b/src/scripts/ui_advisor_ratings.js
@@ -72,7 +72,7 @@ function advisor_ratings_select_culture(window) {
 	var expl = city.rating.get_culture_explanation()
 	window.advice_header.text = __loc(53, 1)
 	advisor_ratings_select_button(window, window.rating_culture)
-	window.advice_text.text = (city.rating.culture <= 90) ? __loc(53, 9 + expl) : __loc(53, 50)
+	window.advice_text.text = (city.rating.culture <= 90) ? __loc(53, 9 + expl) : __loc(53, 65)
 }
 
 [es=(advisor_ratings_window, select_prosperity)]
@@ -80,7 +80,7 @@ function advisor_ratings_select_prosperity(window) {
 	var expl = city.rating.get_prosperity_explanation()
 	advisor_ratings_select_button(window, window.rating_prosperity)
 	window.advice_header.text = __loc(53, 2)
-	window.advice_text.text = (city.rating.prosperity <= 90) ? __loc(53, 16 + expl) : __loc(53, 51)
+	window.advice_text.text = (city.rating.prosperity <= 90) ? __loc(53, 23 + expl) : __loc(53, 66)
 }
 
 [es=(advisor_ratings_window, select_monument)]
@@ -96,7 +96,7 @@ function advisor_ratings_select_kingdom(window) {
 	var expl = city.rating.get_kingdom_explanation()
 	advisor_ratings_select_button(window, window.rating_kingdom)
 	window.advice_header.text = __loc(53, 4)
-	window.advice_text.text = (city.rating.kingdom <= 90) ? __loc(53, 27 + expl) : __loc(53, 53)
+	window.advice_text.text = (city.rating.kingdom <= 90) ? __loc(53, 32 + expl) : __loc(53, 68)
 }
 
 [es=advisor_window]


### PR DESCRIPTION
The Ratings Overseer shows wrong advisor texts under each rating section: Monument shows Kingdom-rating salary advice (\"Your salary is too high...\"), Prosperity shows Culture/health/rating-change snippets at low \`expl\`, Kingdom shows Prosperity texts. At max rating (>90) all four ratings show \"unused - was peace rating reportN\" leftovers from Caesar 3.

### Cause

\`src/scripts/ui_advisor_ratings.js\` calls \`__loc(53, base + expl)\` per rating, but the bases (and max-rating ids) don't match Pharaoh's group-53 layout. They're shifted Caesar 3 holdovers.

Verified against \`Pharaoh_Text.txt\` from a local Pharaoh 1999 install, group 53:

| ids | section |
|---|---|
| 0-8 | headers |
| 9-19 | Culture advice |
| 20-22 | rating change (rising/falling/stagnant) |
| 23-31 | Prosperity advice |
| 32-45 | Kingdom advice |
| 46-54 | unused (peace rating remnants from C3) |
| 55-64 | Monument advice (10× generic \"Remember to instruct OoM…\") |
| 65 | Culture max (\"This city is more Cultured than any in Egypt!\") |
| 66 | Prosperity max (\"The amazing Prosperity of this city is the talk of Egypt!\") |
| 67 | Monument max (\"This city has the most magnificent Monuments in all Egypt!\") |
| 68 | Kingdom max (\"Your Kingdom is the best rated in all Egypt!\") |

### Fix

Five constant changes across the four \`select_*\` handlers, plus Monument's existing one:

| rating | base before | base after | max before | max after |
|---|---|---|---|---|
| Culture | 9 ✓ | 9 | 50 | **65** |
| Prosperity | 16 | **23** | 51 | **66** |
| Monument | 41 | **55** | 52 | **67** |
| Kingdom | 27 | **32** | 53 | **68** |

The new ids are taken directly from the original Pharaoh group-53 layout — texts exist verbatim in \`localization_base_en.js\` / \`localization_base_ru.js\` already; this PR only changes call-site indices.

### Verification

Cross-checked each id against \`~/Documents/PharaohGame/Base_Install/Pharaoh_Text.txt\`:

- 41 = \"Your salary is too high for your current standing. You would do well to reduce it.\" — Kingdom advice (was wrongly under Monument)
- 55-64 = 10× \"Remember to instruct the Overseer of Monuments…\" — Monument advice
- 65 = \"This city is more Cultured than any in Egypt!\" — Culture max
- 66 = \"The amazing Prosperity of this city is the talk of Egypt!\" — Prosperity max
- 67 = \"This city has the most magnificent Monuments in all Egypt!\" — Monument max
- 68 = \"Your Kingdom is the best rated in all Egypt!\" — Kingdom max

Tested in-game (Behdet, mission 6): clicking Monument now shows the correct \"Remember to instruct...\" text instead of the salary one.

### Caveat

\`get_prosperity_explanation()\` can return \`9\` (catch-all). With the corrected base 23, that maps to id 32 = first Kingdom advice text — out of Prosperity's 9-entry range (23-31). This was also broken before (mapped to id 25 = Prosperity unemployment advice, less obviously wrong). Fixing the explanation function's reason set is out of scope for this textid-only PR — happy to follow up separately.

### Scope

- 5 lines in \`src/scripts/ui_advisor_ratings.js\`.
- No new strings / no localization changes / no C++ changes.
- Existing texts in groups already in \`localization_base_*.js\`; only call-site bases change.