### PR TITLE
i18n: translate top-menu Options/Help/Overseers strings (de, ru, ru_f)

### DIFF
--- a/src/scripts/localization_de.js
+++ b/src/scripts/localization_de.js
@@ -1185,6 +1185,12 @@ localization_de = [
 
   { key: "#top_menu_file", text: "Datei" }
   { key: "#top_menu_file_tooltip", text: "Neues Spiel, Laden, Speichern, Spiel beenden" }
+  { key: "#top_menu_options", text: "Optionen" }
+  { key: "#top_menu_options_tooltip", text: "Anzeige, Ton, Geschwindigkeit und Schwierigkeit" }
+  { key: "#top_menu_help", text: "Hilfe" }
+  { key: "#top_menu_help_tooltip", text: "Hilfe, Hinweise und Informationen zum Spiel" }
+  { key: "#top_menu_overseers", text: "Berater" }
+  { key: "#top_menu_overseers_tooltip", text: "Berater zum Zustand der Stadt befragen" }
 
   { key: "#sidebar_speed_header", text: "Geschwindigkeit" }
 ]

--- a/src/scripts/localization_ru.js
+++ b/src/scripts/localization_ru.js
@@ -458,6 +458,12 @@ localization_ru = [
 
     { key: "#top_menu_file", text: "Файл" }
     { key: "#top_menu_file_tooltip", text: "Загрузить, сохранить, начать новую игру и выйти" }
+    { key: "#top_menu_options", text: "Параметры" }
+    { key: "#top_menu_options_tooltip", text: "Настройки экрана, звука, скорости и сложности" }
+    { key: "#top_menu_help", text: "Помощь" }
+    { key: "#top_menu_help_tooltip", text: "Справка, подсказки и сведения об игре" }
+    { key: "#top_menu_overseers", text: "Советники" }
+    { key: "#top_menu_overseers_tooltip", text: "Обратиться к советникам о состоянии города" }
 
     { key: "#sidebar_speed_header", text: "Скорость" }
 

--- a/src/scripts/localization_ru_f.js
+++ b/src/scripts/localization_ru_f.js
@@ -457,6 +457,12 @@ localization_ru_f = [
 
     { key: "#top_menu_file", text: "Файл" }
     { key: "#top_menu_file_tooltip", text: "Загрузить, сохранить, начать новую игру и выйти" }
+    { key: "#top_menu_options", text: "Параметры" }
+    { key: "#top_menu_options_tooltip", text: "Настройки экрана, звука, скорости и сложности" }
+    { key: "#top_menu_help", text: "Помощь" }
+    { key: "#top_menu_help_tooltip", text: "Справка, подсказки и сведения об игре" }
+    { key: "#top_menu_overseers", text: "Советники" }
+    { key: "#top_menu_overseers_tooltip", text: "Обратиться к советникам о состоянии города" }
 
     { key: "#sidebar_speed_header", text: "Скорость" }
 


### PR DESCRIPTION
## Summary
Follow-up to #491. Adds the German and Russian translations for the top-menu header strings (`#top_menu_options`, `#top_menu_help`, `#top_menu_overseers`) and their tooltips, which were introduced in EN by #488 and refined in #491 but were never translated for the other languages.

| Key | de | ru / ru_f |
|---|---|---|
| `#top_menu_options` | Optionen | Параметры |
| `#top_menu_options_tooltip` | Anzeige, Ton, Geschwindigkeit und Schwierigkeit | Настройки экрана, звука, скорости и сложности |
| `#top_menu_help` | Hilfe | Помощь |
| `#top_menu_help_tooltip` | Hilfe, Hinweise und Informationen zum Spiel | Справка, подсказки и сведения об игре |
| `#top_menu_overseers` | Berater | Советники |
| `#top_menu_overseers_tooltip` | Berater zum Zustand der Stadt befragen | Обратиться к советникам о состоянии города |

(`localization_ru_f.js` gets the same strings as `localization_ru.js` — these strings don't have grammatical-gender variants.)

## Test plan
- [ ] Launch with `--language de` → top bar reads `Datei | Optionen | Berater | Hilfe`; tooltips in German.
- [ ] Launch with `--language ru` → top bar reads `Файл | Параметры | Советники | Помощь`; tooltips in Russian.
- [ ] Launch with `--language ru_f` → same Russian tooltips render.