### PR TITLE
fix(ui): raise message list capacity to cover all city messages

### DIFF
--- a/src/graphics/elements/scroll_list_panel.cpp
+++ b/src/graphics/elements/scroll_list_panel.cpp
@@ -115,6 +115,9 @@ void scrollable_list::clear_entry_list() {
 }
 
 void scrollable_list::add_entry(xstring entry_text, uintptr_t user_data) {
+    if (manual_entry_list.full()) {
+        return;
+    }
     manual_entry_list.push_back({ entry_text, user_data });
     _items_count++;
     refresh_scrollbar();

--- a/src/graphics/elements/scroll_list_panel.h
+++ b/src/graphics/elements/scroll_list_panel.h
@@ -7,7 +7,8 @@
 #include <vector>
 
 #define MAX_BUTTONS_IN_SCROLLABLE_LIST 50
-#define MAX_MANUAL_ENTRIES 300
+// must cover MAX_MESSAGES (1000): the messages window adds one entry per city message
+#define MAX_MANUAL_ENTRIES 1000
 
 struct scrollable_list_ui_params {
     vec2i pos = { 0, 0 };


### PR DESCRIPTION
## Summary
- `MAX_MANUAL_ENTRIES` raised from 300 to 1000. The messages window adds one `scrollable_list` entry per city message, and `MAX_MESSAGES` is 1000 — the previous 300-entry `svector` capacity could overflow.
- `scrollable_list::add_entry` now returns early when `manual_entry_list.full()`, as a safety net against overflow.

## Test plan
- [ ] Open the messages window in a city with more than 300 accumulated messages; confirm all entries are listed and scroll correctly without overflow.