### PR TITLE
fix(kingdome): one-shot favor clamp on bankruptcy, recover stuck rating_cap

### DIFF
--- a/src/city/city_kingdome_relations.cpp
+++ b/src/city/city_kingdome_relations.cpp
@@ -127,7 +127,7 @@ void kingdome_relation_t::update_debt_state() {
             months_in_debt = 0;
 
             if (!g_city.figures.kingdome_soldiers) {
-                rating_cap = params().last_debt_rating_cap;
+                rating = std::min<uint8_t>(rating, params().last_debt_rating_cap);
             }
         }
         break;
@@ -348,6 +348,9 @@ void kingdome_relation_t::init() {
 
 void kingdome_relation_t::on_post_load() {
     if (rating_cap == 0) { rating_cap = 100; }
+    if (rating_cap < 100) {
+        rating_cap = 100;
+    }
 }
 
 void kingdome_relation_t::reset() {


### PR DESCRIPTION
Fixes #459.

## Cause

`update_debt_state` case `e_debt_latest` (`src/city/city_kingdome_relations.cpp:130`) does `rating_cap = params().last_debt_rating_cap` (= 10). `rating_cap` is a persistent `uint8_t` save field used as a hard ceiling everywhere (`advance_month`, `change(amount)`), so the cap stays at 10 for the rest of the mission with no recovery path. One bankruptcy permanently caps Kingdom rating at 10, breaking missions with `kingdom goal > 10` (mission 6 = 45).

In the original Caesar 3 / Pharaoh-port (pre-`c75aff7b7a kingdome: redesigned rating calculation`), the equivalent was `city_ratings_limit_favor(10)` — a one-shot clamp that trims the current favor if it's above 10 and returns. No persistent ceiling field existed. The refactor changed the semantics from "one-shot trim" to "permanent cap" without intent. Same family as the religion coverage swap (#457): refactor preserved the name, lost the semantics.

I cross-checked all 5 `update_debt_state` cases against the C original — only this one transition is wrong. The other transitions use `change(amount)` (one-shot, matches original `city_ratings_change_favor(-N)`).

## Fix

Two minimal changes in `src/city/city_kingdome_relations.cpp`:

1. Replace persistent assignment with one-shot clamp (line 130), matching original `city_ratings_limit_favor`:
   ```cpp
   rating = std::min<uint8_t>(rating, params().last_debt_rating_cap);
   ```
2. Save migration in `on_post_load`: if `rating_cap < 100`, restore to 100. Auto-recovers broken pre-fix saves on first load. No behaviour change for fresh games (the default and everywhere else is 100).

`rating_cap` stays in the save format (`uint8_t` bind, backward-compatible) but is now effectively unused — the field becomes a backward-compat shim.

## Verification

- Existing broken save (Behdet, mission 6, `rating_cap = 10`, `debt_state = 4`, real player save): after loading with the fix, `on_post_load` restores `rating_cap = 100`, rating starts climbing again via Pharaoh requests / gifts / invasions defeated. `debt_state` left at 4 (terminal state, no further transitions, no further effects after the fix).
- Future games: when player hits `e_debt_not_allowed`, rating one-shot trimmed to 10 (matches original Pharaoh penalty), then can recover normally. Tested by manually setting `debt_state` and `rating` via the debug Properties window.

## Scope

- 1 file, +4 / -1.
- Save format unchanged (field stays bound).
- Balance unchanged (one-shot -10 → 10 trim is identical to original Pharaoh).
- Out of scope: popup messages in cases 2/3 are renamed from original (`WRATH_OF_THE_EMPEROR` instead of `CITY_STILL_IN_DEBT` / `CITY_IN_DEBT_AGAIN`) — cosmetic, separate.