### PR TITLE
cleanup(city/floods): drop dead init writes

### DIFF
--- a/src/city/city_floods.cpp
+++ b/src/city/city_floods.cpp
@@ -30,7 +30,6 @@ declare_console_command_p(startflood) {
 }
 
 void floods_t::init() {
-    flood_progress = 0;
     unk01 = 0;
     state = FLOOD_STATE_FARMABLE;
     floodplain_width = 0;
@@ -326,9 +325,4 @@ io_buffer* iob_floodplain_settings = new io_buffer([](io_buffer* iob, size_t ver
     iob->bind____skip(1);
     iob->bind(BIND_SIGNATURE_UINT8, &data.quality_last);
     iob->bind____skip(3);
-
-    data.flood_progress = 30;
-    data.unk00 = 0;
-    data.state = FLOOD_STATE_FARMABLE;
-    data.floodplain_width = 10;
 });


### PR DESCRIPTION
## Summary

Two dead-code removals in `src/city/city_floods.cpp`:

- `floods_t::init()` was setting `flood_progress = 0`, but `flood_progress` has an in-class initializer of `30` at `city_floods.h:28`. The `0` write contradicted the canonical reset value used elsewhere in the file (`flood_progress == 30` means fully flooded, the reset cycles all run on 30 not 0).
- The `iob_floodplain_settings` io_buffer lambda wrote hardcoded values (`flood_progress = 30`, `state = FLOOD_STATE_FARMABLE`, etc.) **after** the bind/skip calls. On load, those writes clobbered the just-loaded save data with constants. Loaded values are now preserved.

No behavior change on fresh game start (in-class initializers cover the defaults). Fix is for save/load round-trip.

## Test plan

- [ ] Save a city mid-flood, reload, confirm flood progress and state are preserved instead of resetting to constants
- [ ] Start a new city — flood cycle still triggers normally on the first season transition