### PR TITLE
fix(salary+mansion): apply rank via C++; mansion shows correct savings/salary

### DIFF
--- a/src/city/city_kingdome_js.cpp
+++ b/src/city/city_kingdome_js.cpp
@@ -9,6 +9,14 @@ void ank_global_obj_bind_field(js_State *J, js_StringNode name, e_rating_change 
     js_register_bound_uint8_property(J, name, reinterpret_cast<uint8_t *>(ptr));
 }
 
+void __city_apply_salary_rank(int rank) {
+    const auto &salaries = kingdome_relation_t::params().salary_ranks;
+    rank = std::clamp(rank, 0, (int)salaries.size() - 1);
+    g_city.kingdome.salary_rank = (uint8_t)rank;
+    g_city.kingdome.salary_amount = (uint8_t)salaries[rank];
+}
+ANK_FUNCTION_1(__city_apply_salary_rank)
+
 ANK_GLOBAL_OBJECT(g_city.kingdome, __city_kingdome,
     salary_rank,
     salary_amount,

--- a/src/scripts/city.js
+++ b/src/scripts/city.js
@@ -210,10 +210,7 @@ city {
         return r[rank]
     }
 
-    apply_salary_rank : function(rank) {
-        city.kingdome.salary_rank = rank
-        city.kingdome.salary_amount = city.rank_salary(rank)
-    }
+    apply_salary_rank : __city_apply_salary_rank
     start_foreign_army_invasion : __city_start_foreign_army_invasion
     camera_go_to : __city_camera_go_to
     allowed_foods : __city_allowed_foods

--- a/src/scripts/ui_widgets.js
+++ b/src/scripts/ui_widgets.js
@@ -357,11 +357,11 @@ info_window_mansion {
         title       : text({pos[0, 16], text:"${building.name}", size[px(29), 20], font : FONT_LARGE_BLACK_ON_LIGHT, align:"center"}),
         first_advisor : image_button({pos[40, -1], size[28, 28], pack:PACK_GENERAL, id:106 }),
         resource_img  : resource_icon({pos[16, 44], resource:RESOURCE_GOLD}),
-        savings_hold  : text({pos[44, 44], text:"${text.2} ${building.tax_income_or_storage} Db", font: FONT_NORMAL_BLACK_ON_LIGHT }),
+        savings_hold  : text({pos[44, 44], textfn:function() { return __loc(52, 1) + " " + city.personal_savings + " " + __loc(6, 0) }, font: FONT_NORMAL_BLACK_ON_LIGHT }),
         protection_info : text({pos[32, 64], text:"${text.4}", font: FONT_SMALL_PLAIN, wrap:px(25), multiline:true }),
         warning_text  : text({pos[32, 86], text:"${text.1}", wrap:px(27), font: FONT_NORMAL_BLACK_ON_LIGHT, multiline:true }),
         salary_info   : text({pos[32, 150], text:"${text.5}", font: FONT_NORMAL_BLACK_ON_LIGHT, wrap:px(25), multiline:true }),
-        change_salary : button({text:"${player.rank_name} ${player.salary_amount} ${52.3}", margin{centerx:-200, bottom:-80}, size[400, 30], font: FONT_NORMAL_BLACK_ON_DARK }),
+        change_salary : button({textfn:function() { return _eformat("${city.rank_title(player.salary_rank)} ${player.salary_amount} ${52.3}", {city:city, player:player}) }, margin{centerx:-200, bottom:-80}, size[400, 30], font: FONT_NORMAL_BLACK_ON_DARK }),
 
         button_help   : help_button({})
         button_close  : close_button({})


### PR DESCRIPTION
Two related fixes in the salary/mansion flow.

## Commit 1: salary picker doesn't apply (apply_salary_rank)

The salary picker (Imperial advisor → click on \"Зарплата ...\" → choose rank → click) opens, lets you pick, closes, but the salary stays at 0 in the advisor afterwards.

\`src/scripts/city.js:213\` had:

\`\`\`js
apply_salary_rank : function(rank) {
    city.kingdome.salary_rank = rank
    city.kingdome.salary_amount = city.rank_salary(rank)
}
\`\`\`

Both fields are bound \`uint8_t\` CPTR properties on \`city.kingdome\`. With debug logs:

\`\`\`
APPLY_FN entry rank=4 amount=12  (var amount = city.rank_salary(rank))
APPLY_FN after rank set: 4
APPLY_FN after amount set: 0     ← writing the local var to the bound uint8_t reads back as 0
APPLY_FN after literal 99: 99    ← writing a literal to the SAME property in the SAME function works
\`\`\`

The property write only persists when the RHS is a literal — when it's a local variable or function-call result, the bound CPTR setter ends up storing 0. Direct writes from outside the method (in \`set_salary_window_list_on_click_item\`) work fine for all RHS forms. mujs interaction with bound-pointer properties from inside an object method.

### Original Caesar 3 / Pharaoh-port

Commit \`d27fb9fd79\` (\"Move more emperor-related functions\") in \`src/city/emperor.c\`:

\`\`\`c
void city_emperor_set_salary_rank(int rank)
{
    Data_CityInfo.salaryRank = rank;
    Data_CityInfo.salaryAmount = SALARY_FOR_RANK[rank];
}
\`\`\`

Same logic in C, no engine quirks. The salary picker called this function. When relevant code was migrated to JS in Akhenaten, the function got inlined into JS and started failing.

### Fix

Restore the C++ counterpart and have JS \`city.apply_salary_rank\` simply refer to it.

\`src/city/city_kingdome_js.cpp\`:
\`\`\`cpp
void __city_apply_salary_rank(int rank) {
    const auto &salaries = kingdome_relation_t::params().salary_ranks;
    rank = std::clamp(rank, 0, (int)salaries.size() - 1);
    g_city.kingdome.salary_rank = (uint8_t)rank;
    g_city.kingdome.salary_amount = (uint8_t)salaries[rank];
}
ANK_FUNCTION_1(__city_apply_salary_rank)
\`\`\`

\`src/scripts/city.js:213\`:
\`\`\`js
apply_salary_rank : __city_apply_salary_rank
\`\`\`

\`city.rank_salary\` remains (used by the picker render to display each rank's salary line).

## Commit 2: mansion info window shows wrong values + literal template

The personal mansion info window had two unrelated rendering bugs alongside the salary picker issue.

### \`savings_hold\` showed wrong number

\`\`\`js
savings_hold : text({text:\"\${text.2} \${building.tax_income_or_storage} Db\", ...})
\`\`\`

\`building.tax_income_or_storage\` is the per-building tax counter. For the mansion it grows independently from the player's actual personal savings, so the mansion claimed e.g. \"Дебенов в месяц 10019 Db\" while the Imperial advisor showed \"Сбережения 786 Дб\" — same conceptual value, two completely different numbers. Plus group-103 id 2 says \"Deben per month\" but the value isn't per-month. Both label and value were wrong.

### \`change_salary\` button rendered the literal template

\`\`\`js
change_salary : button({text:\"\${player.rank_name} \${player.salary_amount} \${52.3}\", ...})
\`\`\`

Two issues: \`player.rank_name\` doesn't exist (only \`salary_rank\`/\`salary_amount\` are bound on \`player\`), and \`text:\"\${...}\"\` on a button widget doesn't run \`_eformat\` — only \`textfn:function() { return _eformat(...) }\` does. Result: button rendered the literal string \`\${player.rank name} \$(player.salary amount) Дебенов в месяц\`.

### Fix

Switch both to \`textfn\` and use the same labels the Imperial advisor uses (group 52 id 1 = \"Сбережения\", group 6 id 0 = \"Дб\"):

\`\`\`js
savings_hold  : text({textfn:function() { return __loc(52, 1) + \" \" + city.personal_savings + \" \" + __loc(6, 0) }, ...}),
change_salary : button({textfn:function() { return _eformat(\"\${city.rank_title(player.salary_rank)} \${player.salary_amount} \${52.3}\", {city:city, player:player}) }, ...}),
\`\`\`

### Verification

Mission 6 (Behdet), 2026-05-01:

- Salary picker now actually applies — click rank 2 → advisor shows \"Зарплата королевского учёного 5 Дебенов в месяц\". All 11 ranks update correctly.
- Mansion top line shows \"Сбережения 786 Дб\" (matches Imperial advisor exactly).
- Mansion bottom button shows \"Зарплата королевского учёного 5 Дебенов в месяц\" instead of the raw template string.

### Scope

- +9 lines C++ (`city_kingdome_js.cpp`), −3 lines JS (`city.js`), +2/−2 lines JS (`ui_widgets.js`).
- No changes to salary table, kingdom rating logic, or finance deduction.