### PR TITLE
feat(config): add gameui_disable_nilometer_popups to suppress flood-prediction popups

### DIFF
--- a/src/city/city_floods.cpp
+++ b/src/city/city_floods.cpp
@@ -12,6 +12,7 @@
 #include "city_message.h"
 #include "dev/debug.h"
 #include "game/game.h"
+#include "game/game_config.h"
 
 #include <cmath>
 
@@ -216,6 +217,10 @@ void floods_t::update_next_flood_params() {
 
 void floods_t::post_flood_prediction_message() {
     if (g_scenario.env.hide_nilometer) {
+        return;
+    }
+
+    if (game_features::gameui_disable_nilometer_popups.to_bool()) {
         return;
     }
 

--- a/src/game/game_config.cpp
+++ b/src/game/game_config.cpp
@@ -127,6 +127,7 @@ namespace game_features {
     game_feature gameopt_display_size{"gameopt_display_size", "", vec2i(1280, 800)};
     game_feature gameopt_disable_victory{ "gameopt_disable_victory", "", false };
     game_feature gameopt_player_name{"gameopt_player_name", "", ""};
+    game_feature gameui_disable_nilometer_popups{ "gameui_disable_nilometer_popups", "#TR_CONFIG_DISABLE_NILOMETER_POPUPS", false };
 
     xspan<game_feature*> all() {
         return { _features.data(), _features.size() };

--- a/src/game/game_config.h
+++ b/src/game/game_config.h
@@ -147,6 +147,7 @@ namespace game_features {
     extern game_feature gameopt_display_size;
     extern game_feature gameopt_disable_victory;
     extern game_feature gameopt_player_name;
+    extern game_feature gameui_disable_nilometer_popups;
 
     xspan<game_feature*> all();
     game_feature* find(const xstring& name);

--- a/src/scripts/localization_en.js
+++ b/src/scripts/localization_en.js
@@ -104,6 +104,7 @@ localization_en = [
   {key:"#TR_CONFIG_CARTPUSHERS_YIELD_BY_ID", text:"Cartpushers yield goods by worker ID"}
   {key:"#TR_CONFIG_REBALANCE_WORKSHOP_OUTPUT", text:"Workshop output scales with difficulty"}
   {key:"#TR_CONFIG_PREVENT_DELETE_NEAR_BURNING_RUINS", text:"Prevent deleting buildings near burning ruins"}
+  {key:"#TR_CONFIG_DISABLE_NILOMETER_POPUPS", text:"Disable nilometer flood prediction pop-ups"}
   {key:"#TR_CONFIG_HEADER_SCENARIO_CHANGES", text:"Change scenarios"}
   {key:"#TR_CONFIG_HEADER_RESOURCES", text:"Change resources"}
   {key:"#TR_CONFIG_ANIMALS", text:"Change animals"}


### PR DESCRIPTION
## Summary
Adds a new optional `gameui_disable_nilometer_popups` setting (off by default) that suppresses the flood-quality popup raised by `floods_t::post_flood_prediction_message`.

When enabled, the early-return runs **after** the existing `g_scenario.env.hide_nilometer` check (so scenario authors that already hide the nilometer keep their behavior), and **before** any `messages::popup` is dispatched — so none of the five quality popups (`message_perfect_inundation` … `message_poor_inundation` / drought) appear.

## Why
Players who run scenarios where flood quality is consistent or who simply find the seasonal popup interruptive can opt out without affecting any underlying simulation logic. The flood quality is still computed and applied — only the message dialog is skipped.

## Files
- `src/city/city_floods.cpp` — `#include "game/game_config.h"` + early-return guard in `post_flood_prediction_message`
- `src/game/game_config.{cpp,h}` — flag declaration/definition (default `false`)
- `src/scripts/localization_en.js` — `#TR_CONFIG_DISABLE_NILOMETER_POPUPS` label

## Test plan
- [ ] Default (flag off): nilometer popup still appears at the start of each flood-prediction window.
- [ ] Flag on (set in `akhenaten.conf` or via in-game enhanced settings): no popup appears at the prediction time; flood quality still applies as normal.
- [ ] Toggling the flag mid-game and waiting through the next prediction window respects the new value.
- [ ] Scenarios with `g_scenario.env.hide_nilometer` already true behave the same as before.

No game-logic changes — gating is purely on the popup dispatch.