### PR TITLE
dev(qconsole): click-to-copy lines, multi-select, toolbar controls

### DIFF
--- a/src/dev/imgui_qconsole.cpp
+++ b/src/dev/imgui_qconsole.cpp
@@ -30,9 +30,54 @@ namespace dev {
 
 
     void IMGUIOstream::render() {
+        const ImGuiIO &io = ImGui::GetIO();
+        int line_idx = -1;
         for (const ConsoleBuf::Line &line : strb.getLines()) {
+            ++line_idx;
             if (!linePassFilter(line))
                 continue;
+
+            // Wrap each line in a Selectable for click-to-copy + multi-select.
+            // The Selectable provides hover highlight + click capture; the colored text is
+            // overlaid on top using TextColored after resetting the cursor.
+            const bool is_selected = selected_lines.count(line_idx) > 0;
+
+            ImVec2 line_start = ImGui::GetCursorPos();
+            ImGui::PushID(line_idx);
+            const bool clicked = ImGui::Selectable("##cl", is_selected, 0, ImVec2(0, ImGui::GetTextLineHeight()));
+            ImGui::PopID();
+
+            if (clicked) {
+                if (io.KeyShift && last_clicked_idx >= 0) {
+                    // Shift+Click: replace selection with a contiguous range from anchor to here.
+                    selected_lines.clear();
+                    const int lo = std::min(last_clicked_idx, line_idx);
+                    const int hi = std::max(last_clicked_idx, line_idx);
+                    for (int i = lo; i <= hi; ++i) {
+                        selected_lines.insert(i);
+                    }
+                } else if (io.KeyCtrl) {
+                    // Ctrl+Click: toggle this line in/out of the selection.
+                    if (is_selected) {
+                        selected_lines.erase(line_idx);
+                    } else {
+                        selected_lines.insert(line_idx);
+                    }
+                    last_clicked_idx = line_idx;
+                } else {
+                    // Plain click: replace selection with just this line.
+                    selected_lines.clear();
+                    selected_lines.insert(line_idx);
+                    last_clicked_idx = line_idx;
+                }
+
+                const std::string sel = getSelectionText();
+                if (!sel.empty()) {
+                    ImGui::SetClipboardText(sel.c_str());
+                }
+            }
+
+            ImGui::SetCursorPos(line_start);
 
             for (const ConsoleBuf::TextSequence &seq : line.sequences) {
                 if (seq.style.hasBackgroundColor) {
@@ -52,6 +97,34 @@ namespace dev {
         if ((autoScrollEnabled && shouldScrollToBottom) || (autoScrollEnabled && ImGui::GetScrollY() >= ImGui::GetScrollMaxY()))
             ImGui::SetScrollHereY(1.0f);
         shouldScrollToBottom = false;
+    }
+
+    std::string IMGUIOstream::getAllText() const {
+        std::string result;
+        for (const ConsoleBuf::Line &line : strb.getLines()) {
+            if (!linePassFilter(line))
+                continue;
+            for (const ConsoleBuf::TextSequence &seq : line.sequences) {
+                result += seq.text;
+            }
+            result += '\n';
+        }
+        return result;
+    }
+
+    std::string IMGUIOstream::getSelectionText() const {
+        std::string result;
+        const auto &lines = strb.getLines();
+        for (int idx : selected_lines) {
+            if (idx < 0 || idx >= (int)lines.size()) {
+                continue;
+            }
+            for (const ConsoleBuf::TextSequence &seq : lines[idx].sequences) {
+                result += seq.text;
+            }
+            result += '\n';
+        }
+        return result;
     }
 
     imgui_qconsole::imgui_qconsole() {
@@ -81,6 +154,19 @@ namespace dev {
 
         ImGui::Begin(title, &p_open, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize);
         ImGui::SetWindowFontScale(fontScale);
+
+        if (ImGui::SmallButton("Copy All")) {
+            const std::string all_text = os.getAllText();
+            if (!all_text.empty()) {
+                ImGui::SetClipboardText(all_text.c_str());
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::SmallButton("Clear")) {
+            os.Clear();
+        }
+        ImGui::SameLine();
+        ImGui::Checkbox("Auto-scroll", &os.autoScrollEnabled);
 
         // Reserve enough left-over height for 1 separator + 1 input text
         const float footer_height_to_reserve = ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing();

--- a/src/dev/imgui_qconsole.h
+++ b/src/dev/imgui_qconsole.h
@@ -2,6 +2,7 @@
 
 #include <unordered_set>
 #include <algorithm>
+#include <set>
 #include <vector>
 
 //dependencies
@@ -205,7 +206,16 @@ class IMGUIOstream : public std::ostream
     bool autoScrollEnabled = true;
     bool shouldScrollToBottom = false;
 
-    inline void Clear() { strb.clear(); } ///< clear the output pane
+    /// Indices (into strb.getLines()) of currently selected lines for multi-select copy.
+    std::set<int> selected_lines;
+    /// Anchor index for shift+click range selection.
+    int last_clicked_idx = -1;
+
+    inline void Clear() {
+        strb.clear();
+        selected_lines.clear();
+        last_clicked_idx = -1;
+    } ///< clear the output pane
 
     inline IMGUIOstream() : std::ostream(&strb) {}
 
@@ -214,6 +224,12 @@ class IMGUIOstream : public std::ostream
 
     /// Renders the control in whatever the surrounding IMGUI context is.
     void render();
+
+    /// Returns all log lines (passing the current filter) as plain text, newline-separated.
+    std::string getAllText() const;
+
+    /// Returns currently-selected lines as plain text, newline-separated. Empty if no selection.
+    std::string getSelectionText() const;
     
     inline void applyDefaultStyle(){strb.applyDefaultStyle();}
     inline ConsoleBuf::FormattingParams& defaultStyle(){return strb.defaultStyle;}


### PR DESCRIPTION
## Summary
Quality-of-life improvements to the in-game ImGui console output pane:

- **Click-to-copy:** plain click on a log line selects it and copies its text to the clipboard.
- **Multi-select:** `Shift+Click` extends a contiguous range from the anchor; `Ctrl+Click` toggles individual lines. Each selection change re-copies the selected text.
- **Toolbar:** `Copy All` (copies every line currently passing the filter), `Clear` (also clears the selection state), and an `Auto-scroll` checkbox that exposes the existing flag.

Implementation overlays each line in a thin `ImGui::Selectable` for hover/click capture, then resets the cursor and renders the colored `TextSequence` on top — so highlighting and color rendering both work without a custom widget.

## Test plan
- [ ] Open the dev console, click a single line — text appears in clipboard, line highlights.
- [ ] `Shift+Click` another line — contiguous range selected and copied.
- [ ] `Ctrl+Click` an unselected line — added to selection; click again — removed.
- [ ] `Copy All` copies all visible (filter-passing) lines.
- [ ] `Clear` empties the pane and resets the selection.
- [ ] `Auto-scroll` toggle still pins the view to the bottom on new output when on.

## Note
PR #454 (\"expand migration/sentiment bindings and qconsole controls\") was previously closed. This PR is intentionally narrower — it only adds copy/select UX on the existing output pane, with no new bindings or commands.