### PR TITLE
cartpusher: unstick carts when destination rejects on arrival

### DIFF
--- a/src/figuretype/figure_cartpusher.cpp
+++ b/src/figuretype/figure_cartpusher.cpp
@@ -92,7 +92,11 @@ void figure_cartpusher::do_deliver(bool warehouseman, int action_done, int actio
                     int total_depositable = std::min<int>(carrying, accepting);
                     
                     if (total_depositable <= 0) {
-                        advance_action(ACTION_8_RECALCULATE);
+                        if (warehouseman) {
+                            advance_action(ACTION_8_RECALCULATE);
+                        } else {
+                            determine_deliveryman_destination();
+                        }
                         return;
                     }
 
@@ -100,7 +104,11 @@ void figure_cartpusher::do_deliver(bool warehouseman, int action_done, int actio
                     if (amount != -1) {
                         dump_resource(amount_single_turn);
                     } else {
-                        advance_action(action_fail);
+                        if (warehouseman) {
+                            advance_action(action_fail);
+                        } else {
+                            determine_deliveryman_destination();
+                        }
                         return;
                     }
                 }
@@ -266,6 +274,11 @@ void figure_cartpusher::determine_deliveryman_destination() {
 
     // no one will accept
     base.min_max_seen = understaffed_storages ? 2 : 1;
+    if (++base.routing_try_reroute_counter > 5) {
+        // Give up after repeated failures — return home so the workshop can dispatch a fresh cart.
+        base.routing_try_reroute_counter = 0;
+        return advance_action(ACTION_27_CARTPUSHER_RETURNING);
+    }
     advance_action(ACTION_8_RECALCULATE);
 }
 
@@ -441,6 +454,10 @@ void figure_cartpusher::determine_storageyard_cart_destination() {
 }
 
 void figure_cartpusher::figure_before_action() {
+    if (action_state() != ACTION_8_RECALCULATE && action_state() != ACTION_20_CARTPUSHER_INITIAL) {
+        base.routing_try_reroute_counter = 0;
+    }
+
     if (has_destination()) {
         return;
     }

--- a/src/platform/discord_rpc.cpp
+++ b/src/platform/discord_rpc.cpp
@@ -446,6 +446,7 @@ ANK_FUNCTION(__discord_rpc_clear_activity)
 
 #else // defined(GAME_PLATFORM_ANDROID) || defined(GAME_PLATFORM_BROWSER)
 
+#include "core/profiler.h"
 #include "js/js_game.h"
 
 void __discord_rpc_set_activity(xstring details, xstring state) {} ANK_FUNCTION_2(__discord_rpc_set_activity)


### PR DESCRIPTION
## Summary

Fix a distribution stall where a workshop's only cart pusher gets stuck at a full storage yard / granary, occupying the workshop's cart-pusher slot and preventing further dispatch — even when other yards have space.

When `do_deliver()` finds the destination rejects the load (storage policy not accepting, or yard physically full via `add_resource() == -1`), the cart pusher used to enter `ACTION_8_RECALCULATE` and wait 30 ticks before re-running `determine_deliveryman_destination()`. If `determine_deliveryman_destination()` then also failed, it looped back to `ACTION_8_RECALCULATE` indefinitely.

Two changes in `src/figuretype/figure_cartpusher.cpp`:

- **Skip the 30-tick stall on rejection.** In `do_deliver`, on rejection by a regular cart pusher (`!warehouseman`), call `determine_deliveryman_destination()` directly so the cart immediately picks an alternate yard if one exists. Warehousemen are unchanged (their `calculate_destination` wait is only 2 ticks).
- **Give up after repeated failures.** In `determine_deliveryman_destination`, increment `routing_try_reroute_counter` (the same field already used by emigrants/homeless for the same pattern) on the no-destination-found branch. After 5 consecutive failed searches, transition to `ACTION_27_CARTPUSHER_RETURNING` instead of looping in `ACTION_8`. The cart walks home, despawns, and `building_industry::spawn_figure` dispatches a fresh cart on the next cycle with up-to-date destination info. The counter resets in `figure_before_action()` whenever the cart is not in a retry state.

## Test plan
- [ ] Build a workshop chain (e.g. timber yard → storage yards) and fill the closest yard's policy max so cart pushers get rejected on arrival; verify they immediately seek a more distant yard with space rather than idling at the rejecting yard.
- [ ] Configure all reachable yards to reject the resource (or fill them all); verify the stuck cart eventually returns home and the workshop dispatches a fresh cart once a yard becomes available, instead of staying stuck forever.
- [ ] Spot-check normal (no-rejection) deliveries to confirm no regression in the happy path.
- [ ] Confirm warehouseman / granaryman behavior is unchanged.