### PR TITLE
fix(missions): unlock advisors in missions 5-10

### DIFF
--- a/src/scripts/mission_10_saqqara.js
+++ b/src/scripts/mission_10_saqqara.js
@@ -125,6 +125,14 @@ mission10 { // Saqqara
 	}
 }
 
+[event=event_mission_start, mission=mission10]
+function mission10_on_start(ev) {
+	city.set_empire_available(1)
+	for (var i = ADVISOR_NONE + 1; i <= ADVISOR_DIPLOMACY; i++) {
+		city.set_advisor_available(i, 1)
+	}
+}
+
 [es=event_register_mission_animals, mission=mission10]
 function mission10_register_animals(ev) {
 	city.remove_animals()

--- a/src/scripts/mission_5_timna.js
+++ b/src/scripts/mission_5_timna.js
@@ -89,3 +89,11 @@ mission5 { // Timna
 		}
 	]
 }
+
+[event=event_mission_start, mission=mission5]
+function mission5_on_start(ev) {
+	city.set_empire_available(1)
+	for (var i = ADVISOR_NONE + 1; i <= ADVISOR_DIPLOMACY; i++) {
+		city.set_advisor_available(i, 1)
+	}
+}

--- a/src/scripts/mission_6_behdet.js
+++ b/src/scripts/mission_6_behdet.js
@@ -113,6 +113,14 @@ mission6 { // Behdet
 	}
 }
 
+[event=event_mission_start, mission=mission6]
+function mission6_on_start(ev) {
+	city.set_empire_available(1)
+	for (var i = ADVISOR_NONE + 1; i <= ADVISOR_DIPLOMACY; i++) {
+		city.set_advisor_available(i, 1)
+	}
+}
+
 [es=event_advance_month, mission=mission6]
 function mission6_pharaoh_request_pottery(ev) {
 	if (mission.pharaoh_pottery_requested) {

--- a/src/scripts/mission_7_abydos.js
+++ b/src/scripts/mission_7_abydos.js
@@ -101,6 +101,10 @@ function mission7_register_animals(ev) {
 function mission7_on_start(ev) {
 	city.set_empire_available(1)
 
+	for (var i = ADVISOR_NONE + 1; i <= ADVISOR_DIPLOMACY; i++) {
+		city.set_advisor_available(i, 1)
+	}
+
 	// event_register_mission_animals only fires inside create_herds, which is
 	// skipped on save loads. Re-clear here so a saved game also stays clean.
 	city.remove_animals()

--- a/src/scripts/mission_8_selima.js
+++ b/src/scripts/mission_8_selima.js
@@ -122,6 +122,14 @@ mission8 { // Selima
 	}
 }
 
+[event=event_mission_start, mission=mission8]
+function mission8_on_start(ev) {
+	city.set_empire_available(1)
+	for (var i = ADVISOR_NONE + 1; i <= ADVISOR_DIPLOMACY; i++) {
+		city.set_advisor_available(i, 1)
+	}
+}
+
 [event=event_register_mission_animals, mission=mission8]
 function mission8_register_animals(ev) {
 	city.remove_animals()

--- a/src/scripts/mission_9_abu.js
+++ b/src/scripts/mission_9_abu.js
@@ -120,3 +120,11 @@ mission9 = { // Abu
 		}
 	],
 }
+
+[event=event_mission_start, mission=mission9]
+function mission9_on_start(ev) {
+	city.set_empire_available(1)
+	for (var i = ADVISOR_NONE + 1; i <= ADVISOR_DIPLOMACY; i++) {
+		city.set_advisor_available(i, 1)
+	}
+}


### PR DESCRIPTION
Fixes #501

05e83115e1 removed the C++ default-unlock loop for non-tutorial missions but did not add equivalent set_advisor_available calls in JS for missions 5-10.

- mission_5/6/8/9/10: add event_mission_start handler with unlock loop (same shape as mission 2/3/4)
- mission_7: extend existing handler with the same loop

Verified: fresh start and save-load of mission 6, advisors open. JS-only, +44 lines.