### PR TITLE
feat(config): add gameopt_disable_victory flag

### DIFF
--- a/src/city/victory.cpp
+++ b/src/city/victory.cpp
@@ -209,6 +209,10 @@ void city_t::victory_check() {
         victory_state.state = e_victory_state_lost;
     }
 
+    if (game_features::gameopt_disable_victory.to_bool()) {
+        return;
+    }
+
     if (victory_state.state != e_victory_state_none) {
         g_city_planner.reset();
         if (victory_state.state == e_victory_state_lost) {

--- a/src/game/game_config.cpp
+++ b/src/game/game_config.cpp
@@ -125,6 +125,7 @@ namespace game_features {
     game_feature gameopt_fullscreen{ "gameopt_fullscreen", "", true };
     game_feature gameopt_difficulty{ "gameopt_difficulty", "", 2.0f };
     game_feature gameopt_display_size{"gameopt_display_size", "", vec2i(1280, 800)};
+    game_feature gameopt_disable_victory{ "gameopt_disable_victory", "", false };
 
     xspan<game_feature*> all() {
         return { _features.data(), _features.size() };

--- a/src/game/game_config.h
+++ b/src/game/game_config.h
@@ -145,6 +145,7 @@ namespace game_features {
     extern game_feature gameopt_fullscreen;
     extern game_feature gameopt_difficulty;
     extern game_feature gameopt_display_size;
+    extern game_feature gameopt_disable_victory;
 
     xspan<game_feature*> all();
     game_feature* find(const xstring& name);

--- a/src/game/tutorial_debug.cpp
+++ b/src/game/tutorial_debug.cpp
@@ -9,6 +9,7 @@
 #include "scenario/scenario.h"
 #include "game/mission.h"
 #include "city/victory.h"
+#include "game/game_config.h"
 #include "scenario/criteria.h"
 
 ANK_REGISTER_PROPS_ITERATOR(config_show_tutorial_properties);
@@ -74,6 +75,17 @@ void config_show_tutorial_properties(bool header) {
         game_debug_show_property("victory_state", state_text);
         game_debug_show_property("force_win", g_city.victory_state.force_win);
         game_debug_show_property("force_lost", g_city.victory_state.force_lost);
+        {
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+            ImGui::TextUnformatted("disable_victory");
+            ImGui::TableNextColumn();
+            bool v = game_features::gameopt_disable_victory.to_bool();
+            if (ImGui::Checkbox("##disable_victory", &v)) {
+                game_features::gameopt_disable_victory.set(v);
+                game_features::save();
+            }
+        }
 
         if (winning_population() > 0) {
             bstring64 label;


### PR DESCRIPTION
## Summary

Adds a new `game_features` flag, `gameopt_disable_victory`, that suppresses the post-victory branch of `city_t::victory_check`:

- The would-be `victory_state.state` is still computed (so other systems can read it), but the planner reset / end-game UI path is skipped.
- Useful for endless / sandbox play, where the player wants to keep building past the mission's win/lose thresholds.

A checkbox is also added to the tutorial debug overlay (`config_show_tutorial_properties` in `tutorial_debug.cpp`) so the flag can be toggled at runtime alongside the existing `victory_state` / `force_win` / `force_lost` properties.

## Test plan

- [ ] Toggle `disable_victory` on in the debug overlay
- [ ] Trigger victory conditions in a mission — confirm the win screen / planner reset does NOT fire
- [ ] Toggle off — confirm the next victory check fires the end-game branch normally
- [ ] Save/load round-trip preserves the flag value