### PR TITLE
fix(mission_7): remove crocodiles and other wildlife from Abedju

### DIFF
--- a/src/city/city_animals.cpp
+++ b/src/city/city_animals.cpp
@@ -374,6 +374,13 @@ void city_animals_t::remove_all() {
             }
         }
     }
+
+    // create_herd() figure_create's animals and sets f->formation_id but never
+    // slots them into formation::figures[], so valid_figures() above misses
+    // them. Sweep by figure type to actually clear the world.
+    figure_valid_do([] (figure &f) {
+        f.poof();
+    }, make_array(FIGURE_CROCODILE, FIGURE_OSTRICH, FIGURE_ANTELOPE, FIGURE_HYENA, FIGURE_BIRDS));
 }
 
 void city_animals_t::update() {

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -90,6 +90,20 @@ mission7 { // Abydos
 	}
 }
 
+[event=event_register_mission_animals, mission=mission7]
+function mission7_register_animals(ev) {
+	// Abedju has no native fauna; suppress crocodiles/hyenas spawned via create_herds
+	// during fresh mission start (before any save exists).
+	city.remove_animals()
+}
+
+[event=event_mission_start, mission=mission7]
+function mission7_on_start(ev) {
+	// event_register_mission_animals only fires inside create_herds, which is
+	// skipped on save loads. Re-clear here so a saved game also stays clean.
+	city.remove_animals()
+}
+
 [es=event_advance_month, mission=mission7]
 function mission7_pharaoh_request_beer(ev) {
 	if (mission.pharaoh_beer_requested) {


### PR DESCRIPTION
## Summary

- Mission 7 (Abedju) shouldn't spawn crocodiles, hyenas, or other wild herds — they were attacking fishing boats and breaking the early sea-trade economy.
- Hook **both** `event_register_mission_animals` (fired during `create_herds` on a fresh mission start) **and** `event_mission_start` (also runs on save loads, where `create_herds` is skipped) to call `city.remove_animals` so the map stays clear in both load paths.
- `city_animals_t::remove_all` now also sweeps by figure type after walking herd formations: `create_herd` calls `figure_create` and sets `formation_id` but never registers the figure in `formation::figures[]`, so `valid_figures()` alone leaves the actual crocodile entities on the map.

## Test plan

- [x] Start Mission 7 fresh → no crocodiles spawn at the start.
- [x] Save and reload Mission 7 → no crocodiles spawn after reload.
- [x] In-game restart of Mission 7 → no crocodiles spawn.
- [ ] Regression: Mission 3 (Nekhen) animals still spawn.
- [ ] Regression: other northern-climate missions that should have crocodiles still spawn them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)