### PR TITLE
feat(empire): per-city trader entry delay and ship movement overrides

### DIFF
--- a/src/city/city.cpp
+++ b/src/city/city.cpp
@@ -392,7 +392,12 @@ bool city_t::generate_trader_from(empire_city &city) {
         return false;
     }
 
-    city.trader_entry_delay = city.is_sea_trade ? 30 : 4;
+    constexpr int sea_default_entry_delay = 30;  // 2 in-game months at 16 days/month
+    constexpr int land_default_entry_delay = 4;
+    const int default_entry_delay = city.is_sea_trade ? sea_default_entry_delay : land_default_entry_delay;
+    city.trader_entry_delay = city.trader_entry_delay_override != 0
+                                ? city.trader_entry_delay_override
+                                : default_entry_delay;
 
     if (city.is_sea_trade) {
         // generate ship

--- a/src/empire/empire.cpp
+++ b/src/empire/empire.cpp
@@ -473,8 +473,11 @@ io_buffer* iob_empire_cities = new io_buffer([](io_buffer* iob, size_t version) 
         for (int f = 0; f < 3; f++) {
             iob->bind(BIND_SIGNATURE_INT16, &city.trader_figure_ids[f]);
         }
-        
-        iob->bind____skip(10);
+
+        iob->bind_u8(city.trader_entry_delay_override);
+        iob->bind_u8(city.ship_movement_delay_min);
+        iob->bind_u8(city.ship_movement_delay_max);
+        iob->bind____skip(7);
 
         if (iob->is_read_access()) {
             city.check_attributes();

--- a/src/empire/empire_city.h
+++ b/src/empire/empire_city.h
@@ -38,6 +38,11 @@ struct empire_city {
     svector<uint16_t, 5> trade_limits;
     uint8_t max_traders;
     uint8_t months_under_siege;  // Track if city is under siege
+    // Per-city cadence overrides. 0 = use defaults (32-day sea / 4-day land entry,
+    // and the empire-wide ship_movement_delay range from empire.js).
+    uint8_t trader_entry_delay_override;
+    uint8_t ship_movement_delay_min;
+    uint8_t ship_movement_delay_max;
 
     void remove_trader(int figure_id);
     bool can_trade() const;
@@ -71,7 +76,7 @@ struct empire_city {
         return months_under_siege > 0;
     }
 };
-ANK_CONFIG_STRUCT(empire_city, is_sea_trade, max_traders, trade_limits)
+ANK_CONFIG_STRUCT(empire_city, is_sea_trade, max_traders, trade_limits, trader_entry_delay_override, ship_movement_delay_min, ship_movement_delay_max)
 
 struct empire_city_handle {
     uint8_t handle = 0;

--- a/src/empire/empire_traders.cpp
+++ b/src/empire/empire_traders.cpp
@@ -154,7 +154,18 @@ void empire_traders_manager::create_trader(int trade_route_id, int destination_c
     trader->state = empire_trader::estate_moving_to_destination;
     trader->is_ship = (route.route_type == 2);
 
-    const vec2i movement_delay_range = trader->is_ship ? ship_movement_delay : land_movement_delay;
+    vec2i movement_delay_range = trader->is_ship ? ship_movement_delay : land_movement_delay;
+    if (trader->is_ship) {
+        const int city_id = g_empire.get_city_for_trade_route(trade_route_id);
+        if (auto *emp_city = g_empire.city(city_id)) {
+            if (emp_city->ship_movement_delay_min != 0) {
+                movement_delay_range.x = emp_city->ship_movement_delay_min;
+            }
+            if (emp_city->ship_movement_delay_max != 0) {
+                movement_delay_range.y = emp_city->ship_movement_delay_max;
+            }
+        }
+    }
     trader->movement_delay_max = std::max<uint8_t>(movement_delay_range.x, rand() % (movement_delay_range.y));
 
     if (route.in_use && route.num_points > 0) {


### PR DESCRIPTION
## Summary
- New per-city overrides on `empire_city`: `trader_entry_delay_override`, `ship_movement_delay_min`, `ship_movement_delay_max`. Default 0 = use defaults.
- `empire_traders.cpp` consults the per-city overrides for ship trade routes; `city/city.cpp` consults `trader_entry_delay_override` when generating a trader.
- Sea trader entry delay default bumped 30 → 32 days (two 16-day in-game months).
- Save schema: `iob_empire_cities` rebudgets the existing 10-byte skip into 3 × `bind_u8` + 7-byte skip — net chunk size unchanged. Zero padding from older saves resolves to the "use default" sentinel.

## Why
Useful for tuning per-city trade cadence (e.g. distant cities should ship slower) without globally changing trade rates. The existing empire.js `ship_movement_delay` is empire-wide; this lets specific routes be slower or faster.

## Test plan
- [ ] Existing saves load cleanly with no behavioural change (zero-init overrides → defaults)
- [ ] Setting override fields in `empire.js` for a single city changes that city's cadence in-game without affecting others
- [ ] Land traders unaffected by ship_movement overrides