### PR TITLE
fix(empire): expose pos on EmpireCityObject for the siege battle icon

### DIFF
--- a/src/scripts/empire_city_prototype.js
+++ b/src/scripts/empire_city_prototype.js
@@ -2,3 +2,5 @@ log_info("akhenaten: empire_city_prototype started")
 
 EmpireCity.property.empire_object = { get: function() { return new EmpireCityObject(this.id) } }
 EmpireCity.property.is_sieged = { get: function() { return this.months_under_siege > 0 } }
+
+EmpireCityObject.property.pos = { }


### PR DESCRIPTION
## Summary
- `ui_empire_window.js` draws the besieged-city battle icon from `ecity.empire_object.pos` (added in `d26aa7db8`, 2025-12-27), but `pos` was never declared on `EmpireCityObject`, so the access resolved to `undefined`.
- This declares `EmpireCityObject.property.pos = { }`. The MuJS compiler expands the empty descriptor into a getter that calls the existing native `__property_getter`, which resolves `pos` off the C++ `empire_object` (already registered for reflection via `ANK_CONFIG_PROPERTY(empire_object, id, type, pos)`).

## Test plan
- [ ] With a city under siege on the empire map, confirm the battle icon renders at the city's location.