### PR TITLE
fix: implement Osiris farm curse (building_curse_farms stub)

### DIFF
--- a/src/city/city_industry.cpp
+++ b/src/city/city_industry.cpp
@@ -203,16 +203,16 @@ void building_industry_update_wheat_production() {
 }
 
 void building_curse_farms(int big_curse) {
-    // TODO
-    //    for (int i = 1; i < MAX_BUILDINGS; i++) {
-    //        building *b = building_get(i);
-    //        if (b->state == BUILDING_STATE_VALID && b->output_resource_id && building_is_farm(b->type)) {
-    //            b->data.industry.progress = 0;
-    //            b->data.industry.blessing_days_left = 0;
-    //            b->data.industry.curse_days_left = big_curse ? 48 : 4;
-    //            update_farm_image(b);
-    //        }
-    //    }
+    buildings_valid_farms_do([big_curse](building &b) {
+        building_farm *farm = b.dcast_farm();
+        if (!farm) {
+            return;
+        }
+        farm->runtime_data().progress = 0;
+        b.blessing_days_left = 0;
+        b.curse_days_left = big_curse ? 48 : 4;
+        farm->update_tiles_image();
+    });
 }
 
 void building_workshop_add_raw_material(building* b, int amount, e_resource res) {

--- a/src/city/city_religion_osiris.cpp
+++ b/src/city/city_religion_osiris.cpp
@@ -1,6 +1,7 @@
 #include "city_religion_osiris.h"
 
 #include "city/city.h"
+#include "city/city_industry.h"
 #include "city/city_message.h"
 #include "city_floods.h"
 #include "core/random.h"
@@ -24,7 +25,7 @@ bool god_osiris_t::create_shipwreck_flotsam() {
 
 
 void god_osiris_t::perform_locusts() {
-    // TODO: implement locusts
+    building_curse_farms(1);
     messages::popup("message_wrath_of_osiris_2", 0, 0);
 }
 


### PR DESCRIPTION
## Summary

- Implemented the stubbed `building_curse_farms()` in `src/city/city_industry.cpp` using `buildings_valid_farms_do`, resetting farm progress/blessing and setting `curse_days_left` (4 for minor curse, 48 for major curse)
- Wired the function into `god_osiris_t::perform_locusts` in `src/city/city_religion_osiris.cpp` so Osiris's major wrath curse now actually damages all farms on the map

Previously the curse was a no-op stub — farms were unaffected by Osiris's anger.