### PR TITLE
fix(empire): default max_traders to 1 so player-opened routes spawn traders

### DIFF
--- a/src/city/city.cpp
+++ b/src/city/city.cpp
@@ -379,7 +379,10 @@ bool city_t::generate_trader_from(empire_city &city) {
         trades_in_city += city.trader_figure_ids[i] != 0 ? 1 : 0;
     }
 
-    verify_no_crash(city.max_traders > 0);
+    if (city.max_traders == 0) {
+        return false;
+    }
+
     if (trades_in_city >= city.max_traders) {
         return false;
     }
@@ -397,7 +400,7 @@ bool city_t::generate_trader_from(empire_city &city) {
         const bool has_river_entry = scenario_map_has_river_entry();
         const bool can_sea_trade = !city_trade_has_sea_trade_problems();
         if (has_doks && has_river_entry && can_sea_trade) {
-            g_empire_traders.create_trader(city.route_id, -1);            
+            g_empire_traders.create_trader(city.route_id, -1);
             return true;
         }
     } else {

--- a/src/empire/empire_object.cpp
+++ b/src/empire/empire_object.cpp
@@ -132,6 +132,7 @@ void empire_t::init_cities() {
         city->trader_figure_ids[1] = 0;
         city->trader_figure_ids[2] = 0;
         city->empire_object_id = i;
+        city->max_traders = 1;
     }
 }
 


### PR DESCRIPTION
## Summary

- Empire cities defaulted `max_traders` to 0 in `init_cities`, so any route opened by the player on a city not explicitly listed in the active mission's `cities { ... }` script block silently never produced traders. Reproduced on Mission 7 (Abedju): both Byblos and Perwadjyt routes opened, imports/exports configured, dock staffed — zero traders, zero in-game warnings.
- Default `max_traders = 1` in `init_cities` so any opened empire route works, mirroring the per-mission script defaults already in use.
- Replace the `verify_no_crash(city.max_traders > 0)` sentinel in `generate_trader_from` with a soft `return false`, so engine state stays consistent if a future mission ever does want a zero quota.

## Test plan

- [x] Place dock + open trade routes on Mission 7 (Abedju) → sea traders now arrive monthly for both Byblos and Perwadjyt.
- [ ] Regression: Mission 6 (Behdet) — sea traders still arrive normally.
- [ ] Regression: Mission 1 (Thinis) — land + sea traders still arrive normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)