### PR TITLE
refactor(scribal_school): use common_spawn_figure_trigger + create_roaming_figure

### DIFF
--- a/src/building/building_scribal_school.cpp
+++ b/src/building/building_scribal_school.cpp
@@ -54,31 +54,8 @@ bool building_scribal_school::add_resource(e_resource resource, int amount) {
 }
 
 void building_scribal_school::spawn_figure() {
-    check_labor_problem();
-    if (has_figure_of_type(BUILDING_SLOT_SERVICE, FIGURE_TEACHER)) {
-        return;
-    }
-
-    tile2i road = map_get_road_access_tile(tile(), size());
-    if (!road.valid()) {
-        return;
-    }
-
-    common_spawn_labor_seeker(current_params().min_houses_coverage);
-    int spawn_delay = figure_spawn_timer();
-    if (spawn_delay == -1) {
-        return;
-    }
-
-    base.figure_spawn_delay++;
-    if (base.figure_spawn_delay > spawn_delay) {
-        base.figure_spawn_delay = 0;
-
-        figure* f = figure_create(FIGURE_TEACHER, road, DIR_0_TOP_RIGHT);
-        f->action_state = ACTION_125_ROAMER_ROAMING;
-        f->set_home(id());
-        base.set_figure(BUILDING_SLOT_SERVICE, f->id);
-        f->init_roaming_from_building(0);
+    if (common_spawn_figure_trigger(current_params().min_houses_coverage, BUILDING_SLOT_SERVICE)) {
+        create_roaming_figure(FIGURE_TEACHER, (e_figure_action)ACTION_125_ROAMER_ROAMING, BUILDING_SLOT_SERVICE);
     }
 }
 

--- a/src/figuretype/figure_teacher.cpp
+++ b/src/figuretype/figure_teacher.cpp
@@ -9,23 +9,6 @@
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_teacher)
 
-void figure_teacher::figure_action() {
-    switch (action_state()) {
-    case ACTION_125_ROAMER_ROAMING:
-        base.roam_length++;
-        if (base.roam_length >= base.max_roam_length) {
-            advance_action(ACTION_126_ROAMER_RETURNING);
-        }
-
-        break;
-
-    case ACTION_126_ROAMER_RETURNING:
-        ; // nothing here
-        break;
-
-    }
-}
-
 sound_key figure_teacher::phrase_key() const {
     svector<sound_key, 10> keys;
 

--- a/src/figuretype/figure_teacher.h
+++ b/src/figuretype/figure_teacher.h
@@ -8,7 +8,6 @@ public:
     figure_teacher(figure *f) : figure_impl(f) {}
 
     virtual void on_create() override {}
-    virtual void figure_action() override;
     virtual sound_key phrase_key() const override;
     virtual int provide_service() override;
     virtual e_overlay get_overlay() const override { return OVERLAY_SCRIBAL_SCHOOL; }


### PR DESCRIPTION
## Summary
- Replace hand-rolled labor/road/spawn-delay/figure-setup in `building_scribal_school::spawn_figure` with the shared `common_spawn_figure_trigger` + `create_roaming_figure` path that every other service building uses.
- Drop `figure_teacher::figure_action` — the roam-length / return state machine is already handled by the base roamer behavior once the figure is spawned via `create_roaming_figure`.

## Test plan
- [ ] Scribal school staffed: teacher spawns at the usual cadence, walks the same coverage radius, and returns home.
- [ ] Scribal school with no road access: no spawn, matches prior behavior.
- [ ] Coverage: school still appears in the education overlay and serves nearby housing.