### PR TITLE
fix(housing): residence devolve rendering, vacant-lot splits, missing-pack variants, road-overrun

### DIFF
--- a/src/building/building_house.cpp
+++ b/src/building/building_house.cpp
@@ -379,6 +379,8 @@ void building_house::add_population(int num_people) {
     base.remove_figure(2);
 }
 
+static void split_size2(building* b, e_building_type new_type);
+
 void building_house::change_to(building &b, e_building_type new_type, bool force) {
     auto &d = *(building_house::runtime_data_t*)b.runtime_data;
 
@@ -386,6 +388,16 @@ void building_house::change_to(building &b, e_building_type new_type, bool force
     const int absolute_day = game.simtime.absolute_day(true);
     const bool can_update = (absolute_day - d.last_update_day < house_update_delay);
     if (!force && (house_update_delay > 0 && (new_type > b.type) && can_update)) {
+        return;
+    }
+
+    // Repair corrupted state: a 1x1 hut/cottage/apartment-tier type sitting on
+    // a 2x2 footprint without is_merged is invalid (older saves can carry this
+    // from a prior change_to that downgraded type without splitting). Split
+    // back into 4 individual tiles instead of repainting the bad state.
+    const bool target_is_1x1_tier = (new_type >= BUILDING_HOUSE_CRUDE_HUT && new_type <= BUILDING_HOUSE_SPACIOUS_APARTMENT);
+    if (target_is_1x1_tier && b.size == 2 && !d.is_merged) {
+        split_size2(&b, new_type);
         return;
     }
 
@@ -398,7 +410,7 @@ void building_house::change_to(building &b, e_building_type new_type, bool force
     const auto &house_params = get_house_params(new_type);
     if (house->is_merged()) {
         const size_t max_anims = house_params.variants_merged.data.size();
-        const size_t rand_anim = rand() % max_anims;        
+        const size_t rand_anim = rand() % max_anims;
         auto anim_it = house_params.variants_merged.data.begin();
         std::advance(anim_it, rand_anim);
         d.image_key = anim_it->first;
@@ -1203,10 +1215,20 @@ void building_house::on_destroy() {
 void building_house::on_post_load() {
     building_impl::on_post_load();
 
+    auto &d = runtime_data();
+
+    // Repair pre-fix corrupt state: a 1x1-tier type on a 2x2 non-merged
+    // footprint can persist from saves that hit the old Common Residence
+    // devolve bug. Split before re-binding tiles or hunting for the image_key.
+    const bool target_is_1x1_tier = (base.type >= BUILDING_HOUSE_CRUDE_HUT && base.type <= BUILDING_HOUSE_SPACIOUS_APARTMENT);
+    if (target_is_1x1_tier && base.size == 2 && !d.is_merged) {
+        split_size2(&base, base.type);
+        return;
+    }
+
     const int imgid = map_image_at(tile());
     map_building_tiles_add(id(), tile(), size(), imgid, TERRAIN_BUILDING);
 
-    auto &d = runtime_data();
     const auto &house_params = get_house_params(base.type);
     if (d.image_key.empty()) {
         const auto &variants = house_params.variants.data;

--- a/src/building/building_house.cpp
+++ b/src/building/building_house.cpp
@@ -408,20 +408,25 @@ void building_house::change_to(building &b, e_building_type new_type, bool force
     int image_id = house_image_group<false>(house->house_level());
 
     const auto &house_params = get_house_params(new_type);
-    if (house->is_merged()) {
-        const size_t max_anims = house_params.variants_merged.data.size();
-        const size_t rand_anim = rand() % max_anims;
-        auto anim_it = house_params.variants_merged.data.begin();
-        std::advance(anim_it, rand_anim);
-        d.image_key = anim_it->first;
-        image_id = anim_it->second.first_img();
-    } else {
-        const size_t max_anims = house_params.variants.data.size();
-        const size_t rand_anim = rand() % max_anims;
-        auto anim_it = house_params.variants.data.begin();
-        std::advance(anim_it, rand_anim);
-        d.image_key = anim_it->first;
-        image_id = anim_it->second.first_img();
+    // Pick a random variant whose image actually exists. Some house tiers
+    // reference custom image packs (e.g. PACK_CUSTOM_HOUSE) that aren't
+    // always installed; missing packs make first_img() return garbage
+    // (0/1/65535), which then renders as a black/missing-texture tile.
+    // Probe up to N tries so the picker degrades gracefully.
+    const auto &variants_data = house->is_merged() ? house_params.variants_merged.data : house_params.variants.data;
+    if (!variants_data.empty()) {
+        const size_t n = variants_data.size();
+        const size_t start = rand() % n;
+        for (size_t i = 0; i < n; i++) {
+            auto anim_it = variants_data.begin();
+            std::advance(anim_it, (start + i) % n);
+            const int candidate = anim_it->second.first_img();
+            if (candidate > 0 || i == n - 1) {
+                d.image_key = anim_it->first;
+                image_id = candidate;
+                break;
+            }
+        }
     }
 
     map_building_tiles_add(b.id, b.tile, b.size, image_id, TERRAIN_BUILDING);

--- a/src/building/building_house.cpp
+++ b/src/building/building_house.cpp
@@ -366,6 +366,10 @@ void building_house::add_population(int num_people) {
     }
 
     if (house_population() <= 0) {
+        // Split first so change_to doesn't leave a 1x1 image on a multi-tile footprint.
+        if (base.size > 1) {
+            change_to_vacant_lot();
+        }
         change_to(base, BUILDING_HOUSE_CRUDE_HUT);
     }
 
@@ -430,20 +434,28 @@ void building_house::change_to_vacant_lot() {
     d.population = 0;
     int vacant_lot_id = anim(animkeys().house).first_img();
 
-    if (!is_merged()) {
+    // size>1 covers both merged 1x1's and non-merged residences/manors/estates;
+    // is_merged is false on Common Residence and above.
+    if (base.size <= 1) {
         map_image_set(base.tile, vacant_lot_id);
         return;
     }
 
+    const int original_size = base.size;
     map_building_tiles_remove(base.id, base.tile);
     d.is_merged = 0;
     d.hsize = 1;
     base.size = 1;
     map_building_tiles_add(base.id, base.tile, 1, vacant_lot_id, TERRAIN_BUILDING);
 
-    building_house::create_vacant_lot(base.tile.shifted(1, 0), vacant_lot_id);
-    building_house::create_vacant_lot(base.tile.shifted(0, 1), vacant_lot_id);
-    building_house::create_vacant_lot(base.tile.shifted(1, 1), vacant_lot_id);
+    for (int dy = 0; dy < original_size; dy++) {
+        for (int dx = 0; dx < original_size; dx++) {
+            if (dx == 0 && dy == 0) {
+                continue;
+            }
+            building_house::create_vacant_lot(base.tile.shifted(dx, dy), vacant_lot_id);
+        }
+    }
 }
 
 bool building_house::is_vacant_lot() const {

--- a/src/building/building_house.cpp
+++ b/src/building/building_house.cpp
@@ -1455,7 +1455,8 @@ bool building_house_common_residence::evolve(house_demands* demands) {
     if (status == e_house_evolve) {
         change_to(base, BUILDING_HOUSE_SPACIOUS_RESIDENCE);
     } else if (status == e_house_decay) {
-        change_to(base, BUILDING_HOUSE_SPACIOUS_APARTMENT);
+        // 2x2 -> 1x1: split the footprint, otherwise 3 tiles render black.
+        split_size2(&base, BUILDING_HOUSE_SPACIOUS_APARTMENT);
     }
 
     return false;

--- a/src/building/building_house.cpp
+++ b/src/building/building_house.cpp
@@ -908,8 +908,9 @@ bool building_house::can_expand(int num_tiles) {
 
             if (other_house->id() == id()) {
                 ok_tiles++;
-            } 
-            
+                continue;
+            }
+
             const bool may_expand = other_house->state() == BUILDING_STATE_VALID && other_house->runtime_data().hsize && other_house->house_level() <= house_level();
             ok_tiles += may_expand ? 1 : 0;
         }


### PR DESCRIPTION
## Summary

Five related fixes in `src/building/building_house.cpp`. Each is one logical change in its own commit.

- **Common Residence devolve leaves 3 black tiles** — `change_to(BUILDING_HOUSE_SPACIOUS_APARTMENT)` only swapped the type and image, leaving `b.size = 2` and `hsize = 2`. The 1x1 Spacious Apartment image then rendered on the main tile of a 2x2 footprint, the other 3 tiles stayed black. Replaced with `split_size2` so the 2x2 properly fans out into 4 individual Spacious Apartments.
- **Vacant-lot transitions on multi-tile houses** — `change_to_vacant_lot` gated the multi-tile split on `is_merged()`, but Common Residence and above carry `is_merged = false` despite being 2x2/3x3/4x4. Switched the gate to `size > 1` and generalized the fan-out loop. `add_population` now also splits before resurrecting a multi-tile vacant lot as a Crude Hut.
- **Repair stale 2x2 hut footprints from older saves** — earlier builds shipped with the source bug, so `Mission7d-style` saves can carry buildings stuck at `size=2`, `is_merged=false`, with hut/cottage/apartment-tier types. `on_post_load` and `change_to` now detect that exact invalid combination and split via `split_size2` before painting, so legacy saves render cleanly on load and any path that would otherwise produce the bad state at runtime self-heals.
- **Skip variant images that resolve to missing textures** — `modest_homestead`'s variants list and `rough_cottage`'s `variants_merged_inside` reference `PACK_CUSTOM_HOUSE` (`pharaoh_houses_pack`), which isn't shipped with vanilla installs. `image_id_from_group` returns `-1` for the missing pack, `first_img()` caches `-1 + offset` (0 / 1 / 65535), and the random picker chose those broken IDs roughly 60% of the time on Modest Homestead — black tile on devolve. The picker now iterates from a random start and accepts the first variant whose `first_img() > 0`.
- **`can_expand` double-counted current tile, allowing roads inside footprint** — in the "merge with houses, empty terrain and gardens" pass, the `id() == id()` branch fell through into the `may_expand` check, so the building's own tile contributed +2 to `ok_tiles`. With that slack a footprint containing one road tile could still satisfy `ok_tiles == num_tiles`, expansion proceeded, and `map_building_tiles_add` stripped `TERRAIN_CLEARABLE` (including `TERRAIN_ROAD`) from the overlapping tile — paving over the road. Added the missing `continue`, matching the second pass.

## Test plan

- [x] `cmake --build --preset win-msvc-relwithdebinfo-vs2022 --target akhenaten` clean
- [x] Mission7d-complete5 save loads with no 2x2 black-tile housing artifacts (verified live)
- [x] 1x1 devolves no longer flash a black tile when MODEST_HOMESTEAD picks a variant (verified live)
- [ ] Verify houses no longer expand into adjacent road tiles
- [ ] Verify Common Residence still evolves up correctly (Spacious Apartment merge -> Common Residence -> Spacious -> Elegant -> Fancy)
- [ ] Verify Common Manor / Modest Estate expand and devolve still work (3x3, 4x4 paths)
- [ ] Multi-tile vacant lot reoccupation behaves (immigrant moves into former 2x2 residence)