### PR TITLE
fix(ui): top-menu Options/Help/Overseers labels were blank

### DIFF
--- a/src/scripts/localization_en.js
+++ b/src/scripts/localization_en.js
@@ -1207,6 +1207,12 @@ localization_en = [
 
   { key: "#top_menu_file", text: "File" }
   { key: "#top_menu_file_tooltip", text: "Load, save, new game and exit" }
+  { key: "#top_menu_options", text: "Options" }
+  { key: "#top_menu_options_tooltip", text: "Display, sound, speed and difficulty options" }
+  { key: "#top_menu_overseers", text: "Overseers" }
+  { key: "#top_menu_overseers_tooltip", text: "Open advisors" }
+  { key: "#top_menu_help", text: "Help" }
+  { key: "#top_menu_help_tooltip", text: "Help, about, warnings, tooltip mode" }
 
   { key: "#sidebar_speed_header", text: "Speed" }
   { key: "#no_requests", text: "There are no requests outstanding at the moment." }

--- a/src/scripts/ui_top_menu_widget.js
+++ b/src/scripts/ui_top_menu_widget.js
@@ -68,9 +68,9 @@ top_menu_widget {
 
 	headers {
 		file 			: menu_header({text: "${loc.top_menu_file}", tooltip: "${loc.top_menu_file_tooltip}" })
-		options			: menu_header({text {group:2, id:0}, tooltip[68, 52] })
-		help		   	: menu_header({text {group:3, id:0}, tooltip[68, 53] })
-		advisors  		: menu_header({text {group:4, id:0}, onclick: top_menu_open_advisor })
+		options			: menu_header({text: "${loc.top_menu_options}", tooltip: "${loc.top_menu_options_tooltip}" })
+		help		   	: menu_header({text: "${loc.top_menu_help}", tooltip: "${loc.top_menu_help_tooltip}" })
+		advisors  		: menu_header({text: "${loc.top_menu_overseers}", tooltip: "${loc.top_menu_overseers_tooltip}", onclick: top_menu_open_advisor })
 		debug		   	: menu_header({text: "Debug" })
 		debug_render  	: menu_header({text: "Render" })
 	}


### PR DESCRIPTION
## Summary
- Migrate the `options`, `help`, and `advisors` (Overseers) headers in `ui_top_menu_widget.js` from binary `{group:N, id:0}` lang refs to JS localization, mirroring the existing `file` header pattern.
- Add matching `#top_menu_options*`, `#top_menu_help*`, and `#top_menu_overseers*` entries in `localization_en.js`.

The three header labels were resolving through the binary `lang_text` data at `group:N id:0`, which Pharaoh's original C3 lang file does not populate — menu headers were hardcoded in the original. Only "File" rendered because it was already migrated to JS-loc.

The dropdown items themselves are unchanged — they reference `{group:N, id:1+}` which already resolves correctly.

## Test plan
- [ ] Top bar shows File | Options | Overseers | Help
- [ ] Hovering each header shows the tooltip
- [ ] Clicking each header opens its dropdown; items still dispatch