### PR TITLE
Improve advisor window background modes and responsive centering

### DIFF
--- a/src/graphics/elements/ui.cpp
+++ b/src/graphics/elements/ui.cpp
@@ -29,11 +29,14 @@
 #include "input/mouse.h"
 #include "graphics/screen.h"
 #include "window/message_dialog.h"
+#include "platform/renderer.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <stack>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 
 using namespace ui::opt;
@@ -1183,10 +1186,237 @@ void ui::eimg::image(int image) {
     img_desc.offset = image;
 }
 
+namespace {
+struct background_draw_layout {
+    vec2i pos;
+    float scale = 1.f;
+};
+
+struct blurred_background_cache_entry {
+    SDL_Texture* texture = nullptr;
+    vec2i size = {0, 0};
+};
+
+uint64_t blurred_background_cache_key(const image_t* img, int radius, vec2i target_size) {
+    uint64_t key = (uint64_t)(uintptr_t)img;
+    key ^= ((uint64_t)(uint16_t)radius << 48);
+    key ^= ((uint64_t)(uint16_t)target_size.x << 16);
+    key ^= (uint64_t)(uint16_t)target_size.y;
+    return key;
+}
+
+std::vector<float> gaussian_kernel(int radius) {
+    std::vector<float> kernel(radius * 2 + 1, 0.0f);
+    if (radius <= 0) {
+        kernel[0] = 1.0f;
+        return kernel;
+    }
+
+    const float sigma = std::max(1.0f, radius / 2.5f);
+    const float two_sigma_sq = 2.0f * sigma * sigma;
+    float total = 0.0f;
+    for (int i = -radius; i <= radius; ++i) {
+        const float value = std::exp(-(float)(i * i) / two_sigma_sq);
+        kernel[i + radius] = value;
+        total += value;
+    }
+
+    for (float& value : kernel) {
+        value /= total;
+    }
+    return kernel;
+}
+
+void blur_pass_horizontal(const std::vector<color>& src, std::vector<color>& dst, int width, int height,
+  const std::vector<float>& kernel, int radius) {
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            float a = 0.0f, r = 0.0f, g = 0.0f, b = 0.0f;
+            for (int k = -radius; k <= radius; ++k) {
+                const int sx = std::clamp(x + k, 0, width - 1);
+                const color c = src[y * width + sx];
+                const float w = kernel[k + radius];
+                a += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_ALPHA);
+                r += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_RED);
+                g += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_GREEN);
+                b += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_BLUE);
+            }
+
+            dst[y * width + x] = ((color)std::clamp((int)std::lround(a), 0, 255) << COLOR_BITSHIFT_ALPHA)
+              | ((color)std::clamp((int)std::lround(r), 0, 255) << COLOR_BITSHIFT_RED)
+              | ((color)std::clamp((int)std::lround(g), 0, 255) << COLOR_BITSHIFT_GREEN)
+              | ((color)std::clamp((int)std::lround(b), 0, 255) << COLOR_BITSHIFT_BLUE);
+        }
+    }
+}
+
+void blur_pass_vertical(const std::vector<color>& src, std::vector<color>& dst, int width, int height,
+  const std::vector<float>& kernel, int radius) {
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            float a = 0.0f, r = 0.0f, g = 0.0f, b = 0.0f;
+            for (int k = -radius; k <= radius; ++k) {
+                const int sy = std::clamp(y + k, 0, height - 1);
+                const color c = src[sy * width + x];
+                const float w = kernel[k + radius];
+                a += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_ALPHA);
+                r += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_RED);
+                g += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_GREEN);
+                b += w * COLOR_COMPONENT(c, COLOR_BITSHIFT_BLUE);
+            }
+
+            dst[y * width + x] = ((color)std::clamp((int)std::lround(a), 0, 255) << COLOR_BITSHIFT_ALPHA)
+              | ((color)std::clamp((int)std::lround(r), 0, 255) << COLOR_BITSHIFT_RED)
+              | ((color)std::clamp((int)std::lround(g), 0, 255) << COLOR_BITSHIFT_GREEN)
+              | ((color)std::clamp((int)std::lround(b), 0, 255) << COLOR_BITSHIFT_BLUE);
+        }
+    }
+}
+
+SDL_Texture* get_blurred_background_texture(painter& ctx, const image_t* img, int radius, vec2i target_size,
+  vec2i target_pos, const background_draw_layout& cover_layout, vec2i& out_size) {
+    static std::unordered_map<uint64_t, blurred_background_cache_entry> cache;
+
+    out_size = target_size;
+    if (!img || radius <= 0) {
+        return nullptr;
+    }
+
+    const uint64_t key = blurred_background_cache_key(img, radius, target_size);
+    auto found = cache.find(key);
+    if (found != cache.end() && found->second.texture) {
+        out_size = found->second.size;
+        return found->second.texture;
+    }
+
+    ctx.draw_image(img, cover_layout.pos, COLOR_MASK_NONE, cover_layout.scale);
+
+    std::vector<color> source(target_size.x * target_size.y);
+    if (source.empty()) {
+        return nullptr;
+    }
+
+    if (!g_render.save_screen_buffer(ctx, source.data(), target_pos.x, target_pos.y, target_size.x, target_size.y,
+          target_size.x)) {
+        return nullptr;
+    }
+
+    std::vector<color> temp(source.size());
+    std::vector<color> blurred(source.size());
+    const std::vector<float> kernel = gaussian_kernel(radius);
+    blur_pass_horizontal(source, temp, target_size.x, target_size.y, kernel, radius);
+    blur_pass_vertical(temp, blurred, target_size.x, target_size.y, kernel, radius);
+
+    SDL_Texture* texture = g_render.create_texture_from_buffer(blurred.data(), target_size.x, target_size.y);
+    if (!texture) {
+        return nullptr;
+    }
+
+    cache[key] = {texture, target_size};
+    return texture;
+}
+
+vec2i background_target_size(const ui::ebackground& bg) {
+    vec2i target = bg.pxsize();
+    if (target.x <= 0) {
+        target.x = screen_width();
+    }
+    if (target.y <= 0) {
+        target.y = screen_height();
+    }
+    return target;
+}
+
+background_draw_layout background_calc_layout(const ui::ebackground& bg, const image_t* img, vec2i target_pos,
+  vec2i target_size, ui::ebackground::draw_mode mode) {
+    background_draw_layout layout;
+    if (!img) {
+        layout.pos = target_pos;
+        layout.scale = bg.scale;
+        return layout;
+    }
+
+    const float base_scale = bg.scale > 0.f ? bg.scale : 1.f;
+    const float base_width = img->width * base_scale;
+    const float base_height = img->height * base_scale;
+    const float scale_x = target_size.x / std::max(1.f, base_width);
+    const float scale_y = target_size.y / std::max(1.f, base_height);
+
+    float mode_scale = 1.f;
+    switch (mode) {
+    case ui::ebackground::draw_mode::cover:
+        mode_scale = std::max(scale_x, scale_y);
+        break;
+    case ui::ebackground::draw_mode::contain:
+        mode_scale = std::min(scale_x, scale_y);
+        break;
+    case ui::ebackground::draw_mode::original:
+    default:
+        mode_scale = 1.f;
+        break;
+    }
+
+    layout.scale = base_scale * mode_scale;
+    const int draw_width = (int)(img->width * layout.scale);
+    const int draw_height = (int)(img->height * layout.scale);
+    layout.pos = target_pos + vec2i{(target_size.x - draw_width) / 2, (target_size.y - draw_height) / 2};
+    return layout;
+}
+
+void draw_cover_blurred_backdrop(painter& ctx, const ui::ebackground& bg, const image_t* img, vec2i target_pos,
+  vec2i target_size) {
+    if (!img) {
+        return;
+    }
+
+    const background_draw_layout cover = background_calc_layout(bg, img, target_pos, target_size,
+      ui::ebackground::draw_mode::cover);
+    vec2i blurred_size;
+    SDL_Texture* blurred = get_blurred_background_texture(ctx, img, std::max(1, bg.backdrop_blur_radius), target_size,
+      target_pos, cover, blurred_size);
+    if (!blurred) {
+        return;
+    }
+
+    const color focus_mask = ((color)bg.backdrop_blur_alpha << COLOR_BITSHIFT_ALPHA) | 0x00ffffff;
+    ctx.draw(blurred, target_pos, {0, 0}, blurred_size, focus_mask, 1.f, 1.f, 0, ImgFlag_None, true);
+
+    if (bg.backdrop_shade_alpha > 0) {
+        const color shade = ((color)bg.backdrop_shade_alpha << COLOR_BITSHIFT_ALPHA);
+        graphics_fill_rect(target_pos, target_size, shade);
+    }
+}
+} // namespace
+
 void ui::ebackground::draw(UiFlags flags) {
     painter ctx = game.painter();
+    const image_t* img = image_get(img_desc.tid());
+    if (!img) {
+        return;
+    }
+
     scr_pos = pos;
-    ImageDraw::img_background(ctx, img_desc.tid(), 1.f, pos);
+
+    if (mode == draw_mode::original) {
+        if (backdrop_cover_blur) {
+            const vec2i target_pos = g_state.offset() + pos;
+            const vec2i target_size = background_target_size(*this);
+            draw_cover_blurred_backdrop(ctx, *this, img, target_pos, target_size);
+        }
+
+        ImageDraw::img_background(ctx, img_desc.tid(), scale, pos);
+        return;
+    }
+
+    scr_pos = g_state.offset() + pos;
+    const vec2i target_size = background_target_size(*this);
+
+    if (backdrop_cover_blur && mode != draw_mode::cover) {
+        draw_cover_blurred_backdrop(ctx, *this, img, scr_pos, target_size);
+    }
+
+    const background_draw_layout layout = background_calc_layout(*this, img, scr_pos, target_size, mode);
+    ctx.draw_image(img, layout.pos, COLOR_MASK_NONE, layout.scale);
 }
 
 void ui::ebackground::load(archive arch, element* parent, items& elems) {
@@ -1199,6 +1429,20 @@ void ui::ebackground::load(archive arch, element* parent, items& elems) {
     img_desc.id = arch.r_int("id");
     img_desc.offset = arch.r_int("offset");
     img_desc.path = arch.r_string("path");
+    const xstring mode_str = arch.r_string("mode");
+    const bool cover = arch.r_bool("cover", false);
+    const bool contain = arch.r_bool("contain", false);
+    if (mode_str == "cover" || cover) {
+        mode = draw_mode::cover;
+    } else if (mode_str == "contain" || contain) {
+        mode = draw_mode::contain;
+    } else {
+        mode = draw_mode::original;
+    }
+    backdrop_cover_blur = arch.r_bool("backdrop_cover_blur", false);
+    backdrop_blur_radius = arch.r_int("backdrop_blur_radius", 3);
+    backdrop_blur_alpha = (uint8_t)arch.r_int("backdrop_blur_alpha", 0x16);
+    backdrop_shade_alpha = (uint8_t)arch.r_int("backdrop_shade_alpha", 0x2c);
 }
 
 void ui::eborder::load(archive arch, element* parent, items& elems) {

--- a/src/graphics/elements/ui.h
+++ b/src/graphics/elements/ui.h
@@ -591,8 +591,19 @@ namespace ui {
     };
 
     struct ebackground : public element {
+        enum class draw_mode : uint8_t {
+            original = 0,
+            contain,
+            cover,
+        };
+
         image_desc img_desc;
         float scale = 1.f;
+        draw_mode mode = draw_mode::original;
+        bool backdrop_cover_blur = false;
+        int backdrop_blur_radius = 3;
+        uint8_t backdrop_blur_alpha = 0x16;
+        uint8_t backdrop_shade_alpha = 0x2c;
 
         virtual void draw(UiFlags flags) override;
         virtual void load(archive elem, element* parent, items& elems) override;

--- a/src/platform/screen.cpp
+++ b/src/platform/screen.cpp
@@ -15,6 +15,7 @@
 #include "platform/renderer.h"
 #include "platform/switch/switch.h"
 #include "platform/vita/vita.h"
+#include "window/autoconfig_window.h"
 #include "resource/icons.h"
 
 #include "SDL.h"
@@ -239,6 +240,7 @@ bool platform_screen_t::resize(int pixel_width, int pixel_height, int save) {
 
     if (platform_renderer_create_render_texture(logical_width, logical_height)) {
         g_screen.set_resolution(logical_width, logical_height);
+        autoconfig_window::refresh_all();
         return true;
     }
 

--- a/src/scripts/ui_advisor_chief.js
+++ b/src/scripts/ui_advisor_chief.js
@@ -496,3 +496,8 @@ function advisor_chief_window_on_init(window) {
 	advisor_chief_window_fill_report_rows(window)
 	advisors_toolbar_refresh(window, ADVISOR_CHIEF)
 }
+
+[es=(advisor_chief_window, ui_draw_foreground)]
+function advisor_chief_window_reflow(window) {
+	advisor_window_reflow(window)
+}

--- a/src/scripts/ui_advisor_education.js
+++ b/src/scripts/ui_advisor_education.js
@@ -138,3 +138,8 @@ function advisor_education_window_init(window) {
 
 	advisors_toolbar_refresh(window, ADVISOR_EDUCATION)
 }
+
+[es=(advisor_education_window, ui_draw_foreground)]
+function advisor_education_window_reflow(window) {
+	advisor_window_reflow(window)
+}

--- a/src/scripts/ui_advisor_entertainment.js
+++ b/src/scripts/ui_advisor_entertainment.js
@@ -123,3 +123,8 @@ function advisor_entertainment_window_init(window) {
 
 	advisors_toolbar_refresh(window, ADVISOR_ENTERTAINMENT)
 }
+
+[es=(advisor_entertainment_window, ui_draw_foreground)]
+function advisor_entertainment_window_reflow(window) {
+	advisor_window_reflow(window)
+}

--- a/src/scripts/ui_advisor_finance.js
+++ b/src/scripts/ui_advisor_finance.js
@@ -127,6 +127,7 @@ function advisor_financial_window_on_init(window) {
 
 [es=(advisor_financial_window, ui_draw_foreground)]
 function advisor_financial_window_on_draw(window) {
+    advisor_window_reflow(window)
     advisor_financial_window_update(window)
     advisor_financial_window_update_incomes(window)
     advisor_financial_window_update_expenses(window)

--- a/src/scripts/ui_advisor_health.js
+++ b/src/scripts/ui_advisor_health.js
@@ -116,3 +116,8 @@ function advisor_health_window_init(window) {
 
 	advisors_toolbar_refresh(window, ADVISOR_HEALTH)
 }
+
+[es=(advisor_health_window, ui_draw_foreground)]
+function advisor_health_window_reflow(window) {
+	advisor_window_reflow(window)
+}

--- a/src/scripts/ui_advisor_housing.js
+++ b/src/scripts/ui_advisor_housing.js
@@ -137,3 +137,8 @@ advisor_housing_window {
 		})
 	})
 }
+
+[es=(advisor_housing_window, ui_draw_foreground)]
+function advisor_housing_window_reflow(window) {
+	advisor_window_reflow(window)
+}

--- a/src/scripts/ui_advisor_imperial.js
+++ b/src/scripts/ui_advisor_imperial.js
@@ -209,6 +209,7 @@ function advisor_imperial_window_on_init(window) {
 
 [es=(advisor_imperial_window, ui_draw_foreground)]
 function advisor_imperial_window_draw(window) {
+    advisor_window_reflow(window)
     var totalVis = __imperial_visible_request_count()
     var showDistant = empire.has_distant_battle && empire.dispatched_army.state === 0
     var startReqIdx = showDistant ? 1 : 0

--- a/src/scripts/ui_advisor_labor.js
+++ b/src/scripts/ui_advisor_labor.js
@@ -71,6 +71,7 @@ function advisor_labors_window_init(window) {
 
 [es=(advisor_labors_window, ui_draw_foreground)]
 function advisor_labors_window_draw(window) {
+    advisor_window_reflow(window)
     var item_pos = {x:40, y:25}
     var items_area = window.items_area.screen_pos
     var item_image = {x:40, y:4}

--- a/src/scripts/ui_advisor_military.js
+++ b/src/scripts/ui_advisor_military.js
@@ -82,6 +82,7 @@ function advisor_military_window_init(window) {
 
 [es=(advisor_military_window, ui_draw_foreground)]
 function advisor_military_window_draw(window) {
+    advisor_window_reflow(window)
     if (city.num_forts > 0) {
         var exp_image = get_image("pharaoh_general/paneling_00537")
         var goto_legion_image = get_image("pharaoh_general/paneling_00531")

--- a/src/scripts/ui_advisor_monuments.js
+++ b/src/scripts/ui_advisor_monuments.js
@@ -74,6 +74,7 @@ function advisor_monuments_window_init(window) {
 
 [es=(advisor_monuments_window, ui_draw_foreground)]
 function advisor_monuments_window_draw(window) {
+    advisor_window_reflow(window)
     var n = __city_monuments_list_refresh()
     window.no_monuments.enabled = (n <= 0)
 

--- a/src/scripts/ui_advisor_population.js
+++ b/src/scripts/ui_advisor_population.js
@@ -78,6 +78,7 @@ function advisor_population_percent_in_workforce_value() {
 
 [es=(advisor_population_window, ui_draw_foreground)]
 function advisor_population_window_ui_draw_foreground(window) {
+	advisor_window_reflow(window)
 	var go = advisor_population_window.graph_order
 	if (advisor_population_window._info_text_graph_order === go) {
 		return

--- a/src/scripts/ui_advisor_ratings.js
+++ b/src/scripts/ui_advisor_ratings.js
@@ -148,3 +148,8 @@ function advisor_ratings_window_init(window) {
 
 	advisors_toolbar_refresh(window, ADVISOR_RATINGS)
 }
+
+[es=(advisor_ratings_window, ui_draw_foreground)]
+function advisor_ratings_window_reflow(window) {
+	advisor_window_reflow(window)
+}

--- a/src/scripts/ui_advisor_religion.js
+++ b/src/scripts/ui_advisor_religion.js
@@ -186,6 +186,11 @@ function advisor_religion_window_init(window) {
 	advisors_toolbar_refresh(window, ADVISOR_RELIGION)
 }
 
+[es=(advisor_religion_window, ui_draw_foreground)]
+function advisor_religion_window_reflow(window) {
+	advisor_window_reflow(window)
+}
+
 [es=(advisor_religion_window, draw_background)]
 function advisor_religion_window_draw_background(window) {
 	if (!advisor_religion_window.needs_sync) {

--- a/src/scripts/ui_advisor_trade.js
+++ b/src/scripts/ui_advisor_trade.js
@@ -127,3 +127,8 @@ function advisor_trade_window_init(window) {
     }
     advisors_toolbar_refresh(window, ADVISOR_TRADE)
 }
+
+[es=(advisor_trade_window, ui_draw_foreground)]
+function advisor_trade_window_reflow(window) {
+    advisor_window_reflow(window)
+}

--- a/src/scripts/ui_advisors_window.js
+++ b/src/scripts/ui_advisors_window.js
@@ -20,25 +20,66 @@ function advisor_autoconfig_section(advisor) {
     }
 }
 
+function advisor_window_supported_list() {
+    return [
+        ADVISOR_LABOR,
+        ADVISOR_MILITARY,
+        ADVISOR_IMPERIAL,
+        ADVISOR_RATINGS,
+        ADVISOR_TRADE,
+        ADVISOR_POPULATION,
+        ADVISOR_HEALTH,
+        ADVISOR_EDUCATION,
+        ADVISOR_ENTERTAINMENT,
+        ADVISOR_RELIGION,
+        ADVISOR_FINANCIAL,
+        ADVISOR_CHIEF,
+        ADVISOR_MONUMENTS,
+        ADVISOR_HOUSING
+    ]
+}
+
+function advisor_window_is_supported(advisor) {
+    return advisor_autoconfig_section(advisor) !== null
+}
+
+function advisor_window_is_available(advisor) {
+    return city.is_advisor_available(advisor) > 0
+}
+
 function window_advisors_show_advisor(advisor) {
+    if (!advisor_window_is_supported(advisor)) {
+        city.warnings.show("#not_available_in_this_assignment")
+        return 0
+    }
+
     var avail = city.is_advisor_available(advisor)
     if (avail === 0 || avail === -1) {
         city.warnings.show(avail === 0 ? "#not_available_in_this_assignment" : "#not_available_yet")
         return 0
     }
     window_advisors_prepare_opening()
-    game.last_advisor = advisor
-    var section = advisor_autoconfig_section(advisor)
-    if (!section) {
-        return 0
-    }
-    window_show_by_id(section)
+    __game_settings.last_advisor = advisor
+    window_advisors_show()
     return 1
 }
 
+var ADVISOR_BACKGROUND_MODE = "cover" // "cover", "contain", "original"
+var ADVISOR_BACKGROUND_BLURRED_BACKDROP = false
+
 advisor_window_base {
     ui {
-        advisors_backdrop : image({ pack:PACK_UNLOADED, id:11, pos:[sw(-1024)/2, sh(-768)/2] })
+        advisors_backdrop : background({
+            pack:PACK_UNLOADED,
+            id:11,
+            mode:ADVISOR_BACKGROUND_MODE,
+            backdrop_cover_blur:ADVISOR_BACKGROUND_BLURRED_BACKDROP,
+            backdrop_blur_radius:12,
+            backdrop_blur_alpha:255,
+            backdrop_shade_alpha:112,
+            fill_width:true,
+            fill_height:true
+        })
         advisors_strip    : image({ pack:PACK_GENERAL, id:160, pos:[sw(-640)/2, sh(400)/2] })
         labor_btn         : image_button({ pos:[sw(-640)/2 + 12, sh(418)/2], size:[33, 32], pack:PACK_GENERAL, id:159, offset:0, tooltip:[68, 71], onclick: show_advisor_window(ADVISOR_LABOR) })
         military_btn      : image_button({ pos:[sw(-640)/2 + 52, sh(418)/2], size:[39, 32], pack:PACK_GENERAL, id:159, offset:4, tooltip:[68, 72], onclick: show_advisor_window(ADVISOR_MILITARY) })
@@ -59,33 +100,72 @@ advisor_window_base {
 
 function show_advisor_window(advisor) {
     return function() {
+        if (!advisor_window_is_supported(advisor)) {
+            city.warnings.show("#not_available_in_this_assignment")
+            return 0
+        }
+
         window_advisors_show_advisor(advisor)
     }
 }
 
 function window_advisors_show_checked() {
-    var avail = 0
     var last = __game_settings.last_advisor
-    if (city.is_advisor_available(last)) {
-        avail = 1
-    } else {
-        for (var adv = ADVISOR_NONE + 1; adv < ADVISOR_MAX; adv++) {
-            if (city.is_advisor_available(adv)) {
-                __game_settings.last_advisor = adv
-                avail = 1
-                break
-            }
+    if (advisor_window_is_supported(last) && advisor_window_is_available(last)) {
+        return window_advisors_show_advisor(last)
+    }
+
+    var advisors = advisor_window_supported_list()
+    for (var i = 0; i < advisors.length; i++) {
+        var adv = advisors[i]
+        if (advisor_window_is_available(adv)) {
+            return window_advisors_show_advisor(adv)
         }
     }
-    if (avail === 1) {
-        window_advisors_show()
-    } else {
-        var text = (avail === 0) ? "#not_available_in_this_assignment" : "#not_available_yet"
-        city.warnings.show(text)
+
+    city.warnings.show("#not_available_in_this_assignment")
+}
+
+function advisor_window_reflow(window) {
+    if (!window) {
+        return
     }
+
+    var frameX = ((screen.width - px(40)) / 2) | 0
+    var frameY = ((screen.height - px(30)) / 2) | 0
+
+    if (window.advisor_area) {
+        window.advisor_area.pos = { x: frameX, y: frameY }
+    }
+
+    if (window.advisors_strip) {
+        window.advisors_strip.pos = { x: frameX, y: frameY + 440 }
+    }
+
+    function set_toolbar_pos(id, dx) {
+        if (window[id]) {
+            window[id].pos = { x: frameX + dx, y: frameY + 449 }
+        }
+    }
+
+    set_toolbar_pos("labor_btn", 12)
+    set_toolbar_pos("military_btn", 52)
+    set_toolbar_pos("imperial_btn", 96)
+    set_toolbar_pos("ratings_btn", 135)
+    set_toolbar_pos("trade_btn", 178)
+    set_toolbar_pos("population_btn", 229)
+    set_toolbar_pos("health_btn", 282)
+    set_toolbar_pos("education_btn", 322)
+    set_toolbar_pos("entertainment_btn", 363)
+    set_toolbar_pos("religion_btn", 406)
+    set_toolbar_pos("financial_btn", 445)
+    set_toolbar_pos("chief_btn", 490)
+    set_toolbar_pos("monuments_btn", 542)
+    set_toolbar_pos("back_btn", 588)
 }
 
 function advisors_toolbar_refresh(window, advisor) {
+    advisor_window_reflow(window)
     __game_settings.last_advisor = advisor
 
     window.labor_btn.selected = (ADVISOR_LABOR == advisor)
@@ -102,19 +182,19 @@ function advisors_toolbar_refresh(window, advisor) {
     window.chief_btn.selected = (ADVISOR_CHIEF == advisor)
     window.monuments_btn.selected = (ADVISOR_MONUMENTS == advisor)
 
-    window.labor_btn.readonly = !city.is_advisor_available(ADVISOR_LABOR)
-    window.military_btn.readonly = !city.is_advisor_available(ADVISOR_MILITARY)
-    window.imperial_btn.readonly = !city.is_advisor_available(ADVISOR_IMPERIAL)
-    window.ratings_btn.readonly = !city.is_advisor_available(ADVISOR_RATINGS)
-    window.trade_btn.readonly = !city.is_advisor_available(ADVISOR_TRADE)
-    window.population_btn.readonly = !city.is_advisor_available(ADVISOR_POPULATION)
-    window.health_btn.readonly = !city.is_advisor_available(ADVISOR_HEALTH)
-    window.education_btn.readonly = !city.is_advisor_available(ADVISOR_EDUCATION)
-    window.entertainment_btn.readonly = !city.is_advisor_available(ADVISOR_ENTERTAINMENT)
-    window.religion_btn.readonly = !city.is_advisor_available(ADVISOR_RELIGION)
-    window.financial_btn.readonly = !city.is_advisor_available(ADVISOR_FINANCIAL)
-    window.chief_btn.readonly = !city.is_advisor_available(ADVISOR_CHIEF)
-    window.monuments_btn.readonly = !city.is_advisor_available(ADVISOR_MONUMENTS)
+    window.labor_btn.readonly = !advisor_window_is_available(ADVISOR_LABOR)
+    window.military_btn.readonly = !advisor_window_is_available(ADVISOR_MILITARY)
+    window.imperial_btn.readonly = !advisor_window_is_available(ADVISOR_IMPERIAL)
+    window.ratings_btn.readonly = !advisor_window_is_available(ADVISOR_RATINGS)
+    window.trade_btn.readonly = !advisor_window_is_available(ADVISOR_TRADE)
+    window.population_btn.readonly = !advisor_window_is_available(ADVISOR_POPULATION)
+    window.health_btn.readonly = !advisor_window_is_available(ADVISOR_HEALTH)
+    window.education_btn.readonly = !advisor_window_is_available(ADVISOR_EDUCATION)
+    window.entertainment_btn.readonly = !advisor_window_is_available(ADVISOR_ENTERTAINMENT)
+    window.religion_btn.readonly = !advisor_window_is_available(ADVISOR_RELIGION)
+    window.financial_btn.readonly = !advisor_window_is_available(ADVISOR_FINANCIAL)
+    window.chief_btn.readonly = !advisor_window_is_available(ADVISOR_CHIEF)
+    window.monuments_btn.readonly = !advisor_window_is_available(ADVISOR_MONUMENTS)
 
     window.back_btn.enabled = true
 }

--- a/src/scripts/ui_top_menu_widget.js
+++ b/src/scripts/ui_top_menu_widget.js
@@ -15,7 +15,13 @@ function top_menu_cities_old_toggle(p1, p2) { game_features.gameui_empire_city_o
 function top_menu_open_advisor(advisor, p2) {
 	widget_top_menu_clear_state()
 	window_go_back()
-	emit event_show_window{ id:advisor }
+
+	if (typeof advisor === "number") {
+		window_advisors_show_advisor(advisor)
+		return
+	}
+
+	window_advisors_show_checked()
 }
 
 function top_menu_show_console(p1, p2) { window_show_cheat_console(true) }

--- a/src/window/window_advisors.cpp
+++ b/src/window/window_advisors.cpp
@@ -38,6 +38,38 @@ static pcstr advisor_autoconfig_section(e_advisor a) {
     }
 }
 
+static bool advisor_window_can_show(e_advisor advisor) {
+    pcstr section = advisor_autoconfig_section(advisor);
+    return section && g_city.is_advisor_available(advisor) == AVAILABLE && autoconfig_window::find(section);
+}
+
+static e_advisor advisor_window_fallback() {
+    static const e_advisor supported[] = {
+        ADVISOR_LABOR,
+        ADVISOR_MILITARY,
+        ADVISOR_IMPERIAL,
+        ADVISOR_RATINGS,
+        ADVISOR_TRADE,
+        ADVISOR_POPULATION,
+        ADVISOR_HEALTH,
+        ADVISOR_EDUCATION,
+        ADVISOR_ENTERTAINMENT,
+        ADVISOR_RELIGION,
+        ADVISOR_FINANCIAL,
+        ADVISOR_CHIEF,
+        ADVISOR_MONUMENTS,
+        ADVISOR_HOUSING,
+    };
+
+    for (e_advisor advisor : supported) {
+        if (advisor_window_can_show(advisor)) {
+            return advisor;
+        }
+    }
+
+    return ADVISOR_NONE;
+}
+
 void window_advisors_prepare_opening() {
     g_city.labor.allocate_workers();
 
@@ -58,8 +90,14 @@ void window_advisors_prepare_opening() {
 void window_advisors_show() {
     window_advisors_prepare_opening();
 
-    pcstr section = advisor_autoconfig_section((e_advisor)g_settings.last_advisor);
-    if (!section) {
+    e_advisor advisor = (e_advisor)g_settings.last_advisor;
+    if (!advisor_window_can_show(advisor)) {
+        advisor = advisor_window_fallback();
+        g_settings.last_advisor = advisor;
+    }
+
+    pcstr section = advisor_autoconfig_section(advisor);
+    if (!section || !autoconfig_window::find(section)) {
         return;
     }
 


### PR DESCRIPTION
## Summary

This updates the advisor UI to support multiple background presentation modes and improves responsive centering when the game window is resized.

### Background modes

The advisor background widget now supports three modes:

- `original`: keeps the original placement logic
- `contain`: fits the source image inside the available area while preserving aspect ratio
- `cover`: fills the available area while preserving aspect ratio

In addition, advisor backgrounds can optionally render a blurred cover backdrop behind the main image, which allows combinations such as:

- original image with blurred fullscreen backdrop
- contain image with blurred fullscreen backdrop
- plain cover without blur

## What changed

- added advisor background mode support in the UI background element
- kept the original menu background behavior intact while enabling the new modes for advisor windows
- updated advisor windows to use the shared background configuration
- fixed advisor menu/opening logic so advisor buttons and fallbacks resolve valid windows reliably
- reflow advisor window layout during drawing so the advisor panel and bottom strip stay centered after window resize
- refreshed autoconfig windows after screen resolution changes

## Why

Advisor windows were previously tied to fixed coordinates and a single background behavior. That caused two issues:

- background presentation could not be switched between original, contain, and cover styles
- advisor windows did not consistently recenter after resizing the game window

This change makes the background behavior configurable while keeping the advisor layout responsive.

## Validation

- built `akhenaten` successfully in `RelWithDebInfo`
- verified the updated advisor scripts compile into the generated JS wrapper sources during the build
