### PR TITLE
fix(advisor): use city.kingdome.personal_savings in imperial overseer

### DIFF
--- a/src/scripts/ui_advisor_imperial.js
+++ b/src/scripts/ui_advisor_imperial.js
@@ -174,7 +174,7 @@ advisor_imperial_window {
                                       })
 
                 personal_savings : label({pos[72, 374]
-                                          textfn:function() { return _eformat( "${52.1} ${city.personal_savings} ${6.0}", { city : city }) }
+                                          textfn:function() { return _eformat( "${52.1} ${city.kingdome.personal_savings} ${6.0}", { city : city }) }
                                          })
                 money_lost   : label({pos[272, 374], textfn: function() { return "0 " + __loc(52, 79) } })
                 no_requests  : label({margin{ left:40, centery:0}, text:"#no_requests", font:FONT_NORMAL_WHITE_ON_DARK })


### PR DESCRIPTION
## Summary

Imperial advisor («Political overseer for My Dynasty») showed «Savings of **undefined** Db» instead of the actual amount.

## Cause

`src/scripts/ui_advisor_imperial.js:177` referenced `${city.personal_savings}` in the `_eformat` template. The C++ binding (`src/city/city_kingdome_js.cpp`) exposes `personal_savings` on `__city_kingdome`, which is mounted as `city.kingdome` (`src/scripts/city_kingdome.js`). `city.personal_savings` is undefined; `_eformat` resolves undefined to the literal string `'undefined'` (`src/scripts/common.js:48`).

All other references in the codebase use `city.kingdome.personal_savings` — this was an isolated typo, likely from the recent migration of the imperial advisor to scripts (`ce2f175513`, `0098c85e3e`).

## Fix

```diff
- textfn:function() { return _eformat( "${52.1} ${city.personal_savings} ${6.0}", { city : city }) }
+ textfn:function() { return _eformat( "${52.1} ${city.kingdome.personal_savings} ${6.0}", { city : city }) }
```

## Verification

Loaded a save where `kingdome.personal_savings = 4518`. Before: «Сбережения undefined Дб». After: «Сбережения 4518 Дб». No other consumers of this template.