### PR TITLE
fix(shipyard): guard std::prev against begin() in approach_progress

### DIFF
--- a/src/building/building_shipyard.cpp
+++ b/src/building/building_shipyard.cpp
@@ -167,7 +167,7 @@ bool building_shipyard::add_resource(e_resource resource, int amount) {
 template<typename T>
 int approach_progress(int pct_workers, const T &thresholds) {
     auto it = std::lower_bound(thresholds.begin(), thresholds.end(), pct_workers, [] (const auto &pair, int value) { return pair.first <= value; });
-    int delta = (it != thresholds.end()) ? std::prev(it)->second : 0;
+    int delta = (it != thresholds.begin()) ? std::prev(it)->second : 0;
     return delta;
 }
 


### PR DESCRIPTION
## Summary

- `approach_progress` in `building_shipyard.cpp` called `std::prev(it)` after `std::lower_bound` while only guarding against `it == end()`. When `pct_workers` was below the lowest threshold the lambda made the iterator land on `begin()`, so `std::prev` walked before begin and tripped the debug iterator assertion ("cannot seek array iterator before begin"). Reproducible by placing a shipwright with no workers yet.
- Guarding against `begin()` instead of `end()` also fixes the symmetric latent bug at the top of the range — at 100%+ workers `lower_bound` returned `end()` and the function returned 0 instead of the highest tier value (e.g. 8 for fishing boats, 5 for warships).

## Test plan

- [x] Place a shipwright on a map and let it sit at 0% workers — no longer crashes.
- [ ] Confirm a shipwright at 100%+ workers progresses at the highest-tier rate (was returning 0 progress before).
- [ ] Regression: warship and transport-ship production rates still scale correctly across worker percentages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)