### PR TITLE
fix(io): create save folder before write; surface failures to UI

### DIFF
--- a/src/io/gamestate/boilerplate.cpp
+++ b/src/io/gamestate/boilerplate.cpp
@@ -629,6 +629,7 @@ bool GamestateIO::write_mission(const int scenario_id) {
 
 bool GamestateIO::write_savegame(pcstr filename_short) {
     vfs::path full = fullpath_saves(filename_short);
+    vfs::create_folders(vfs::content_path(fullpath_saves("").c_str()));
 
     // write file
     e_file_format format = get_format_from_file(filename_short);

--- a/src/scripts/ui_file_dialog_save.js
+++ b/src/scripts/ui_file_dialog_save.js
@@ -94,7 +94,11 @@ function file_dialog_save_handle_commit(ev) {
     var normalized = file_dialog_save_basename_from_list_entry(source_name)
     var pending = file_dialog_save.pending_type
     if (pending === FILE_TYPE_SAVED_GAME) {
-        game.write_savegame(normalized + ".svx")
+        var ok = game.write_savegame(normalized + ".svx")
+        if (!ok) {
+            log_info("[savedlg] write_savegame failed for '" + normalized + ".svx'")
+            return
+        }
         ui.window_city_show()
         __set_last_loaded_utf8(FILE_TYPE_SAVED_GAME, normalized)
     } else if (pending === FILE_TYPE_SCENARIO) {


### PR DESCRIPTION
## Summary
- `GamestateIO::write_savegame` now calls `vfs::create_folders(fullpath_saves(""))` before `FILEIO.serialize`, matching the existing pattern in `player_data_prepare_savegame` (`src/game/player.cpp`).
- `file_dialog_save_handle_commit` captures the bool return from `game.write_savegame`; on false, logs `[savedlg] write_savegame failed for '<name>.svx'` and leaves the dialog open instead of silently returning to the city view.

## Background
The save dialog refactor in 40770fb15 routed manual saves through `GamestateIO::write_savegame`, which (unlike `player_data_prepare_savegame`) does not create the parent directory. This made manual saves into a fresh dynasty fail with `Unable to write file, file could not be accessed`. Monthly autosave often appeared to "work" because it ran after some prior call had already created the directory; manual saves without that prior step failed.

## Test plan
- [ ] Manual Save → Save Game writes the file under `Save/<player>/`
- [ ] The new file appears in the Load list
- [ ] Monthly autosave still writes successfully
- [ ] If write fails (e.g. forced read-only dir), dialog stays open and the log records the failure