### PR TITLE
fix(messages): suppress unknown-id popups that fell through to help dialog

### DIFF
--- a/src/city/city_message.cpp
+++ b/src/city/city_message.cpp
@@ -4,6 +4,7 @@
 #include "scenario/scenario_event_manager.h"
 #include "content/vfs.h"
 #include "core/encoding.h"
+#include "core/log.h"
 #include "core/string.h"
 #include "city/city_religion.h"
 #include "figure/formation.h"
@@ -151,6 +152,11 @@ void city_message_post_full(bool use_popup, xstring template_id, const event_ph_
         return;
     }
 
+    if (lang_get_message_uid(template_id) == 0) {
+        logs::info("city_message_post_full: unknown message id '%s' - popup suppressed", template_id.c_str());
+        return;
+    }
+
     data.total_messages++;
     data.current_message_id = id;
 
@@ -220,6 +226,12 @@ void city_message_post_full(bool use_popup, xstring template_id, const event_ph_
 city_message &message_manager_t::post_common(bool use_popup, xstring mm_text, int param1, int param2, int god, int bg_img) {
     int id = new_message_id();
     if (id < 0) {
+        static city_message dummy;
+        return dummy;
+    }
+
+    if (lang_get_message_uid(mm_text) == 0) {
+        logs::info("messages::popup: unknown message id '%s' - popup suppressed", mm_text.c_str());
         static city_message dummy;
         return dummy;
     }

--- a/src/io/gamefiles/lang.cpp
+++ b/src/io/gamefiles/lang.cpp
@@ -75,12 +75,6 @@ const lang_message& lang_get_message(int id) {
         }
     }
 
-    for (const auto &it : game_messages) {
-        if (it.second.id == 10) { // message_table_of_contents - default message
-            return it.second;
-        }
-    }
-
     static lang_message dummy{};
     return dummy;
 }

--- a/src/scripts/mission_9_abu.js
+++ b/src/scripts/mission_9_abu.js
@@ -1,7 +1,7 @@
 log_info("akhenaten: mission 9 abu started")
 
 mission9 = { // Abu
-	start_message : 0, //TUTORIAL_SOLDIERS_AND_FORT, 245 = 146 + 99 - 1
+	start_message : "", //TUTORIAL_SOLDIERS_AND_FORT, 245 = 146 + 99 - 1
 	env {
 		has_animals : true
 		marshland_grow : default_marshland_grow

--- a/src/widget/widget_top_menu_game_js.cpp
+++ b/src/widget/widget_top_menu_game_js.cpp
@@ -16,6 +16,7 @@
 #include "graphics/window.h"
 #include "graphics/screenshot.h"
 #include "io/gamestate/boilerplate.h"
+#include "core/log.h"
 #include "core/profiler.h"
 #include "game/game.h"
 
@@ -117,6 +118,7 @@ pcstr __widget_top_menu_features(int, int) {
 ANK_FUNCTION_2(__widget_top_menu_features)
 
 pcstr __widget_top_menu_show_help(int, int) {
+    logs::info("__widget_top_menu_show_help invoked");
     widget_top_menu_clear_state();
     window_go_back();
     window_message_dialog_show("message_dialog_help", -1, window_city_draw_all);

--- a/src/window/message_dialog_new.cpp
+++ b/src/window/message_dialog_new.cpp
@@ -39,6 +39,7 @@
 #include "js/js_game.h"
 #include "game/game.h"
 #include "message_dialog.h"
+#include "core/log.h"
 #include "core/string.h"
 #include "city/military.h"
 
@@ -387,6 +388,7 @@ void ui::message_dialog_base::button_close() {
 }
 
 void ui::message_dialog_base::button_help() {
+    logs::info("message_dialog_base::button_help invoked, help_id='%s'", help_id.empty() ? "<empty>" : help_id.c_str());
     button_close();
     if (!help_id.empty()) {
         g_message_dialog_instance->show(help_id, -1, background_callback);
@@ -502,6 +504,10 @@ void window_message_setup_help_id(xstring helpid) {
 }
 
 void window_show_help() {
+    logs::info("window_show_help invoked, help_id='%s'",
+        (g_message_dialog_instance && !g_message_dialog_instance->help_id.empty())
+            ? g_message_dialog_instance->help_id.c_str()
+            : "<none>");
     auto &data = g_window_manager;
     auto &current_window = data.window_queue[data.queue_index];
     if (g_message_dialog_instance && !g_message_dialog_instance->help_id.empty()) {

--- a/src/window/window_info.cpp
+++ b/src/window/window_info.cpp
@@ -43,6 +43,7 @@
 #include "window/message_dialog.h"
 #include "widget/widget_sidebar.h"
 #include "io/gamefiles/lang.h"
+#include "core/log.h"
 #include "dev/debug.h"
 #include "js/js_game.h"
 
@@ -310,6 +311,7 @@ object_info &common_info_window::get_object_info() {
 void common_info_window::update_buttons(object_info &c) {
     vec2i bgsize = ui["background"].pxsize();
     ui["button_help"].onclick([&c] {
+        logs::info("window_info button_help invoked, help_id=%d", c.help_id);
         if (c.help_id > 0) {
             const xstring help_id = lang_get_message_id(c.help_id);
             window_message_dialog_show(help_id, -1, window_city_draw_all);


### PR DESCRIPTION
## Summary

The generic help dialog (`message_table_of_contents`) was popping up mid-game without user input. Two latent issues conspired:

- `lang_get_message(int id)` silently fell back to id 10 (`message_table_of_contents`) for any unknown int. Every accidental popup with an unresolved message id became the help dialog.
- `messages::popup` → `post_common` / `city_message_post_full` never validated the result of `lang_get_message_uid`. When it returned 0, `show_message_popup` called `lang_get_message(0)` and hit the fallback above.

Plug both holes:
- `lang.cpp`: drop the `id == 10` fallback so unknown ids return the empty dummy.
- `city_message.cpp`: skip the popup and log when `lang_get_message_uid` returns 0 (in both `post_common` and `city_message_post_full`).
- `mission_9_abu.js`: `start_message: 0` → `""` so the xstring binding cannot produce a non-empty unknown id.

Also adds **temporary** `logs::info` breadcrumbs at every legitimate help-dialog entry point (`window_show_help`, `message_dialog_base::button_help`, the top-menu Help item, and `window_info`'s `button_help` onclick). These should be removed once the fix is confirmed in the wild — kept here so any remaining spurious invocation can be traced via the log.

## Test plan

- [ ] Build the akhenaten target in Debug; confirm no compile errors.
- [ ] Load a save where the help dialog had been popping up randomly; play for several minutes and confirm it no longer appears.
- [ ] Verify legitimate help still works:
  - [ ] Top Menu → Help → Help opens the help dialog; log shows `__widget_top_menu_show_help invoked`.
  - [ ] Click the `?` on a building info window; log shows `window_info button_help invoked, help_id=…` and the appropriate help message opens.
  - [ ] On any open message dialog, click its help button; log shows `message_dialog_base::button_help invoked, help_id=…`.
- [ ] If a spurious popup recurs, check the log for `messages::popup: unknown message id '…'` (suppressed cases) or one of the breadcrumb lines, then file a follow-up using the captured id/path. After the fix is confirmed, remove the four breadcrumbs in a follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)