### PR TITLE
fix(fishing): stop boats teleporting on arrival and reshuffling spots monthly

### DIFF
--- a/src/city/city_fishing_points.cpp
+++ b/src/city/city_fishing_points.cpp
@@ -107,6 +107,13 @@ void city_fishing_points_t::clear() {
 void city_fishing_points_t::update_month(int points_num) {
     clear();
 
+    // Periodic monthly call (default arg) — keep existing positions and just
+    // re-spawn the figure entities. Re-rolling teleported spots and broke trips.
+    if (points_num < 0) {
+        create();
+        return;
+    }
+
     int num_fishing_spots = 0;
     for (int i = 0; i < MAX_FISH_POINTS; i++) {
         if (g_scenario.fishing_points[i].x() > 0)

--- a/src/figuretype/figure_fishing_boat.cpp
+++ b/src/figuretype/figure_fishing_boat.cpp
@@ -18,6 +18,7 @@
 #include "city/city_warnings.h"
 #include "game/game_events.h"
 #include "js/js_game.h"
+#include "scenario/scenario.h"
 #include <algorithm>
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_fishing_boat);
@@ -196,53 +197,12 @@ void figure_fishing_boat::figure_action() {
         base.move_ticks(1);
         base.height_adjusted_ticks = 0;
         if (direction() == DIR_FIGURE_NONE) {
-            grid_area area = map_grid_get_area(tile(), 1, 1);
-            tile2i another_boat_tile = area.find_if([this] (const tile2i &tt) {
-                bool has_figure = map_has_figure_types_at(tt, make_array(FIGURE_FISHING_BOAT));
-                return (has_figure && map_figure_id_get(tt) != id());
-            });
-
-            if (another_boat_tile.valid()) {
-                base.wait_ticks = 999;
-                advance_action(ACTION_196_FISHING_BOAT_RANDOM_FPOINT);
-                runtime_data().fishing_point_check_attempts = 0;
-                return;
-            }
-
-            auto &rdata = runtime_data();
-            const int MAX_CHECK_ATTEMPTS = 3;
-            
-            if (rdata.fishing_point_check_attempts < MAX_CHECK_ATTEMPTS) {
-                water_dest result = map_water_find_alternative_fishing_boat_tile(base);
-                if (result.found) {
-                    grid_area alt_area = map_grid_get_area(result.tile, 1, 1);
-                    tile2i alt_another_boat = alt_area.find_if([this] (const tile2i &tt) {
-                        bool has_figure = map_has_figure_types_at(tt, make_array(FIGURE_FISHING_BOAT));
-                        return (has_figure && map_figure_id_get(tt) != id());
-                    });
-                    
-                    if (!alt_another_boat.valid()) {
-                        rdata.fishing_point_check_attempts++;
-                        route_remove();
-                        base.destination_tile = result.tile;
-                    } else {
-                        rdata.fishing_point_check_attempts = MAX_CHECK_ATTEMPTS;
-                        advance_action(ACTION_192_FISHING_BOAT_FISHING);
-                        base.direction = base.previous_tile_direction;
-                        base.wait_ticks = 0;
-                    }
-                } else {
-                    rdata.fishing_point_check_attempts = MAX_CHECK_ATTEMPTS;
-                    advance_action(ACTION_192_FISHING_BOAT_FISHING);
-                    base.direction = base.previous_tile_direction;
-                    base.wait_ticks = 0;
-                }
-            } else {
-                rdata.fishing_point_check_attempts = 0;
-                advance_action(ACTION_192_FISHING_BOAT_FISHING);
-                base.direction = base.previous_tile_direction;
-                base.wait_ticks = 0;
-            }
+            // Reached the sticky fishing spot. Commit unconditionally — collisions
+            // with other boats are tolerated; both can fish on/near the same tile.
+            runtime_data().fishing_point_check_attempts = 0;
+            advance_action(ACTION_192_FISHING_BOAT_FISHING);
+            base.direction = base.previous_tile_direction;
+            base.wait_ticks = 0;
         } else if (direction() == DIR_FIGURE_REROUTE || direction() == DIR_FIGURE_CAN_NOT_REACH) {
             runtime_data().fishing_point_check_attempts = 0;
             advance_action(ACTION_193_FISHING_BOAT_GOING_TO_WHARF);
@@ -323,7 +283,26 @@ void figure_fishing_boat::figure_action() {
                 base.wait_ticks++;
                 if (base.wait_ticks >= max_wait_ticks) {
                     base.wait_ticks = 0;
-                    tile2i fish_tile = g_city.fishing_points.closest_fishing_point(tile(), true);
+
+                    auto &rd = runtime_data();
+                    tile2i fish_tile = rd.preferred_fishing_tile;
+
+                    bool sticky_valid = false;
+                    if (fish_tile.valid()) {
+                        for (int i = 0; i < MAX_FISH_POINTS; i++) {
+                            const tile2i &p = g_scenario.fishing_points[i];
+                            if (p.valid() && p == fish_tile) {
+                                sticky_valid = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!sticky_valid) {
+                        fish_tile = g_city.fishing_points.closest_fishing_point(tile(), false);
+                        rd.preferred_fishing_tile = fish_tile;
+                    }
+
                     if (fish_tile.valid() && map_water_is_point_inside(fish_tile)) {
                         wharf->runtime_data().no_fishing_points_warning_shown = 0;
                         runtime_data().fishing_point_check_attempts = 0;

--- a/src/figuretype/figure_fishing_boat.h
+++ b/src/figuretype/figure_fishing_boat.h
@@ -29,6 +29,7 @@ public:
     struct runtime_data_t {
         bool had_home;
         uint8_t fishing_point_check_attempts;
+        tile2i preferred_fishing_tile;
     } FIGURE_RUNTIME_DATA_T;
 
     virtual void on_create() override;

--- a/src/grid/water.cpp
+++ b/src/grid/water.cpp
@@ -265,24 +265,6 @@ shore_orientation map_shore_determine_orientation(tile2i tile, int size, bool ad
     return {false, 0};
 }
 
-water_dest map_water_find_alternative_fishing_boat_tile(figure &boat) {
-    if (map_figure_id_get(boat.tile) == boat.id) {
-        return {false};
-    }
-
-    grid_area area = map_grid_get_area(boat.tile, 1, 1);
-
-    svector<tile2i, 16> tiles;
-    area.for_each([&] (tile2i tt) {
-        if (!map_has_figure_at(tt) && map_terrain_is(tt, TERRAIN_WATER)) {
-            tiles.push_back(tt);
-        }
-    });
-
-    tile2i result = tiles.empty() ? tile2i::invalid : tiles[rand() % tiles.size()];
-    return { result.valid(), 0, result };
-}
-
 water_dest map_water_find_shipwreck_tile(figure &wreck) {
     if (map_terrain_is(wreck.tile, TERRAIN_WATER) && map_figure_id_get(wreck.tile) == wreck.id) {
         return {false};

--- a/src/grid/water.h
+++ b/src/grid/water.h
@@ -47,7 +47,6 @@ struct water_dest {
 
 shore_orientation map_shore_determine_orientation(tile2i tile, int size, bool adjust_xy, bool adjacent = false, int shore_terrain = TERRAIN_WATER);
 
-water_dest map_water_find_alternative_fishing_boat_tile(figure &boat);
 water_dest map_water_find_shipwreck_tile(figure &wreck);
 void map_water_rebuild_shores();
 bool map_water_can_spawn_boat(tile2i tile, int size, tile2i &boat_tile);


### PR DESCRIPTION
## Summary

- When a fishing boat arrived at its target tile and another boat was sharing the spot, the engine re-rolled an adjacent water tile and rerouted, causing visible teleport jitter and dropping the in-flight fishing trip. Boats now commit to the chosen tile on arrival — collisions are tolerated; both can fish on/near the same point.
- Each boat remembers its preferred fishing point in runtime data and only re-picks if the scenario removes that point. The monthly fishing-point refresh used to reshuffle every boat's assignment; with the default arg it now keeps positions and just respawns the figure entities.
- Removes the now-unused `map_water_find_alternative_fishing_boat_tile` helper.

## Test plan

- [x] Run a mission with multiple wharves on the same lake and verify boats no longer teleport when they cluster at a spot.
- [x] Confirm fishing trips complete successfully and produce meat at the wharf.
- [x] Regression: scenarios with seasonal fishing-point movement (river-fed maps) — boats still pick a fresh point when their original is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)