### PR TITLE
Fix Android CI SDK detection and SDL Java bootstrap

### DIFF
--- a/.github/workflows/akhenaten_android.yml
+++ b/.github/workflows/akhenaten_android.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         java-version: 17
         distribution: temurin
@@ -31,6 +31,20 @@ jobs:
     - name: Build APK
       run: |
         cd android
+        SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+        if [ -z "$SDK_ROOT" ]; then
+          for candidate in "$HOME/Android/Sdk" "$HOME/android-sdk" "/usr/local/lib/android/sdk"; do
+            if [ -d "$candidate" ]; then
+              SDK_ROOT="$candidate"
+              break
+            fi
+          done
+        fi
+        if [ -z "$SDK_ROOT" ] || [ ! -d "$SDK_ROOT" ]; then
+          echo "Android SDK not found on runner"
+          exit 1
+        fi
+        printf 'sdk.dir=%s\n' "$SDK_ROOT" > local.properties
         bash ./gradlew assembleDebug --stacktrace
     - name: Upload APK
       uses: actions/upload-artifact@v6

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,4 +1,5 @@
 prebuilt/
 build_android_deps/
 akhenaten/src/main/cpp/_deps/
+local.properties
 

--- a/android/akhenaten/build.gradle
+++ b/android/akhenaten/build.gradle
@@ -27,6 +27,7 @@ ext.dependencyRepos = [
 
 // Директория для исходников зависимостей
 def depsDir = new File(projectDir, "src/main/cpp/_deps")
+def sdlAndroidJavaDir = new File(depsDir, "SDL2-src/android-project/app/src/main/java")
 // Директория для prebuilt библиотек
 def prebuiltDir = new File(projectDir.parent, "prebuilt")
 
@@ -541,6 +542,7 @@ android {
         }
         sourceSets {
             main.res.srcDirs += '../../res/android'
+            main.java.srcDirs += sdlAndroidJavaDir.absolutePath
             if (file('../../res/packed_assets').exists()) {
                 println 'Using packed assets'
                 main.assets.srcDirs += '../../res/packed_assets'
@@ -635,6 +637,13 @@ task downloadImguiSource {
 // Убеждаемся, что зависимости готовы перед сборкой CMake
 afterEvaluate {
     def libraries = ['zlib', 'SDL2', 'SDL2_mixer', 'freetype', 'harfbuzz', 'libpng']
+
+    tasks.matching {
+        def name = it.name
+        name.startsWith("javaPreCompile") || name.endsWith("JavaWithJavac")
+    }.configureEach { task ->
+        task.dependsOn downloadDependenciesSources
+    }
     
     tasks.matching { 
         def name = it.name

--- a/android/gradlew
+++ b/android/gradlew
@@ -85,6 +85,58 @@ APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 APP_NAME="Gradle"
 APP_BASE_NAME=${0##*/}
 
+LOCAL_PROPERTIES="$APP_HOME/local.properties"
+
+sdk_dir_from_local_properties() {
+    if [ ! -f "$LOCAL_PROPERTIES" ]; then
+        return 1
+    fi
+
+    sdk_line=$( grep '^sdk.dir=' "$LOCAL_PROPERTIES" 2>/dev/null | tail -n 1 )
+    if [ -z "$sdk_line" ]; then
+        return 1
+    fi
+
+    sdk_path=${sdk_line#sdk.dir=}
+    sdk_path=$( printf '%s' "$sdk_path" | sed 's#\\\\#\\#g' )
+    sdk_path=$( printf '%s' "$sdk_path" | sed 's#\\:#:#g' )
+    sdk_path=$( printf '%s' "$sdk_path" | sed 's#\\ # #g' )
+
+    if [ -d "$sdk_path" ]; then
+        printf '%s' "$sdk_path"
+        return 0
+    fi
+
+    return 1
+}
+
+write_local_properties() {
+    sdk_path=$1
+    printf 'sdk.dir=%s\n' "$sdk_path" > "$LOCAL_PROPERTIES"
+}
+
+ensure_android_sdk_local_properties() {
+    if sdk_dir_from_local_properties >/dev/null 2>&1; then
+        return 0
+    fi
+
+    sdk_root=${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}
+    if [ -z "$sdk_root" ]; then
+        for candidate in "$HOME/Android/Sdk" "$HOME/android-sdk" "/usr/local/lib/android/sdk"; do
+            if [ -d "$candidate" ]; then
+                sdk_root=$candidate
+                break
+            fi
+        done
+    fi
+
+    if [ -n "$sdk_root" ] && [ -d "$sdk_root" ]; then
+        write_local_properties "$sdk_root"
+    fi
+}
+
+ensure_android_sdk_local_properties
+
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -32,6 +32,30 @@ set APP_HOME=%DIRNAME%
 @rem Resolve any "." and ".." in APP_HOME to make it shorter.
 for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
 
+set LOCAL_PROPERTIES=%APP_HOME%\local.properties
+set SDK_ROOT=
+
+if exist "%LOCAL_PROPERTIES%" (
+  for /f "usebackq tokens=1,* delims==" %%A in ("%LOCAL_PROPERTIES%") do (
+    if "%%A"=="sdk.dir" (
+      set SDK_ROOT=%%B
+    )
+  )
+)
+
+if defined SDK_ROOT (
+  set SDK_ROOT=%SDK_ROOT:\\=\%
+  set SDK_ROOT=%SDK_ROOT\:=:%
+)
+
+if not defined SDK_ROOT if defined ANDROID_SDK_ROOT set SDK_ROOT=%ANDROID_SDK_ROOT%
+if not defined SDK_ROOT if defined ANDROID_HOME set SDK_ROOT=%ANDROID_HOME%
+if not defined SDK_ROOT if exist "%LOCALAPPDATA%\Android\Sdk" set SDK_ROOT=%LOCALAPPDATA%\Android\Sdk
+
+if defined SDK_ROOT if exist "%SDK_ROOT%" (
+  > "%LOCAL_PROPERTIES%" echo sdk.dir=%SDK_ROOT%
+)
+
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Sun Nov 30 11:30:30 CET 2025
-sdk.dir=C\:\\Users\\ROG Zephyrus G16\\AppData\\Local\\Android\\Sdk

--- a/src/platform/akhenaten.cpp
+++ b/src/platform/akhenaten.cpp
@@ -58,10 +58,8 @@
 #include <emscripten/emscripten.h>
 #endif
 
-#ifndef GAME_PLATFORM_ANDROID
 #include "dev/perfmon.h"
 #include "dev/perfmon_nanoprofiler.h"
-#endif
 
 #if defined(_WIN32)
 

--- a/src/platform/screen.cpp
+++ b/src/platform/screen.cpp
@@ -84,12 +84,12 @@ void platform_screen_t::set_scale_percentage(int new_scale, int pixel_width, int
 
 #if defined(GAME_PLATFORM_ANDROID)
 static void set_scale_for_screen(int pixel_width, int pixel_height) {
-    set_scale_percentage(android_get_screen_density() * 100, pixel_width, pixel_height);
-    // config_set(CONFIG_SCREEN_CURSOR_SCALE, scale_percentage);
-    if (window) {
-        // system_init_cursors(scale_percentage);
+    g_sdl_screen.set_scale_percentage(android_get_screen_density() * 100, pixel_width, pixel_height);
+    // config_set(CONFIG_SCREEN_CURSOR_SCALE, g_sdl_screen.scale_percentage);
+    if (g_sdl_screen.window) {
+        // system_init_cursors(g_sdl_screen.scale_percentage);
     }
-    logs::info("Auto-setting scale to %i", scale_percentage);
+    logs::info("Auto-setting scale to %i", g_sdl_screen.scale_percentage);
 }
 #endif
 


### PR DESCRIPTION
## Summary

This updates the Android build so it no longer depends on a checked-in machine-specific SDK path and so the app module compiles the SDL Android Java layer required by `AkhenatenMainActivity`.

## Changes

- remove the tracked `android/local.properties` file with a machine-specific Windows SDK path
- ignore `android/local.properties` in git
- update Android CI to use `actions/setup-java@v5`
- generate `local.properties` in CI from the runner SDK location
- bootstrap `local.properties` automatically in `gradlew` and `gradlew.bat` from `ANDROID_SDK_ROOT`, `ANDROID_HOME`, or common default SDK paths
- add SDL Android Java sources from the downloaded SDL dependency to the app `sourceSets`
- make Java compile tasks depend on dependency download so `SDLActivity` is available before `javac` runs

## Why

The Android workflow originally failed because Gradle read a repository-local `sdk.dir` that only existed on one Windows machine.

After fixing that, the next Android blocker was Java compilation: `AkhenatenMainActivity` extends `org.libsdl.app.SDLActivity`, but the SDL Android Java sources were never added to the Gradle app module.

## Validation

- inspected the failing GitHub Actions Android logs
- confirmed the original `sdk.dir` / `local.properties` problem was resolved
- ran `./gradlew :akhenaten:compileDebugJavaWithJavac`
- ran `./gradlew assembleDebug`