### PR TITLE
fix: academy animation id typo (id:4 -> id:44)

### DIFF
--- a/src/scripts/building_education.js
+++ b/src/scripts/building_education.js
@@ -45,8 +45,8 @@ building_academy {
   animations {
     _pack { pack:PACK_GENERAL }
     preview { id:44 }
-    base { id:4 }
-    work { pos [36, -4], id:4, offset:1, max_frames:18 }
+    base { id:44 }
+    work { pos [36, -4], id:44, offset:1, max_frames:18 }
   }
 
   overlay : OVERLAY_EDUCATION


### PR DESCRIPTION
## Summary

- Fixed a typo in `building_education.js` where the Academy building's `base` and `work` animations used `id:4` instead of `id:44`
- scribal_school / library / academy use sequential pack IDs 42 / 43 / 44 -- academy was broken, causing it to render the wrong sprite