### PR TITLE
fix(religion): correct calc_percentage args in coverage formula

### DIFF
--- a/src/city/city_religion.cpp
+++ b/src/city/city_religion.cpp
@@ -174,11 +174,19 @@ void city_religion_t::calc_coverage() {
         return;
     }
 
-    coverage[GOD_OSIRIS] = std::min(calc_percentage(pop, god_coverage_total(GOD_OSIRIS, BUILDING_SHRINE_OSIRIS, BUILDING_TEMPLE_OSIRIS, BUILDING_TEMPLE_COMPLEX_OSIRIS)), 100);
-    coverage[GOD_RA] = std::min(calc_percentage(pop, god_coverage_total(GOD_RA, BUILDING_SHRINE_RA, BUILDING_TEMPLE_RA, BUILDING_TEMPLE_COMPLEX_RA)), 100);
-    coverage[GOD_PTAH] = std::min(calc_percentage(pop, god_coverage_total(GOD_PTAH, BUILDING_SHRINE_PTAH, BUILDING_TEMPLE_PTAH, BUILDING_TEMPLE_COMPLEX_PTAH)), 100);
-    coverage[GOD_SETH] = std::min(calc_percentage(pop, god_coverage_total(GOD_SETH, BUILDING_SHRINE_SETH, BUILDING_TEMPLE_SETH, BUILDING_TEMPLE_COMPLEX_SETH)), 100);
-    coverage[GOD_BAST] = std::min(calc_percentage(pop, god_coverage_total(GOD_BAST, BUILDING_SHRINE_BAST, BUILDING_TEMPLE_BAST, BUILDING_TEMPLE_COMPLEX_BAST)), 100);
+    auto god_coverage_pct = [this, pop](e_god g, e_building_type s, e_building_type t, e_building_type c) {
+        return std::min(calc_percentage(god_coverage_total(g, s, t, c), pop), 100);
+    };
+
+    coverage[GOD_OSIRIS]
+      = god_coverage_pct(GOD_OSIRIS, BUILDING_SHRINE_OSIRIS, BUILDING_TEMPLE_OSIRIS, BUILDING_TEMPLE_COMPLEX_OSIRIS);
+    coverage[GOD_RA] = god_coverage_pct(GOD_RA, BUILDING_SHRINE_RA, BUILDING_TEMPLE_RA, BUILDING_TEMPLE_COMPLEX_RA);
+    coverage[GOD_PTAH]
+      = god_coverage_pct(GOD_PTAH, BUILDING_SHRINE_PTAH, BUILDING_TEMPLE_PTAH, BUILDING_TEMPLE_COMPLEX_PTAH);
+    coverage[GOD_SETH]
+      = god_coverage_pct(GOD_SETH, BUILDING_SHRINE_SETH, BUILDING_TEMPLE_SETH, BUILDING_TEMPLE_COMPLEX_SETH);
+    coverage[GOD_BAST]
+      = god_coverage_pct(GOD_BAST, BUILDING_SHRINE_BAST, BUILDING_TEMPLE_BAST, BUILDING_TEMPLE_COMPLEX_BAST);
 
     int result = coverage[GOD_OSIRIS] + coverage[GOD_RA]
                         + coverage[GOD_PTAH] + coverage[GOD_SETH]


### PR DESCRIPTION
Fixes #457.

## Cause

`src/city/city_religion.cpp:177-181` calls `calc_percentage(pop, god_coverage_total(...))` for each god. Since `calc_percentage(value, total) = value * 100 / total` (`src/core/calc.h:16`), this computes `pop * 100 / temple_capacity` — the inverse of "percentage of population the temples cover". More temples = larger divisor = lower coverage = lower mood. Religion advisor ends up showing gods with lots of temples as Wrathful and gods with few temples as Pleased.

Every other `calc_percentage` call in the codebase (e.g. `src/city/coverage.cpp:97-116` for booth/library/academy/school) uses the convention `calc_percentage(capacity, pop)`. Religion was the only place where the args were reversed. The bug was introduced in `f13bd84a54 refactor: redesigned religion system` (2024-07-29) when the per-house coverage logic was replaced with the simple percentage formula.

## Fix

Swap the two arguments in all five lines (one per god). To keep the resulting lines under 120 columns and avoid five almost-identical statements, the shared `std::min(calc_percentage(god_coverage_total(...), pop), 100)` is extracted into a local lambda.

Diff: +13 / −5 in `src/city/city_religion.cpp`. No new strings, no save format change, no behaviour change beyond the percentage calculation. `coverage_common` and `city_sentiment_t::calc_contribution_religion_coverage` automatically pick up the corrected values.

## Verification

Tested on a Behdet (mission 6) save with Ra at 6 temples / 26 shrines / festival 1 month ago:

- Before: `coverage[RA]` low (formula: `pop * 100 / 6150` clamped), `target_mood ≈ 40`, mood drifting down → Ra Wrathful.
- After: `coverage[RA] = 100`, `target_mood = 100`, after one Ra festival `mood = 100` → Ra Loved.

Cross-checked Osiris on the same save (2 temples, 6 shrines, coverage = 58, festival just held, months_since_festival = 6): `target_mood = 58 + 12 - 6 = 64` matches the debug Properties window readout exactly. Festival now actually moves the needle (was 32 → now 64 after a single festival, exactly the festival_penalty delta).

## Scope

- 1 file, 5 lines logically (lambda + five usages).
- No gameplay tuning, no save migration, no UI changes — just the percentage formula direction.
- Out of scope: separate `happy_ankhs` typo on line 815 (`= std::min<uint8_t>(god->wrath_bolts, 50)` overwrites accumulated happy_ankhs with wrath_bolts, blessings never trigger). Will be a separate PR.