### PR TITLE
Add player click-to-move control for warships

### DIFF
--- a/src/figuretype/figure_war_ship.cpp
+++ b/src/figuretype/figure_war_ship.cpp
@@ -55,7 +55,7 @@ water_dest map_water_get_closest_working_warship_wharf(figure &boat) {
             mindist = curdist;
             dock_tile = water_tiles.point_a;
         }
-    }, BUILDING_TRANSPORT_WHARF);
+    }, BUILDING_WARSHIP_WHARF);
 
     if (!wharf) {
         return { false, 0 };
@@ -80,6 +80,15 @@ void figure_warship::before_poof() {
 
 void figure_warship::figure_action() {
     building* b = home();
+
+    // Newly-spawned warships have home = shipyard, not a wharf. Let
+    // figure_action_common() drive the spawn -> wharf transition; the
+    // destroyed-wharf recovery below only applies once a wharf is the home.
+    if (action_state() == ACTION_205_WARSHIP_CREATED) {
+        figure_action_common();
+        return;
+    }
+
     building_warship_wharf *wharf = b->dcast_warship_wharf();
     
     // Check if wharf is destroyed or invalid
@@ -185,6 +194,7 @@ void figure_warship::update_animation() {
     case ACTION_205_WARSHIP_CREATED: anim_key = "idle"; break;
     case ACTION_209_WARSHIP_ON_PATROL: anim_key = "idle"; break;
     case ACTION_203_WARSHIP_MOORED: anim_key = "idle"; break;
+    case ACTION_211_WARSHIP_IDLE_AT_TILE: anim_key = "idle"; break;
     }
 
     image_set_animation(anim_key);
@@ -238,7 +248,9 @@ void figure_warship::figure_action_common() {
             water_dest result = map_water_get_wharf_for_new_warship(base);
             if (result.bid && result.found) {
                 b->remove_figure_by_id(id()); // remove from original building
-                set_home(result.bid);
+                building *new_home = building_get(result.bid);
+                set_home(new_home->id);
+                new_home->set_figure(BUILDING_SLOT_BOAT, &base);
                 advance_action(ACTION_207_WARSHIP_GOING_TO_WHARF);
                 base.destination_tile = result.tile;
                 base.source_tile = result.tile;
@@ -323,5 +335,52 @@ void figure_warship::figure_action_common() {
             }
         }
     } break;
+
+    case ACTION_210_WARSHIP_GOING_TO_TILE:
+        base.move_ticks(1);
+        base.height_adjusted_ticks = 0;
+        if (direction() == DIR_FIGURE_NONE) {
+            advance_action(ACTION_211_WARSHIP_IDLE_AT_TILE);
+            base.source_tile = base.destination_tile;
+            base.wait_ticks = 0;
+        } else if (direction() == DIR_FIGURE_REROUTE) {
+            route_remove();
+        } else if (direction() == DIR_FIGURE_CAN_NOT_REACH) {
+            advance_action(ACTION_211_WARSHIP_IDLE_AT_TILE);
+            base.source_tile = base.tile;
+        }
+        break;
+
+    case ACTION_211_WARSHIP_IDLE_AT_TILE:
+        // idle indefinitely; player must issue another order to move
+        break;
     }
+}
+
+void figure_warship::move_to_tile(tile2i dest) {
+    runtime_data().active_order = e_order_move_to_tile;
+    base.destination_tile = dest;
+    advance_action(ACTION_210_WARSHIP_GOING_TO_TILE);
+    route_remove();
+}
+
+void figure_warship::move_to_wharf(int wharf_building_id, tile2i dock_tile) {
+    building *new_home = building_get(wharf_building_id);
+    if (!new_home || !new_home->is_valid()) {
+        return;
+    }
+
+    building *old_home = home();
+    if (old_home && old_home->id != wharf_building_id) {
+        old_home->remove_figure_by_id(id());
+    }
+
+    set_home(wharf_building_id);
+    new_home->set_figure(BUILDING_SLOT_BOAT, &base);
+
+    runtime_data().active_order = e_order_goto_wharf;
+    base.destination_tile = dock_tile;
+    base.source_tile = dock_tile;
+    advance_action(ACTION_207_WARSHIP_GOING_TO_WHARF);
+    route_remove();
 }

--- a/src/figuretype/figure_war_ship.h
+++ b/src/figuretype/figure_war_ship.h
@@ -10,6 +10,8 @@ enum e_warship_action {
     ACTION_207_WARSHIP_GOING_TO_WHARF = 207,
     ACTION_208_WARSHIP_GOING_TO_RANDOM = 208,
     ACTION_209_WARSHIP_ON_PATROL = 209,
+    ACTION_210_WARSHIP_GOING_TO_TILE = 210,
+    ACTION_211_WARSHIP_IDLE_AT_TILE = 211,
 };
 
 class figure_warship : public figure_impl {
@@ -21,6 +23,7 @@ public:
         e_order_hold_position,
         e_order_seek_and_destroy,
         e_order_repair,
+        e_order_move_to_tile,
         e_order_max,
     };
 
@@ -54,6 +57,9 @@ public:
 
     void figure_action_goto_wharf();
     void figure_action_common();
+
+    void move_to_tile(tile2i dest);
+    void move_to_wharf(int wharf_building_id, tile2i dock_tile);
 };
 ANK_CONFIG_STRUCT(figure_warship::order_t, id, text)
 ANK_CONFIG_STRUCT(figure_warship::static_params, orders_info)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -303,6 +303,7 @@ static int get_elapsed_ticks() {
     pcstr meaning_windows[] = {
         "window_city",
         "window_city_military",
+        "window_city_warship",
         "window_sliding_sidebar",
         "window_overlay_menu",
         "window_build_menu",
@@ -448,7 +449,7 @@ void game_t::time_init(int year) {
 
 void game_t::city_sounds_frame_begin() {
     OZZY_PROFILER_FUNCTION();
-    if (g_window_manager.window_is("window_city") || g_window_manager.window_is("window_city_military") || g_window_manager.window_is("window_sliding_sidebar")) {
+    if (g_window_manager.window_is("window_city") || g_window_manager.window_is("window_city_military") || g_window_manager.window_is("window_city_warship") || g_window_manager.window_is("window_sliding_sidebar")) {
         sound_city_play();
     }
 }

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -371,7 +371,7 @@ const cursor* input_cursor_data(cursor_shape cursor_id, cursor_scale scale) {
 }
 
 void input_cursor_update(xstring window) {
-    if (window == "window_city_military") {
+    if (window == "window_city_military" || window == "window_city_warship") {
         system_set_cursor(CURSOR_SWORD);
     } else if (window == "window_city" && g_city_planner.build_type == BUILDING_CLEAR_LAND) {
         system_set_cursor(CURSOR_SHOVEL);

--- a/src/platform/akhenaten.cpp
+++ b/src/platform/akhenaten.cpp
@@ -373,7 +373,7 @@ static void run_and_draw() {
 
             const bool main_windows
               = (g_window_manager.window_is("window_city") || g_window_manager.window_is("window_city_military")
-                 || g_window_manager.window_is("window_sliding_sidebar"));
+                 || g_window_manager.window_is("window_city_warship") || g_window_manager.window_is("window_sliding_sidebar"));
             if (!!game_features::gameui_draw_fps && main_windows) {
                 int y_offset = screen_height() - 24;
                 int y_offset_text = y_offset + 5;

--- a/src/scripts/figures.js
+++ b/src/scripts/figures.js
@@ -664,8 +664,7 @@ figure_magistrate {
 
 	category: figure_category_citizen
 	max_damage: 10
-	info_help_id:182
-    info_text_id:210
+	meta { help_id: 182, text_id: 210 }
 	terrain_usage : TERRAIN_USAGE_ROADS
 	max_roam_length : 800
 }
@@ -1517,12 +1516,12 @@ figure_warship {
 		big_image { pack:PACK_UNLOADED, id:25, offset:FIGURE_WARSHIP }
 	}
 
-	orders {
-		goto_wharf { id: 1, text: 9 }
+	orders_info {
+		goto_wharf { id: 1, text: 17 }
 		engage_nearby { id: 2, text: 11 }
-		hold_position { id: 3, text: 13 }
-		seek_and_destroy { id: 4, text: 15 }
-		repair { id: 5, text: 17 }
+		hold_position { id: 3, text: 9 }
+		seek_and_destroy { id: 4, text: 13 }
+		repair { id: 5, text: 15 }
 	}
 
 	sounds {
@@ -1539,8 +1538,7 @@ figure_warship {
 	missile_attack_value : 6
 	missile_delay : 200
 
-	info_help_id: 84,
-  info_text_id: 184,
+	meta { help_id: 84, text_id: 184 }
 	terrain_usage : TERRAIN_USAGE_ANY,
 }
 

--- a/src/scripts/ui_widgets.js
+++ b/src/scripts/ui_widgets.js
@@ -119,9 +119,9 @@ figure_warship_info_window = {
         background       : outer_panel({size: [29, 23]}),
         name             : text_center({pos: [16, 16], size: [px(27), 20], text:"${figure.class_name}", font : FONT_LARGE_BLACK_ON_DARK }),
         hullstrength_lb  : text({pos: [102, 58], text:"${184.2}" }),
-        hullstrength_val : text({pos: [202, 58], text:"" }),
+        hullstrength_val : text({pos: [232, 58], text:"" }),
         crewfatique_lb   : text({pos: [102, 88], text:"${184.27}" }),
-        crewfatique_val  : text({pos: [202, 88], text:"" }),
+        crewfatique_val  : text({pos: [232, 88], text:"" }),
 
         hold_position    : image_button({param1:3, param2:9, pos:[87 * 0 + 16, 134], pack:PACK_UNLOADED, id:37, offset:0 + 0, offset_pressed:0, offset_focused:0, border:true }),
         engage_nearby    : image_button({param1:2, param2:11, pos:[87 * 1 + 16, 134], pack:PACK_UNLOADED, id:37, offset:0 + 1, offset_pressed:0, offset_focused:0, border:true }),

--- a/src/widget/widget_city.cpp
+++ b/src/widget/widget_city.cpp
@@ -39,6 +39,12 @@
 #include "window/window_building_info.h"
 #include "window/window_city.h"
 #include "window/window_city_military.h"
+#include "window/window_city_warship.h"
+#include "figuretype/figure_war_ship.h"
+#include "building/building_warship_wharf.h"
+#include "grid/figure.h"
+#include "grid/water.h"
+#include "grid/building.h"
 #include "game/game.h"
 #include "core/threading.h"
 #include "overlays/city_overlay.h"
@@ -142,7 +148,7 @@ void update_tile_coords(vec2i pixel, tile2i tile, painter &ctx) {
 void screen_city_t::update_clouds(painter &ctx) {
     OZZY_PROFILER_FUNCTION();
 
-    if (game.paused || (!g_window_manager.window_is("window_city") && !g_window_manager.window_is("window_city_military"))) {
+    if (game.paused || (!g_window_manager.window_is("window_city") && !g_window_manager.window_is("window_city_military") && !g_window_manager.window_is("window_city_warship"))) {
         g_clouds.pause();
     }
 
@@ -1003,7 +1009,7 @@ void screen_city_t::handle_first_touch(tile2i tile) {
     e_building_type type = g_city_planner.build_type;
 
     if (touch_was_click(first)) {
-        if (handle_cancel_construction_button(first) || handle_legion_click(tile)) {
+        if (handle_cancel_construction_button(first) || handle_legion_click(tile) || handle_warship_click(tile)) {
             return;
         }
 
@@ -1170,6 +1176,111 @@ void screen_city_t::handle_input_military(const mouse *m, const hotkeys *h, int 
     }
 }
 
+bool screen_city_t::handle_warship_click(tile2i tile) {
+    if (!tile.valid()) {
+        return false;
+    }
+
+    int figure_id = map_figure_id_get(tile);
+    while (figure_id > 0) {
+        figure *f = ::figure_get(figure_id);
+        if (f->state == FIGURE_STATE_ALIVE && smart_cast<figure_warship>(f)) {
+            window_city_warship_show(figure_id);
+            return true;
+        }
+        figure_id = (figure_id != f->next_figure) ? f->next_figure : 0;
+    }
+    return false;
+}
+
+void screen_city_t::warship_map_click(int warship_figure_id, tile2i tile) {
+    if (!tile.valid()) {
+        window_city_show();
+        return;
+    }
+
+    figure *f = ::figure_get(warship_figure_id);
+    if (!f || f->state != FIGURE_STATE_ALIVE) {
+        window_city_show();
+        return;
+    }
+
+    figure_warship *w = smart_cast<figure_warship>(f);
+    if (!w) {
+        window_city_show();
+        return;
+    }
+
+    // If the click landed on a warship wharf, route there to moor.
+    int bid = map_building_at(tile);
+    if (bid > 0) {
+        building *b = ::building_get(bid);
+        if (b && b->is_valid()) {
+            building_warship_wharf *wharf = b->dcast_warship_wharf();
+            if (wharf) {
+                tile2i dock = wharf->get_water_access_tiles().point_a;
+                if (dock.valid()) {
+                    w->move_to_wharf(wharf->id(), dock);
+                    window_city_show();
+                    return;
+                }
+            }
+        }
+    }
+
+    if (!map_water_is_point_inside(tile)) {
+        window_city_show();
+        return;
+    }
+
+    w->move_to_tile(tile);
+    window_city_show();
+}
+
+void screen_city_t::handle_input_warship(const mouse *m, const hotkeys *h, int warship_figure_id) {
+    current_tile = update_city_view_coords(*m);
+
+    if (!city_view_is_sidebar_collapsed() && widget_minimap_handle_mouse(m)) {
+        return;
+    }
+
+    if (m->is_touch) {
+        const touch_t *t = get_earliest_touch();
+        if (!t->in_use) {
+            return;
+        }
+
+        handle_touch_scroll(t, true);
+    }
+
+    scroll_map(m);
+
+    if (m->right.went_up || h->escape_pressed) {
+        capture_input = false;
+        g_warning_manager.clear_all();
+        window_city_show();
+        return;
+    }
+
+    figure *f = ::figure_get(warship_figure_id);
+    if (!f || f->state != FIGURE_STATE_ALIVE || !smart_cast<figure_warship>(f)) {
+        capture_input = false;
+        window_city_show();
+        return;
+    }
+
+    current_tile = update_city_view_coords(*m);
+
+    const bool m_left_down = (!m->is_touch && m->left.went_down);
+    const auto *early_touch = get_earliest_touch();
+    const bool m_has_touch = (m->is_touch && m->left.went_up && touch_was_click(early_touch));
+
+    if (m_left_down || m_has_touch) {
+        const tile2i tile = current_tile;
+        warship_map_click(warship_figure_id, tile);
+    }
+}
+
 void screen_city_t::handle_mouse(const mouse* m) {
     current_tile = update_city_view_coords(*m);
 
@@ -1182,7 +1293,7 @@ void screen_city_t::handle_mouse(const mouse* m) {
 
     g_city_planner.draw_as_constructing = false;
     if (m->left.went_down) {
-        if (handle_legion_click(current_tile)) {
+        if (handle_legion_click(current_tile) || handle_warship_click(current_tile)) {
             return;
         }
 

--- a/src/widget/widget_city.h
+++ b/src/widget/widget_city.h
@@ -38,6 +38,9 @@ struct screen_city_t {
     tile2i update_city_view_coords(vec2i pixel);
     void handle_input_military(const mouse *m, const hotkeys *h, int legion_formation_id);
     void military_map_click(int legion_formation_id, tile2i tile);
+    bool handle_warship_click(tile2i tile);
+    void handle_input_warship(const mouse *m, const hotkeys *h, int warship_figure_id);
+    void warship_map_click(int warship_figure_id, tile2i tile);
     int input_coords_in_city(int x, int y);
 
     void draw(painter &ctx);

--- a/src/window/window_city.cpp
+++ b/src/window/window_city.cpp
@@ -142,7 +142,7 @@ void window_city_draw_foreground(int) {
     widget_sidebar_city_draw_foreground();
     widget_top_menu_draw();
 
-    if (g_window_manager.window_is("window_city") || g_window_manager.window_is("window_city_military")) {
+    if (g_window_manager.window_is("window_city") || g_window_manager.window_is("window_city_military") || g_window_manager.window_is("window_city_warship")) {
         window_city_draw_paused_and_time_left();
         draw_cancel_construction();
     }

--- a/src/window/window_city_warship.cpp
+++ b/src/window/window_city_warship.cpp
@@ -1,0 +1,37 @@
+#include "window_city_warship.h"
+
+#include "window_city.h"
+#include "city/city_warnings.h"
+#include "widget/widget_city.h"
+#include "widget/widget_minimap.h"
+#include "widget/widget_top_menu_game.h"
+#include "widget/sidebar/common.h"
+#include "widget/widget_sidebar.h"
+#include "graphics/window.h"
+#include "grid/point.h"
+
+static int selected_warship_figure_id;
+
+static void draw_foreground_warship(int) {
+    widget_top_menu_draw();
+    window_city_draw();
+    widget_sidebar_city_draw_foreground();
+    window_city_draw_paused_and_time_left();
+}
+
+void window_city_warship_show(int warship_figure_id) {
+    selected_warship_figure_id = warship_figure_id;
+
+    static window_type window = {
+        "window_city_warship",
+        window_city_draw_background,
+        draw_foreground_warship,
+        [] (auto m, auto h) {
+          window_city_handle_hotkeys(h);
+          g_screen_city.handle_input_warship(m, h, selected_warship_figure_id);
+        },
+        [] (auto c) { g_screen_city.draw_tooltip(c); }
+    };
+
+    window_show(&window);
+}

--- a/src/window/window_city_warship.h
+++ b/src/window/window_city_warship.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void window_city_warship_show(int warship_figure_id);

--- a/src/window/window_figure_warship_info.cpp
+++ b/src/window/window_figure_warship_info.cpp
@@ -1,10 +1,15 @@
 #include "window/window_figure_info.h"
+#include "window/window_city.h"
 
 #include "figuretype/figure_war_ship.h"
+#include "input/mouse.h"
+#include "graphics/image.h"
+#include "graphics/elements/button.h"
 
 struct figure_warship_info_window : public figure_info_window_t<figure_warship_info_window> {
     virtual void init(object_info &c) override;
     virtual void window_info_background(object_info &c) override;
+    virtual void window_info_foreground(object_info &c) override;
     virtual bool check(object_info &c) override {
         return !!c.figure_get<figure_warship>();
     }
@@ -13,15 +18,42 @@ struct figure_warship_info_window : public figure_info_window_t<figure_warship_i
 figure_warship_info_window figure_warship_infow;
 
 pcstr button_ids[] = { "hold_position", "engage_nearby", "seek_and_destroy", "repair", "return_to_wharf" };
+
+static int hull_strength_text_id(figure_warship *f) {
+    const int max_dmg = f->base.max_damage();
+    if (max_dmg <= 0) {
+        return 3;
+    }
+    const int health_pct = 100 - (f->base.damage * 100 / max_dmg);
+    if (health_pct >= 90) return 3; // Very strong
+    if (health_pct >= 70) return 4; // Strong
+    if (health_pct >= 50) return 5; // Good
+    if (health_pct >= 30) return 6; // Average
+    if (health_pct >= 10) return 7; // Fair
+    return 8;                        // Weak
+}
+
+static vec2i resolve_button_size(ui::eimage_button *imgbtn) {
+    if (imgbtn->size.x > 0 && imgbtn->size.y > 0) {
+        return imgbtn->size;
+    }
+    const image_t *img = image_get(imgbtn->img_desc);
+    if (img && img->width > 0 && img->height > 0) {
+        return vec2i{img->width, img->height};
+    }
+    // Fallback: button slot width is 87 in the layout, height ~60 for command buttons.
+    return vec2i{87, 60};
+}
+
 void figure_warship_info_window::init(object_info &c) {
     figure_info_window::init(c);
 
     figure_warship *f = c.figure_get<figure_warship>();
 
     for (const pcstr id : button_ids) {
-        ui[id].onclick([f, this] (int p1, int p2) {
-            const auto &params = f->params();
+        ui[id].onclick([f] (int p1, int p2) {
             f->runtime_data().active_order = p1;
+            window_city_show();
         });
     }
 }
@@ -35,13 +67,62 @@ void figure_warship_info_window::window_info_background(object_info &c) {
     ui["repair"].darkened = (f->base.damage == 0) ? UiFlags_Grayscale : UiFlags_None;
     ui["return_to_wharf"].darkened = (f->base.action_state == ACTION_203_WARSHIP_MOORED) ? UiFlags_Grayscale : UiFlags_None;
 
+    ui["hullstrength_val"].text_var("%s", ui::str(c.group_id, hull_strength_text_id(f)));
+    // Crew fatigue mechanic isn't simulated yet — display "Rested" as a placeholder.
+    ui["crewfatique_val"].text_var("%s", ui::str(c.group_id, 28));
+
+    const mouse &m = mouse::get();
+    int hovered_param1 = 0;
     for (const pcstr id : button_ids) {
         auto imgbtn = ui[id].dcast_image_button();
         imgbtn->select(order == imgbtn->param1);
+        const vec2i sz = resolve_button_size(imgbtn);
+        const vec2i btn_screen = c.offset + imgbtn->pos;
+        if (m.x >= btn_screen.x && m.x < btn_screen.x + sz.x
+            && m.y >= btn_screen.y && m.y < btn_screen.y + sz.y
+            && !hovered_param1) {
+            hovered_param1 = imgbtn->param1;
+        }
     }
 
+    // Show description for the hovered button if any, otherwise the active order's description.
+    const int display_order = hovered_param1 ? hovered_param1 : order;
     const auto &orders_info = f->current_params().orders_info;
-    auto it = std::find_if(orders_info.begin(), orders_info.end(), [order] (auto &p) { return p.second.id == order; });
-    ui["action_header"] = ui::str(c.group_id, it->second.text);
-    ui["action_text"] = ui::str(c.group_id, it->second.text + 1);
+    auto it = std::find_if(orders_info.begin(), orders_info.end(), [display_order] (auto &p) { return p.second.id == display_order; });
+    if (it != orders_info.end()) {
+        ui["action_header"].text_var("%s", ui::str(c.group_id, it->second.text));
+        ui["action_text"].text_var("%s", ui::str(c.group_id, it->second.text + 1));
+    } else if (display_order == figure_warship::e_order_move_to_tile) {
+        ui["action_header"].text_var("%s", "Moving to position");
+        ui["action_text"].text_var("%s", "The ship is sailing to the position you designated and will hold there until ordered otherwise.");
+    } else {
+        ui["action_header"].text_var("%s", "");
+        ui["action_text"].text_var("%s", "");
+    }
+}
+
+void figure_warship_info_window::window_info_foreground(object_info &c) {
+    figure_info_window::window_info_foreground(c);
+
+    // Draw a focus border around whichever order button the cursor is over.
+    // Queue via ui::push so it draws on top of the buttons during the deferred flush.
+    const mouse &m = mouse::get();
+    for (const pcstr id : button_ids) {
+        auto imgbtn = ui[id].dcast_image_button();
+        if (!imgbtn) {
+            continue;
+        }
+        const vec2i sz = resolve_button_size(imgbtn);
+        const vec2i btn_screen = c.offset + imgbtn->pos;
+        const bool over = m.x >= btn_screen.x && m.x < btn_screen.x + sz.x
+                       && m.y >= btn_screen.y && m.y < btn_screen.y + sz.y;
+        if (over) {
+            using namespace ui::opt;
+            ui::push(ui::cmd_t::button_border,
+                     Pos{btn_screen - vec2i{4, 4}},
+                     Size{sz + vec2i{8, 8}},
+                     ImgFlagsTag{ImgFlag_Alpha});
+            break;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Restores the original Pharaoh interaction that was missing from the upstream port: left-click a warship to enter control mode (cursor becomes a sword), click a water tile to send the ship there, click a warship wharf to auto-moor.
- Mirrors the existing legion control flow: new `window_city_warship` parallels `window_city_military`. Two new warship action states (`ACTION_210_WARSHIP_GOING_TO_TILE` / `ACTION_211_WARSHIP_IDLE_AT_TILE`) and a new `e_order_move_to_tile` order back the movement.
- Wires the new window into game tick / city sounds / cursor / FPS overlay / paused-HUD checks so the city continues to simulate while in control mode.
- Fixes `figures.js` metadata so the warship info window receives a non-zero `group_id` (the previous `info_help_id` / `info_text_id` keys were silently ignored — replaced with the proper `meta { help_id, text_id }` block). Same one-line cousin fix applied to `figure_magistrate`, which had the same parser-ignored keys.
- Second commit polishes the info window: populates hull-strength / crew-fatigue value text, adds hover focus borders on the order buttons (via the deferred `ui::push` queue so they render above the buttons), auto-closes on order click, and bumps label-to-value spacing in `ui_widgets.js`.

## Test plan
- [ ] Build a shipwright + warship wharf, request a warship, wait for it to moor.
- [ ] Left-click warship -> cursor turns into sword. Click far water tile -> ship sails there and idles.
- [ ] Left-click warship -> click warship wharf -> ship auto-moors.
- [ ] Right-click warship -> info window opens; hull strength and crew fatigue values are visible with proper spacing.
- [ ] Hover each order button -> focus border + description appear; clicking issues the order and closes the window.
- [ ] After issuing a left-click move-to-tile, right-click the ship -> info window shows the "Moving to position" description.
- [ ] ESC / right-click while in control mode -> cursor reverts, no movement issued.
- [ ] Confirm magistrate info window also shows text now (drive-by fix).