### PR TITLE
fix: implement noble figure roaming and animation (empty stubs)

### DIFF
--- a/src/figuretype/figure_noble.cpp
+++ b/src/figuretype/figure_noble.cpp
@@ -1,13 +1,32 @@
 #include "figure_noble.h"
 
+#include "figure/action.h"
 #include "js/js_game.h"
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_noble);
 
 void figure_noble::figure_action() {
+    switch (action_state()) {
+    case FIGURE_ACTION_149_CORPSE:
+        base.figure_combat_handle_corpse();
+        break;
+
+    case ACTION_125_ROAMER_ROAMING:
+        do_roam(TERRAIN_USAGE_ROADS, ACTION_126_ROAMER_RETURNING);
+        break;
+
+    case ACTION_126_ROAMER_RETURNING:
+        do_returnhome(TERRAIN_USAGE_ROADS);
+        break;
+    }
 }
 
 void figure_noble::update_animation() {
+    xstring animkey = animkeys().walk;
+    if (action_state(FIGURE_ACTION_149_CORPSE)) {
+        animkey = animkeys().death;
+    }
+    image_set_animation(animkey);
 }
 
 void figure_noble::before_poof() {


### PR DESCRIPTION
## Summary

- Implemented `figure_action()` and `update_animation()` in `src/figuretype/figure_noble.cpp`
- Nobles were spawned by noble houses but had empty stubs — they never moved or animated
- Now uses the standard ACTION_125/126 roamer state machine with walk/death animation dispatch