### PR TITLE
fix(monuments): replace C3 peace stub with Pharaoh sqrt-weighted formula

### DIFF
--- a/src/city/city_buildings_js.cpp
+++ b/src/city/city_buildings_js.cpp
@@ -213,6 +213,12 @@ int __building_at(int x, int y) {
 }
 ANK_FUNCTION_2(__building_at)
 
+int __building_type(int bid) {
+    building *b = building_get(bid);
+    return (b && b->is_valid()) ? (int)b->type : 0;
+}
+ANK_FUNCTION_1(__building_type)
+
 bvariant __map_grid_get_area(tile2i tile, int size, int radius) {
     return bvariant(map_grid_get_area(tile2i(tile), size, radius));
 }

--- a/src/city/city_js.cpp
+++ b/src/city/city_js.cpp
@@ -18,14 +18,8 @@
 
 #include "city/city_population.h"
 
-void __city_ratings_apply_monument_yearly(int new_monument, int new_years_of_monument, int monument_explanation_reason) {
-    g_city.ratings.monument = new_monument;
-    g_city.ratings.monument_years_of_monument = new_years_of_monument;
-    g_city.ratings.monument_num_criminals = 0;
-    g_city.ratings.monument_num_rioters = 0;
-    g_city.ratings.monument_destroyed_buildings = 0;
-}
-ANK_FUNCTION_3(__city_ratings_apply_monument_yearly)
+void __city_ratings_set_monument(int new_value) { g_city.ratings.monument = new_value; }
+ANK_FUNCTION_1(__city_ratings_set_monument)
 
 int __city_rating_kingdom() { return g_city.kingdome.rating; }
 ANK_FUNCTION(__city_rating_kingdom)

--- a/src/scripts/city_monuments.js
+++ b/src/scripts/city_monuments.js
@@ -1,46 +1,66 @@
 log_info("akhenaten: city_monuments.js started")
 
+var MONUMENT_WEIGHTS = {}
+MONUMENT_WEIGHTS[BUILDING_PYRAMID]            = 80
+MONUMENT_WEIGHTS[BUILDING_SPHINX]             = 60
+MONUMENT_WEIGHTS[BUILDING_MAUSOLEUM]          = 30
+MONUMENT_WEIGHTS[BUILDING_ALEXANDRIA_LIBRARY] = 35
+MONUMENT_WEIGHTS[BUILDING_CAESAREUM]          = 35
+MONUMENT_WEIGHTS[BUILDING_PHAROS_LIGHTHOUSE]  = 60
+MONUMENT_WEIGHTS[BUILDING_SMALL_ROYAL_TOMB]   = 15
+MONUMENT_WEIGHTS[BUILDING_ABU_SIMBEL]         = 120
+MONUMENT_WEIGHTS[BUILDING_MEDIUM_ROYAL_TOMB]  = 30
+MONUMENT_WEIGHTS[BUILDING_LARGE_ROYAL_TOMB]   = 50
+MONUMENT_WEIGHTS[BUILDING_GRAND_ROYAL_TOMB]   = 80
+
+var MONUMENT_RATING_MULT = 6.32
+var MONUMENT_RATING_OFFSET = 0.5
+
 [es=event_advance_month]
-function city_update_yearly_monument_rating(ev) {
-	if (ev.month != 0) {
+function city_update_monthly_monument_rating(ev) {
+	var n = __city_monuments_list_refresh()
+	if (n == 0) {
+		__city_ratings_set_monument(0)
 		return
 	}
-	var y = city.rating.monument_years_of_monument
-	var ncr = city.rating.monument_num_criminals
-	var nri = city.rating.monument_num_rioters
-	var db = city.rating.monument_destroyed_buildings
-	var m = city.rating.monument
 
-	var change = y < 2 ? 2 : 5
-	if (ncr) {
-		change -= 1
-	}
-	if (nri) {
-		change -= 5
-	}
-	if (db) {
-		change -= db
-	}
+	var sum = 0
+	for (var i = 0; i < n; i++) {
+		var bid = __city_monuments_list_id_at(i)
+		if (!bid) {
+			continue
+		}
+		var bt = __building_type(bid)
+		var w = MONUMENT_WEIGHTS[bt]
+		if (!w) {
+			continue
+		}
+		var phase = __building_monument_phase_code(bid)
+		var phases = __building_monument_phases_total(bid)
+		var mat = __building_monument_material_pct_min(bid)
 
-	var new_years = (nri || db) ? 0 : (y + 1)
+		var progress = 0
+		if (phase == -1) {
+			progress = 100
+		} else if (phases > 0) {
+			progress = ((phase - 1) * 100 + mat) / phases
+			if (progress < 0) {
+				progress = 0
+			}
+			if (progress > 100) {
+				progress = 100
+			}
+		}
 
-	var city_pop = city.population
-	var max_pop_limit = city_pop < 4000 ? city_pop : 4000
-	var cap_part = (max_pop_limit / 1000) | 0
-	if (cap_part < 1) {
-		cap_part = 1
-	}
-	var monument_ratings_cap = cap_part * 25
-
-	var new_m = m + change
-	if (new_m < 0) {
-		new_m = 0
-	}
-
-	if (new_m > monument_ratings_cap) {
-		new_m = monument_ratings_cap
+		sum += (w * progress) / 100
 	}
 
-	var expl = city.rating.get_monument_explanation()
-	__city_ratings_apply_monument_yearly(new_m, new_years, expl)
+	var rating = MONUMENT_RATING_MULT * Math.sqrt(sum) + MONUMENT_RATING_OFFSET
+	if (rating < 0) {
+		rating = 0
+	}
+	if (rating > 100) {
+		rating = 100
+	}
+	__city_ratings_set_monument(rating | 0)
 }


### PR DESCRIPTION
Fixes #486

## Summary

Monument rating was running the old Caesar 3 Peace logic (yearly +2/+5, global criminal/rioter/destroyed penalties, population cap) mechanically renamed by `efb80aa0ea` four years ago. After PR #448 made the handler actually fire monthly, the dormant C3 path became visible: rating grew unbounded with no monument in the city.

Reverse-engineered the real Pharaoh logic from `Pharaoh.exe` (`FUN_0046ef50` → `FUN_004f78a0`) via Ghidra. Reimplemented the formula in JS with a monthly tick:

```
rating = clamp(6.32 * sqrt(Σ weight × progress% / 100) + 0.5, 0, 100)
```

Weights live in a JS table; per-monument progress comes from `phase()` + `material_pct_min` accessors that were already exposed.

## Changes

- `src/city/city_buildings_js.cpp`: new binding `__building_type(bid)` (needed for weight lookup).
- `src/city/city_js.cpp`: replaced the C3-peace stub `__city_ratings_apply_monument_yearly(int, int, int)` with a clean setter `__city_ratings_set_monument(int)`. Legacy peace fields (`monument_num_criminals/rioters/destroyed_buildings/years_of_monument`) stay zeroed in the struct for save-compat; they no longer feed the formula.
- `src/scripts/city_monuments.js`: rewritten — subscribed to `event_advance_month` (no `month==0` gate), iterates monuments via the existing `__city_monuments_list_*` API, computes the sqrt-weighted formula via `Math.sqrt`.

3 files, +62/-42.

## Weights

Empirical, in JS table:

```
PYRAMID=80, SPHINX=60, MAUSOLEUM=30, ALEXANDRIA_LIBRARY=35, CAESAREUM=35,
PHAROS_LIGHTHOUSE=60, SMALL_ROYAL_TOMB=15, ABU_SIMBEL=120,
MEDIUM_ROYAL_TOMB=30, LARGE_ROYAL_TOMB=50, GRAND_ROYAL_TOMB=80
```

The exact original weights live at `DAT_005d19d4` in `Pharaoh.exe`, indexed via scenario-init metadata at `DAT_00ea5fa0`. Extracting them would need another RE pass; the values above approximate the expected balance and can be tuned in JS without touching C++.

## Not in scope

- Completion-bonus path (`FUN_004f7cc6`/`FUN_004f7cdb` in `Pharaoh.exe`) — not decompiled, not in this formula.
- `monument_record_criminal/rioter/destroyed` callsites in `city_crime.cpp:58/81`, `figure_robber.cpp:131`, `city_maintenance.cpp:82` — kept as no-op consumers of the legacy fields. Could be cleaned in a follow-up PR.
- `update_monument_explanation` (the old C3 peace 10/30/60/90/100 bands) — left alone, separate concern.

## Verification

- Behdet save (mission 6, no monument, year 2664 BC): rating **35 → 0** on the first monthly tick, stable at 0 across 10+ game years.
- macOS arm64 RelWithDebInfo build, with and without `--mixed`.
- Build clean (`ninja akhenaten` 1006/1006).