### PR TITLE
fix(mission2): drop disease_handled from victory state (tutorial trigger, not a win condition)

### DIFF
--- a/src/scripts/mission_2_perwadjyt.js
+++ b/src/scripts/mission_2_perwadjyt.js
@@ -190,7 +190,6 @@ function mission2_on_disease(ev) {
 [event=event_update_victory_state, mission=mission2]
 function mission2_handle_victory_state(ev) {
 	city.set_victory_reason("figs_stored_handled", mission.figs_stored_handled)
-	city.set_victory_reason("disease_handled", mission.disease_handled)
 	city.set_victory_reason("pottery_step1_stored_handled", mission.pottery_step1_stored_handled)
 	city.set_victory_reason("pottery_step2_stored_handled", mission.pottery_step2_stored_handled)
 


### PR DESCRIPTION
## Summary
- `mission2_on_disease()` flips `mission.disease_handled = true` only when a disease event actually fires in the city, and uses that flag purely to gate the one-time healthcare tutorial popup and the apothecary/physician unlocks.
- The victory loop in `src/city/victory.cpp` requires *every* entry in `g_victory_reasons` to be true, so registering `disease_handled` as a victory reason meant a clean playthrough (no disease ever) could never satisfy victory.
- Removed the `set_victory_reason("disease_handled", ...)` call. The remaining reasons (`figs_stored_handled`, `pottery_step1_stored_handled`, `pottery_step2_stored_handled`) are the actual mission objectives.

## Test plan
- [ ] Mission 2 (Perwadjyt) playthrough without a disease event: hitting all three pottery/figs goals + population/housing targets now triggers victory.
- [ ] Mission 2 playthrough where a disease *does* fire: tutorial popup still appears, apothecary/physician/health-advisor unlock as before; victory still triggers on the three real goals.