### PR TITLE
fix(courthouse): register JS module and use exported roamer action constant

### DIFF
--- a/src/scripts/building_courthouse.js
+++ b/src/scripts/building_courthouse.js
@@ -3,7 +3,7 @@ log_info("akhenaten: building_courthouse started")
 [es=(building_courthouse, spawn_figure)]
 function building_courthouse_spawn_figure(ev) {
     var building = city.get_building(ev.bid)
-    building.common_spawn_roamer(FIGURE_MAGISTRATE, building_courthouse.min_houses_coverage, ACTION_125_MAGISTRATE_ROAMING)
+    building.common_spawn_roamer(FIGURE_MAGISTRATE, building_courthouse.min_houses_coverage, ACTION_125_ROAMER_ROAMING)
 }
 
 [es=(building_courthouse, update_graphic)]

--- a/src/scripts/modules.js
+++ b/src/scripts/modules.js
@@ -52,6 +52,7 @@ import building_mine_gems
 import building_granary
 import building_health
 import building_architect_post
+import building_courthouse
 import overlays
 import images
 import population


### PR DESCRIPTION
Fixes #525

## Summary

Two-line fix completing the JS migration of courthouse from commit `4f5883da2c`:

1. `src/scripts/modules.js` — add missing `import building_courthouse` so the new module is loaded by MuJS.
2. `src/scripts/building_courthouse.js` — replace `ACTION_125_MAGISTRATE_ROAMING` (C++ enum alias not exposed to JS) with `ACTION_125_ROAMER_ROAMING` (exported in `src/js/js_constants.cpp:91`, same value 125).

Without these, the `spawn_figure` event for courthouse was emitted to no handler, magistrates never spawned, `houses_covered` stayed at 0, and `city_labor` permanently excluded courthouses from worker allocation. Symptom in info-window: `0 Employee (10 needed)` regardless of free workforce.

The first regression masks the second — the constant-name crash is invisible until the module is actually loaded.

## Verification

- macOS arm64 build (`macos-clang-relwithdebinfo-ninja-arm64`).
- Mission 6 (Behdet) save with established courthouses: before — permanent `0/10`; after — magistrates spawn, `houses_covered` accumulates, workers allocated within ~1–2 game months, full employment.