### PR TITLE
fix(docker): despawn idle docker when it can't deliver or fetch

### DIFF
--- a/src/figuretype/figure_docker.cpp
+++ b/src/figuretype/figure_docker.cpp
@@ -481,8 +481,8 @@ void figure_docker::figure_action() {
         base.resource_id = RESOURCE_NONE;
         base.cart_image_id = 0;
         base.animctx.frame = 0;
-        if (!deliver_import_resource(b)) {
-            fetch_export_resource(b);
+        if (!deliver_import_resource(b) && !fetch_export_resource(b)) {
+            poof();
         }
         break;
 


### PR DESCRIPTION
## Summary
- In `ACTION_132_DOCKER_IDLING`, the docker previously called `fetch_export_resource` only as a fallback after a failed `deliver_import_resource`, with no handling for the case where neither succeeds — leaving the docker stuck looping the idle action.
- Now, if **both** `deliver_import_resource` and `fetch_export_resource` fail, the docker `poof()`s.

## Test plan
- [ ] Load a city with a dock whose route has no warehouse able to accept imports or supply exports; confirm the idling docker despawns instead of looping the idle animation indefinitely.