### PR TITLE
fix(industry): workshops never consumed their inputs

### DIFF
--- a/src/building/building.cpp
+++ b/src/building/building.cpp
@@ -442,7 +442,7 @@ bool building::workshop_has_resources() {
     verify_no_crash(is_workshop());
     bool has_second_material = true;
     if (input.resource_second != RESOURCE_NONE) {
-        has_second_material = (stored_amount(input.resource_second) > 100);
+        has_second_material = (stored_amount(input.resource_second) >= 100);
     }
 
     bool hase_first_resource = (stored_amount(input.resource) >= 100);

--- a/src/building/building_impl.cpp
+++ b/src/building/building_impl.cpp
@@ -251,9 +251,9 @@ const auto& get_properties() {
         { tags().building, tags().output_resource, [] (building &b, const xstring &) { return bvariant(resource_name(b.output.resource)); }},
         { tags().building, tags().second_output_resource, [] (building &b, const xstring &) { return bvariant(resource_name(b.output.resource_second)); }},
         { tags().building, tags().first_material, [] (building &b, const xstring &) { return bvariant(resource_name(b.input.resource)); }},
-        { tags().building, tags().first_material_stored, [] (building &b, const xstring &) { return bvariant(b.stored_first().value); }},
+        { tags().building, tags().first_material_stored, [] (building &b, const xstring &) { return bvariant(b.stored_amount(b.input.resource)); }},
         { tags().building, tags().second_material, [] (building &b, const xstring &) { return bvariant(resource_name(b.input.resource_second)); }},
-        { tags().building, tags().second_material_stored, [] (building &b, const xstring &) { return bvariant(b.stored_second().value); }},
+        { tags().building, tags().second_material_stored, [] (building &b, const xstring &) { return bvariant(b.stored_amount(b.input.resource_second)); }},
         { tags().farm, tags().fertility, [] (building &b, const xstring &) { return bvariant(map_get_fertility_for_farm(b.tile.grid_offset())); }},
     };
     return bproperties;

--- a/src/building/building_industry.cpp
+++ b/src/building/building_industry.cpp
@@ -95,6 +95,10 @@ void building_industry::update_production() {
     auto &d = runtime_data();
     // d.has_raw_materials = false;
 
+    if (d.progress == 0) {
+        return;
+    }
+
     if (g_city.resource.is_mothballed(base.output.resource)) {
         return;
     }

--- a/src/city/city_industry.cpp
+++ b/src/city/city_industry.cpp
@@ -218,7 +218,7 @@ void building_curse_farms(int big_curse) {
 void building_workshop_add_raw_material(building* b, int amount, e_resource res) {
     if (b->id > 0 && b->is_workshop() && b->need_resource(res)) {
         if (b->input.resource == res || b->input.resource_second == res) {
-            b->store_resource(b->input.resource, amount);
+            b->store_resource(res, amount);
         } else {
             verify_no_crash(false);
         }

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -46,10 +46,10 @@ brickworks_info_window {
         warning_text  : text({pos[32, 58], wrap:px(26), font : FONT_NORMAL_BLACK_ON_LIGHT, multiline:true })
 
         resource_icon : resource_icon({pos[32, 205], prop:"${building.first_material}" })
-        resource_stored : text({pos[55, 210], size[px(27), 20], text:"${text.14} ${building.first_material_stored}", font:FONT_NORMAL_BLACK_ON_LIGHT })
+        resource_stored : text({pos[55, 210], size[px(27), 20], text:"${text.13} ${building.first_material_stored}", font:FONT_NORMAL_BLACK_ON_LIGHT })
 
         resource_icon_b : resource_icon({pos: [32, 225], prop:"${building.second_material}" })
-        resource_stored_b : text({pos[55, 230], size[px(27), 20], text:"${text.13} ${building.second_material_stored}", font:FONT_NORMAL_BLACK_ON_LIGHT })
+        resource_stored_b : text({pos[55, 230], size[px(27), 20], text:"${text.14} ${building.second_material_stored}", font:FONT_NORMAL_BLACK_ON_LIGHT })
     })
 }
 


### PR DESCRIPTION
## Summary

`industry.update_production` (the daily progress increment) runs at simtick 20, before `update_day` fires at end-of-day where `start_production` lives. After a cycle finished and progress reset to 0, the next day's `update_production` would tick progress past 0 before `update_day` got a chance to call `start_production` — so inputs were **never consumed** but output kept being produced. Workshops were running for free.

Gating the daily increment behind `progress > 0` means it only fires after `start_production` has set progress to 1 and consumed the inputs. The cycle now flows correctly: `progress=0` → `start_production` consumes inputs → progress increments daily until max → `production_finished` stores output and resets to 0 → repeat.

Affects every production building (brewery, weaver, weaponsmith, papyrus, pottery, lamps, paint, jewels, chariots, brickworks).

Bundled in are four related fixes surfaced while debugging brickworks specifically:

- `building_workshop_add_raw_material` was storing every delivery as `input.resource` regardless of which resource was actually delivered, so straw deliveries to a brickworks landed in the clay slot and clay accumulated past the 200 cap.
- `workshop_has_resources` used `> 100` for the second input vs `>= 100` for the first — inconsistent with `start_production` which uses `>= 100` for both.
- `first_material_stored` / `second_material_stored` bvariant accessors read storage slots `[0]` / `[1]` instead of looking up by resource type, so the brickworks panel could show one resource's count under the other resource's label.
- Brickworks UI panel labels were swapped (`text.13` / `text.14`).

## Test plan

- [ ] Build a brickworks with clay pit + grain farm + storage yard supply.
- [ ] Confirm clay and straw arrive and stay capped at 200 each.
- [ ] Confirm both counters drop by 100 each at the start of every production cycle.
- [ ] Confirm bricks are produced and exported to a storage yard.
- [ ] Spot-check brewery / weaver / pottery / weaponsmith / papyrus also still consume their inputs.
- [ ] Confirm extractors (clay pit, mines, quarries) still produce normally — they pass through the same gate but have no inputs to consume.