### PR TITLE
polish(ui): refine top-menu header tooltip wording

### DIFF
--- a/src/scripts/localization_en.js
+++ b/src/scripts/localization_en.js
@@ -1208,11 +1208,11 @@ localization_en = [
   { key: "#top_menu_file", text: "File" }
   { key: "#top_menu_file_tooltip", text: "Load, save, new game and exit" }
   { key: "#top_menu_options", text: "Options" }
-  { key: "#top_menu_options_tooltip", text: "Display, sound, speed and difficulty options" }
-  { key: "#top_menu_overseers", text: "Overseers" }
-  { key: "#top_menu_overseers_tooltip", text: "Open advisors" }
+  { key: "#top_menu_options_tooltip", text: "Display, sound, speed and difficulty settings" }
   { key: "#top_menu_help", text: "Help" }
-  { key: "#top_menu_help_tooltip", text: "Help, about, warnings, tooltip mode" }
+  { key: "#top_menu_help_tooltip", text: "Get help, hints and information about the game" }
+  { key: "#top_menu_overseers", text: "Advisors" }
+  { key: "#top_menu_overseers_tooltip", text: "Consult your advisors about the state of the city" }
 
   { key: "#sidebar_speed_header", text: "Speed" }
   { key: "#no_requests", text: "There are no requests outstanding at the moment." }


### PR DESCRIPTION
Follow-up to #488 (already merged).

## Summary
- `#top_menu_options_tooltip`: "...difficulty options" → "...difficulty **settings**"
- `#top_menu_help_tooltip`: "Help, about, warnings, tooltip mode" → "**Get help, hints and information about the game**"
- `#top_menu_overseers`: "Overseers" → "**Advisors**" (the in-game term used elsewhere)
- `#top_menu_overseers_tooltip`: "Open advisors" → "**Consult your advisors about the state of the city**"

The internal loc key `#top_menu_overseers` is preserved so nothing else needs to change. The header in `ui_top_menu_widget.js` still references `${loc.top_menu_overseers}`.

## Test plan
- [ ] Top bar still shows File | Options | Advisors | Help
- [ ] Hover each header → tooltip wording matches the new strings