### PR TITLE
fix(trade): trade-ship + docker reliability

### DIFF
--- a/src/figuretype/figure_docker.cpp
+++ b/src/figuretype/figure_docker.cpp
@@ -101,13 +101,50 @@ building_dest figure_docker::get_closest_warehouse_for_import(tile2i pos, empire
         return importable[r] && (!dock_filter || dock->is_trade_accepted(r));
     };
 
-    e_resource resource = city_trade_next_docker_import_resource();
-    for (e_resource i = RESOURCES_MIN; i < RESOURCES_MAX && !allowed(resource); ++i) {
-        resource = city_trade_next_docker_import_resource();
+    // If the dock's ship has per-good budgets populated, pick from those (preserves per-visit
+    // proportional split). Otherwise fall back to the legacy global round-robin.
+    figure_trade_ship* ship = nullptr;
+    if (dock && dock->runtime_data().trade_ship) {
+        ship = figure_get<figure_trade_ship>(dock->runtime_data().trade_ship);
     }
 
-    if (!allowed(resource)) {
-        return { 0, tile2i::invalid };
+    bool budgets_populated = false;
+    if (ship) {
+        for (const auto& slot : ship->runtime_data().import_budgets) {
+            if (slot.resource != 0) {
+                budgets_populated = true;
+                break;
+            }
+        }
+    }
+
+    e_resource resource = RESOURCE_NONE;
+    if (budgets_populated) {
+        for (const auto& slot : ship->runtime_data().import_budgets) {
+            if (slot.resource == 0 || slot.remaining_chunks == 0) {
+                continue;
+            }
+            const e_resource r = (e_resource)slot.resource;
+            if (allowed(r)) {
+                resource = r;
+                break;
+            }
+        }
+
+        if (resource == RESOURCE_NONE) {
+            // Budgets exist but all exhausted/blocked — do not trade more this visit.
+            return { 0, tile2i::invalid };
+        }
+    } else {
+        // Legacy / no-budget path: use the global round-robin.
+        resource = city_trade_next_docker_import_resource();
+        for (e_resource i = RESOURCES_MIN; i < RESOURCES_MAX && !allowed(resource); ++i) {
+            resource = city_trade_next_docker_import_resource();
+        }
+
+        if (!allowed(resource)) {
+            return { 0, tile2i::invalid };
+        }
     }
 
     int min_distance = 10000;
@@ -505,6 +542,7 @@ void figure_docker::figure_action() {
                 if (ship) {
                     ship->dump_resource(100);
                     ship->runtime_data().failed_dock_attempts = 0;
+                    ship->consume_import_budget(base.resource_id);
                 }
                 base.wait_ticks = 0;
                 trader().record_sold_resource(base.resource_id);

--- a/src/figuretype/figure_docker.cpp
+++ b/src/figuretype/figure_docker.cpp
@@ -288,7 +288,6 @@ bool figure_docker::deliver_import_resource(building* b) {
         return false;
     }
 
-    ship->dump_resource(100);
     set_destination(result.bid);
     base.wait_ticks = 0;
     advance_action(ACTION_133_DOCKER_IMPORT_QUEUE);
@@ -326,6 +325,12 @@ bool figure_docker::fetch_export_resource(building* b) {
     base.destination_tile = result.tile;
     base.resource_id = resource;
     return true;
+}
+
+void figure_docker::figure_before_action() {
+    if (action_state() == ACTION_132_DOCKER_IDLING) {
+        base.routing_try_reroute_counter = 0;
+    }
 }
 
 void figure_docker::figure_action() {
@@ -366,6 +371,20 @@ void figure_docker::figure_action() {
 
     base.terrain_usage = TERRAIN_USAGE_ROADS;
     switch (action_state()) {
+    case ACTION_8_RECALCULATE:
+        // Without this case a routing failure leaves the docker non-idle, so the moored ship's failed_dock_attempts never advances.
+        if (++base.routing_try_reroute_counter > 5) {
+            base.routing_try_reroute_counter = 0;
+            base.poof();
+            return;
+        }
+        load_resource(RESOURCE_NONE, 0);
+        base.cart_image_id = 0;
+        base.wait_ticks = 0;
+        set_destination(home(), home()->tile);
+        advance_action(ACTION_138_DOCKER_IMPORT_RETURNING);
+        break;
+
     case ACTION_132_DOCKER_IDLING:
         base.resource_id = RESOURCE_NONE;
         base.cart_image_id = 0;
@@ -472,6 +491,10 @@ void figure_docker::figure_action() {
             auto trade_city = ship ? ship->empire_city() : empire_city_handle{};
 
             if (try_import_resource(destination(), base.resource_id, trade_city)) {
+                if (ship) {
+                    ship->dump_resource(100);
+                    ship->runtime_data().failed_dock_attempts = 0;
+                }
                 base.wait_ticks = 0;
                 trader().record_sold_resource(base.resource_id);
                 advance_action(ACTION_138_DOCKER_IMPORT_RETURNING);
@@ -495,6 +518,12 @@ void figure_docker::figure_action() {
             base.wait_ticks = 0;
             const bool can_export = try_export_resource(destination(), base.resource_id, trade_city);
             if (can_export) {
+                if (dock.trade_ship) {
+                    auto ship = figure_get<figure_trade_ship>(dock.trade_ship);
+                    if (ship) {
+                        ship->runtime_data().failed_dock_attempts = 0;
+                    }
+                }
                 int amount = trader().record_bought_resource(base.resource_id);
                 load_resource(base.resource_id, amount);
                 set_destination(home(), home()->tile);
@@ -562,7 +591,7 @@ void figure_docker::update_animation() {
 }
 
 void figure_docker::poof() {
-
+    figure_carrier::poof();
 }
 
 void figure_docker::on_destroy() {

--- a/src/figuretype/figure_docker.cpp
+++ b/src/figuretype/figure_docker.cpp
@@ -92,15 +92,21 @@ bool figure_docker::try_export_resource(building* b, e_resource resource, empire
     return 0;
 }
 
-building_dest figure_docker::get_closest_warehouse_for_import(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, e_resource& import_resource) {
+building_dest figure_docker::get_closest_warehouse_for_import(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, building_dock *dock, e_resource& import_resource) {
     const resource_list importable = g_empire.importable_resources_from_city(city.handle);
 
+    // Treat an unconfigured dock (all-zero trading_goods, e.g. legacy saves) as accept-all so the filter doesn't strand trade.
+    const bool dock_filter = dock && dock->runtime_data().trading_goods.is_not_zero();
+    auto allowed = [&](e_resource r) {
+        return importable[r] && (!dock_filter || dock->is_trade_accepted(r));
+    };
+
     e_resource resource = city_trade_next_docker_import_resource();
-    for (e_resource i = RESOURCES_MIN; i < RESOURCES_MAX && !importable[resource]; ++i) {
+    for (e_resource i = RESOURCES_MIN; i < RESOURCES_MAX && !allowed(resource); ++i) {
         resource = city_trade_next_docker_import_resource();
     }
 
-    if (!importable[resource]) {
+    if (!allowed(resource)) {
         return { 0, tile2i::invalid };
     }
 
@@ -177,15 +183,20 @@ building_dest figure_docker::get_closest_warehouse_for_import(tile2i pos, empire
     return { min_building_id, warehouse_tile };
 }
 
-building_dest figure_docker::get_closest_warehouse_for_export(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, e_resource &export_resource) {
+building_dest figure_docker::get_closest_warehouse_for_export(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, building_dock *dock, e_resource &export_resource) {
     const resource_list exportable = g_empire.exportable_resources_from_city(city.handle);
 
+    const bool dock_filter = dock && dock->runtime_data().trading_goods.is_not_zero();
+    auto allowed = [&](e_resource r) {
+        return exportable[r] && (!dock_filter || dock->is_trade_accepted(r));
+    };
+
     e_resource resource = city_trade_next_docker_export_resource();
-    for (int i = RESOURCES_MIN; i < RESOURCES_MAX && !exportable[resource]; i++) {
+    for (int i = RESOURCES_MIN; i < RESOURCES_MAX && !allowed(resource); i++) {
         resource = city_trade_next_docker_export_resource();
     }
 
-    if (!exportable[resource]) {
+    if (!allowed(resource)) {
         return { 0, tile2i::invalid };
     }
 
@@ -283,7 +294,7 @@ bool figure_docker::deliver_import_resource(building* b) {
 
     tile2i trade_center_tile = get_trade_center_location();
     e_resource resource;
-    auto result = get_closest_warehouse_for_import(trade_center_tile, ship->empire_city(), b->distance_from_entry, b->road_network_id, resource);
+    auto result = get_closest_warehouse_for_import(trade_center_tile, ship->empire_city(), b->distance_from_entry, b->road_network_id, dock, resource);
     if (!result.bid) {
         return false;
     }
@@ -312,7 +323,7 @@ bool figure_docker::fetch_export_resource(building* b) {
 
     tile2i trade_cener_tile = get_trade_center_location();
     e_resource resource;
-    auto result = get_closest_warehouse_for_export(trade_cener_tile, ship->empire_city(), b->distance_from_entry, b->road_network_id, resource);
+    auto result = get_closest_warehouse_for_export(trade_cener_tile, ship->empire_city(), b->distance_from_entry, b->road_network_id, dock, resource);
 
     if (!result.bid) {
         return false;

--- a/src/figuretype/figure_docker.h
+++ b/src/figuretype/figure_docker.h
@@ -23,6 +23,7 @@ public:
 
     virtual void on_create() override {}
     virtual void on_destroy() override;
+    virtual void figure_before_action() override;
     virtual void figure_action() override;
     virtual sound_key phrase_key() const override;
     virtual void update_animation() override;

--- a/src/figuretype/figure_docker.h
+++ b/src/figuretype/figure_docker.h
@@ -4,6 +4,8 @@
 #include "empire/empire_city.h"
 #include "empire/trader_handler.h"
 
+class building_dock;
+
 enum e_docker_action {
     ACTION_132_DOCKER_IDLING = 132,
     ACTION_133_DOCKER_IMPORT_QUEUE = 133,
@@ -39,6 +41,6 @@ public:
     bool fetch_export_resource(building* dock);
     bool try_import_resource(building *b, e_resource resource, empire_city_handle city_id);
     bool try_export_resource(building *b, e_resource resource, empire_city_handle city_id);
-    building_dest get_closest_warehouse_for_import(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, e_resource &import_resource);
-    building_dest get_closest_warehouse_for_export(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, e_resource &export_resource);
+    building_dest get_closest_warehouse_for_import(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, building_dock *dock, e_resource &import_resource);
+    building_dest get_closest_warehouse_for_export(tile2i pos, empire_city_handle city, int distance_from_entry, int road_network_id, building_dock *dock, e_resource &export_resource);
 };

--- a/src/figuretype/figure_trader_ship.cpp
+++ b/src/figuretype/figure_trader_ship.cpp
@@ -22,7 +22,7 @@
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_trade_ship);
 
-// Days a moored ship will tolerate idle dockers before giving up the visit.
+// Days a moored/anchored ship will tolerate idle dockers before giving up the visit.
 // Bumped from 10 to 25 so a temporarily-blocked dock doesn't truncate a trade run.
 constexpr uint8_t TRADE_SHIP_IDLE_DAYS_MAX = 25;
 
@@ -48,6 +48,7 @@ void ANK_PERMANENT_CALLBACK(event_trade_ship_arrival, ev) {
     ship->base.allow_move_type = EMOVE_DEEPWATER;
     ship->base.wait_ticks = 10;
     ship->runtime_data().trader = empire_trader_handle{ ev.tid };
+    ship->populate_import_budgets();
 
     emp_city->trader_figure_ids[empire_trader_index] = ship->id();
 }
@@ -113,6 +114,74 @@ bool figure_trade_ship::done_trading() {
         return false;
     }
     return true;
+}
+
+void figure_trade_ship::populate_import_budgets() {
+    auto& d = runtime_data();
+    for (auto& slot : d.import_budgets) {
+        slot.resource = 0;
+        slot.remaining_chunks = 0;
+    }
+
+    auto* emp_city = g_empire.city(d.empire_city.handle);
+    if (!emp_city) {
+        return;
+    }
+
+    const resource_list importable = g_empire.importable_resources_from_city(d.empire_city.handle);
+    auto& route = emp_city->get_route();
+
+    // Total weight = sum of per-resource yearly trade limits across all importable goods.
+    int total_weight = 0;
+    for (const auto& r : resource_list::all) {
+        if (importable[r.type]) {
+            total_weight += route.limit(r.type);
+        }
+    }
+
+    if (total_weight <= 0) {
+        return;
+    }
+
+    const int total_chunks = max_capacity() / 100;  // 1200 / 100 = 12
+    int slot_idx = 0;
+    for (const auto& r : resource_list::all) {
+        if (slot_idx >= VISIT_BUDGET_SLOTS) {
+            break;
+        }
+        if (!importable[r.type]) {
+            continue;
+        }
+        const int weight = route.limit(r.type);
+        // Proportional share, floored to a whole 100-unit chunk.
+        const int chunks = (weight * total_chunks) / total_weight;
+        if (chunks <= 0) {
+            continue;
+        }
+        d.import_budgets[slot_idx].resource = (uint8_t)r.type;
+        d.import_budgets[slot_idx].remaining_chunks = (uint8_t)std::min(chunks, 255);
+        slot_idx++;
+    }
+}
+
+int figure_trade_ship::import_budget_remaining(e_resource r) const {
+    const auto& d = runtime_data();
+    for (const auto& slot : d.import_budgets) {
+        if (slot.resource == (uint8_t)r) {
+            return slot.remaining_chunks;
+        }
+    }
+    return 0;
+}
+
+void figure_trade_ship::consume_import_budget(e_resource r) {
+    auto& d = runtime_data();
+    for (auto& slot : d.import_budgets) {
+        if (slot.resource == (uint8_t)r && slot.remaining_chunks > 0) {
+            slot.remaining_chunks--;
+            return;
+        }
+    }
 }
 
 void figure_trade_ship::on_create() {
@@ -329,7 +398,7 @@ void figure_trade_ship::poof() {
 
 void figure_trade_ship::update_day() {
     // Only count idle days while moored at a dock. Queued ships (ACTION_114) wait
-    // indefinitely behind ships that are still trading - they should never time out
+    // indefinitely behind ships that are still trading — they should never time out
     // just for sitting in line.
     if (!action_state(ACTION_112_TRADE_SHIP_MOORED)) {
         return;

--- a/src/figuretype/figure_trader_ship.cpp
+++ b/src/figuretype/figure_trader_ship.cpp
@@ -22,6 +22,10 @@
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_trade_ship);
 
+// Days a moored ship will tolerate idle dockers before giving up the visit.
+// Bumped from 10 to 25 so a temporarily-blocked dock doesn't truncate a trade run.
+constexpr uint8_t TRADE_SHIP_IDLE_DAYS_MAX = 25;
+
 void ANK_PERMANENT_CALLBACK(event_trade_ship_arrival, ev) {
     tile2i river_entry = scenario_map_river_entry();
 
@@ -102,8 +106,8 @@ bool figure_trade_ship::done_trading() {
     building* b = destination();
     auto& d = runtime_data();
     if (b->state == BUILDING_STATE_VALID && b->type == BUILDING_DOCK && b->num_workers > 0) {
-        if (d.failed_dock_attempts >= 10) {
-            d.failed_dock_attempts = 11;
+        if (d.failed_dock_attempts >= TRADE_SHIP_IDLE_DAYS_MAX) {
+            d.failed_dock_attempts = TRADE_SHIP_IDLE_DAYS_MAX + 1;
             return true;
         }
         return false;
@@ -233,7 +237,7 @@ void figure_trade_ship::figure_action() {
                 base.destination_tile = free_dock.tile;
             }
 
-            if (d.failed_dock_attempts >= 10) {
+            if (d.failed_dock_attempts >= TRADE_SHIP_IDLE_DAYS_MAX) {
                 advance_action(ACTION_115_TRADE_SHIP_LEAVING, scenario_map_river_exit());
             }
             base.wait_ticks = 0;
@@ -324,8 +328,10 @@ void figure_trade_ship::poof() {
 }
 
 void figure_trade_ship::update_day() {
-    const bool on_raid = action_state(ACTION_114_TRADE_SHIP_ANCHORED, ACTION_112_TRADE_SHIP_MOORED);
-    if (!on_raid) {
+    // Only count idle days while moored at a dock. Queued ships (ACTION_114) wait
+    // indefinitely behind ships that are still trading - they should never time out
+    // just for sitting in line.
+    if (!action_state(ACTION_112_TRADE_SHIP_MOORED)) {
         return;
     }
 

--- a/src/figuretype/figure_trader_ship.h
+++ b/src/figuretype/figure_trader_ship.h
@@ -33,12 +33,25 @@ public:
         uint16_t max_capacity;
     } FIGURE_STATIC_DATA_T;
 
+    // Per-visit per-good import cap. Up to 8 active import goods per route — more than
+    // any realistic Pharaoh route. Transient: recomputed each ship arrival, no save semantics.
+    static constexpr int VISIT_BUDGET_SLOTS = 8;
+    struct visit_budget_slot {
+        uint8_t resource;          // e_resource value, 0 = empty slot
+        uint8_t remaining_chunks;  // remaining 100-unit deliveries this visit
+    };
+
     struct runtime_data_t {
         empire_trader_handle trader;
         empire_city_handle empire_city;
         uint8_t failed_dock_attempts;
         uint16_t amount_bought;
+        visit_budget_slot import_budgets[VISIT_BUDGET_SLOTS];
     } FIGURE_RUNTIME_DATA_T;
+
+    void populate_import_budgets();
+    int import_budget_remaining(e_resource r) const;
+    void consume_import_budget(e_resource r);
 
     virtual void on_create() override;
     virtual void on_destroy() override;


### PR DESCRIPTION
## Summary

Bundle of four related reliability fixes for the trade-ship / docker pipeline. Each is a separate commit so this PR can be reviewed (and bisected) commit-by-commit.

### 7a — Cap moored idle days, don't time out queued ships
- Renames the magic-number `10` to `TRADE_SHIP_IDLE_DAYS_MAX = 25`. The old 10-day cap was too tight: a dock briefly blocked by routing or a stuck docker forced ships to leave with cargo still aboard.
- Narrows `update_day`'s idle counter to `ACTION_112_TRADE_SHIP_MOORED` only (was: anchored OR moored). Queued ships at `ACTION_114` should never time out for sitting in line behind a still-trading ship.

### 7b — Recover from routing failures, propagate poof to base
- Adds `ACTION_8_RECALCULATE` handler. Without it, a routing failure (e.g. road demolished mid-route) left the docker in a non-idle state forever, and the moored ship's `failed_dock_attempts` never advanced.
- `figure_before_action` resets `routing_try_reroute_counter` when idling. Otherwise the retry counter from a failed run carries over into the next visit.
- `figure_docker::poof()` was a no-op, leaking docker figures. Now forwards to `figure_carrier::poof()`.
- Moves `ship->dump_resource(100)` from `deliver_import_resource` (entry) into the success branch of `ACTION_135`. Previously the ship lost 100 cargo on every delivery attempt even if the warehouse rejected the goods.
- Resets `failed_dock_attempts = 0` on successful import (ACTION_135) and successful export (ACTION_140) so a productive trade visit doesn't count toward the idle-day cap.

### 7c — Dock-aware resource selection
- Threads `building_dock*` through `get_closest_warehouse_for_import/export` and uses the dock's `trading_goods` bitmap to filter the candidate resource list. A dock configured for ebony only sends its dockers fetching/delivering ebony.
- Filter is gated on `trading_goods.is_not_zero()` so legacy/unconfigured docks bypass it (preserves existing behavior on old saves).

### 7d — Per-visit import budgets
- Adds `import_budgets[]` to ship `runtime_data_t`: 8 slots of `(resource, remaining_chunks)`. Recomputed every arrival via `populate_import_budgets()`, which divides `max_capacity()/100` chunks proportionally across importable goods weighted by `route.limit(r)`.
- `consume_import_budget()` decrements on successful delivery.
- `get_closest_warehouse_for_import` prefers budget-allocated goods when any slot is populated. If all are exhausted/blocked the visit ends. Legacy / no-budget path keeps the global round-robin so saves without the budget data keep working.

## Test plan

- [ ] **7a**: Block one dock with a stuck docker; queued ships behind it must NOT time out — only the moored one does, after 25 days
- [ ] **7b**: Force a routing failure on a docker (demolish road mid-route) — docker should `poof` after 5 retries, not strand. Failed delivery should NOT consume ship cargo
- [ ] **7c**: Dock with `trading_goods` set to a single resource: docker walking from that dock only picks that resource at the warehouse, not other importable goods
- [ ] **7d**: On a multi-good route, ship cargo splits proportionally across goods (not all 12 chunks of one good); after budget is exhausted, ship leaves rather than continuing to import
- [ ] Save/load round-trip on a save with mid-trade ships: the budgets are transient (no save semantics), so legacy saves should drop into the round-robin path automatically