### PR TITLE
fix(mission2): unlock bridges so beautification submenu shows in build menu

### DIFF
--- a/src/scripts/mission_2_perwadjyt.js
+++ b/src/scripts/mission_2_perwadjyt.js
@@ -81,7 +81,8 @@ function mission2_on_start(ev) {
 		city.use_building(BUILDING_LARGE_STATUE, true)
 		city.use_building(BUILDING_GARDENS, true)
 		city.use_building(BUILDING_PLAZA, true)
-		city.use_building(BUILDING_MENU_WATER_CROSSINGS, true)
+		city.use_building(BUILDING_LOW_BRIDGE, true)
+		city.use_building(BUILDING_FERRY, true)
 	}
 
 	if (mission.disease_handled) {
@@ -160,7 +161,8 @@ function mission2_warehouse_pottery_2_check(ev) {
 	city.use_building(BUILDING_LARGE_STATUE, true)
 	city.use_building(BUILDING_GARDENS, true)
 	city.use_building(BUILDING_PLAZA, true)
-	city.use_building(BUILDING_MENU_WATER_CROSSINGS, true)
+	city.use_building(BUILDING_LOW_BRIDGE, true)
+	city.use_building(BUILDING_FERRY, true)
 
 	ui.popup_message("message_tutorial_municipal_structures")
 }


### PR DESCRIPTION
## Summary
- The pottery-step-2 trigger in mission 2 (Perwadjyt) called `use_building(BUILDING_MENU_WATER_CROSSINGS, true)` without enabling any actual bridge or ferry inside it.
- The empty submenu caused `count_items` (which only counts submenus with enabled contents) to disagree with `next_index` (which only checks the `enabled` flag) by one, silently truncating the last enabled item — `BUILDING_MENU_BEAUTIFICATION` — from the Municipal Structures list.
- Replaced the orphan menu enable with `BUILDING_LOW_BRIDGE` and `BUILDING_FERRY`. Their `is_water_crossing` flag cascades to enable the menu, so its count matches its enabled state and Beautification renders correctly.

## Notes
The underlying inconsistency between `count_items` and `next_index` in `src/city/city_building_menu_ctrl.cpp` is a latent bug that could bite again if any future script enables a submenu without contents. Worth a follow-up to make those two functions agree, but kept out of this PR to keep the scope minimal.

## Test plan
- [ ] Play mission 3 - Perwadjyt past pottery step 2; verify the \"municipal structures\" message fires
- [ ] Open Municipal Structures sidebar category; confirm Beautification submenu is visible alongside Water Crossings
- [ ] Open the Beautification submenu; confirm gardens, plaza, small/medium/large statues are all listed
- [ ] Open the Water Crossings submenu; confirm low bridge and ferry are listed
- [ ] Save and reload mid-mission; confirm Beautification still appears (mission2_on_start re-applies the unlocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)