### PR TITLE
fix(ui): scribal-school workers_desc lookup path

### DIFF
--- a/src/scripts/ui_scribal_school_window.js
+++ b/src/scripts/ui_scribal_school_window.js
@@ -37,5 +37,5 @@ function scribal_school_info_window_init(window) {
         reason.id = 3
     }
 
-    window.inner_panel.workers_desc.text = __loc(reason.group, reason.id)
+    window.workers_desc.text = __loc(reason.group, reason.id)
 }


### PR DESCRIPTION
## Summary

`scribal_school_info_window_init` was reading the `workers_desc` element via `window.inner_panel.workers_desc`, but the element is a direct child of the window (no `inner_panel` wrapper), so the lookup failed and the workers reason text never rendered.

## Test plan

- [ ] Click on a Scribal School in-game
- [ ] Confirm the info panel shows the correct workers description text (instead of being blank)