### PR TITLE
fix(trade): release ghost trader and dock slots

### DIFF
--- a/src/empire/empire_traders.cpp
+++ b/src/empire/empire_traders.cpp
@@ -2,16 +2,19 @@
 
 #include "empire/empire.h"
 #include "empire/empire_object.h"
+#include "empire/empire_city.h"
 #include "empire/type.h"
 #include "graphics/image.h"
 #include "graphics/image_groups.h"
 #include "graphics/graphics.h"
 #include "figuretype/figure_kingdome_trader.h"
 #include "figuretype/figure_trader_ship.h"
+#include "building/building_dock.h"
 #include "core/calc.h"
 #include "game/game.h"
 #include "dev/debug.h"
 #include "city/city.h"
+#include "city/city_figures.h"
 #include "core/log.h"
 #include "js/js_game.h"
 
@@ -187,6 +190,78 @@ void empire_traders_manager::clear_all() {
     for (int i = 0; i < traders.size(); ++i) {
         traders[i].id = i;
         traders[i].is_active = false;
+    }
+}
+
+void empire_traders_manager::purge_dead() {
+    // Defensive sweep after save load. Three places can hold a stale reference
+    // to a vanished trade ship or caravan: traders[].is_active, dock.trade_ship,
+    // and empire_city.trader_figure_ids. Without this, old saves and crash-recovered
+    // states starve every trade route once the 2-per-route cap is full of ghosts.
+
+    std::array<bool, 100> live_handles{};
+    figure_valid_do(
+      [&](figure& f) {
+          if (auto* ship = f.dcast()->dcast_trade_ship()) {
+              uint8_t h = ship->runtime_data().trader.handle;
+              if (h < live_handles.size()) {
+                  live_handles[h] = true;
+              }
+              return;
+          }
+          if (auto* caravan = f.dcast()->dcast_trade_caravan()) {
+              uint8_t h = caravan->runtime_data().trader.handle;
+              if (h < live_handles.size()) {
+                  live_handles[h] = true;
+              }
+          }
+      },
+      make_array(FIGURE_TRADE_SHIP, FIGURE_TRADE_CARAVAN));
+
+    int freed_empire = 0;
+    for (size_t i = 1; i < traders.size(); ++i) {
+        if (traders[i].is_active && !live_handles[i]) {
+            traders[i].is_active = false;
+            ++freed_empire;
+        }
+    }
+
+    int freed_dock = 0;
+    for (building_id bid : g_city.buildings.track_buildings(BUILDING_DOCK)) {
+        building_dock* dock = building_get(bid)->dcast_dock();
+        if (!dock) {
+            continue;
+        }
+        auto& d = dock->runtime_data();
+        if (d.trade_ship == 0) {
+            continue;
+        }
+        figure* f = figure_get(d.trade_ship);
+        if (!f || f->state == FIGURE_STATE_NONE || f->type != FIGURE_TRADE_SHIP) {
+            d.trade_ship = 0;
+            ++freed_dock;
+        }
+    }
+
+    int freed_city = 0;
+    for (auto& city : g_empire.get_cities()) {
+        for (int i = 0; i < 3; ++i) {
+            int fid = city.trader_figure_ids[i];
+            if (fid == 0) {
+                continue;
+            }
+            figure* f = figure_get(fid);
+            if (!f || f->state == FIGURE_STATE_NONE
+                || (f->type != FIGURE_TRADE_SHIP && f->type != FIGURE_TRADE_CARAVAN)) {
+                city.trader_figure_ids[i] = 0;
+                ++freed_city;
+            }
+        }
+    }
+
+    if (freed_empire || freed_dock || freed_city) {
+        logs::info("empire_traders::purge_dead: freed %d empire slots, %d dock slots, %d city slots", freed_empire,
+          freed_dock, freed_city);
     }
 }
 

--- a/src/empire/empire_traders.h
+++ b/src/empire/empire_traders.h
@@ -46,7 +46,8 @@ public:
     void create_trader(int trade_route_id, int destination_city_id);
     void remove_trader(int trader_id);
     void clear_all();
-    
+    void purge_dead();
+
     std::array<empire_trader, 100> traders;
     vec2i ship_movement_delay;
     vec2i land_movement_delay;

--- a/src/figuretype/figure_trader_ship.cpp
+++ b/src/figuretype/figure_trader_ship.cpp
@@ -2,6 +2,7 @@
 
 #include "figure/figure.h"
 #include "empire/trader_handler.h"
+#include "empire/empire_traders.h"
 #include "figure_shipwreck.h"
 #include "building/building_dock.h"
 #include "game/game.h"
@@ -191,6 +192,20 @@ void figure_trade_ship::on_create() {
 void figure_trade_ship::on_destroy() {
     figure_carrier::on_destroy();
     empire_city().remove_trader(id());
+
+    // Release the empire-side trader slot. complete_trade() only fires when state
+    // reaches estate_returning_home — if the ship dies via kill(), demolished dock,
+    // or any path that skips back_to_city(), is_active stays true forever and the
+    // route fills up to its 2-trader cap with ghosts.
+    auto& trader = g_empire_traders.traders[runtime_data().trader.handle];
+    trader.is_active = false;
+
+    // Release the dock slot. Otherwise the next ship is rejected by
+    // map_get_free_destination_dock (trade_ship != 0 with a dead figure id).
+    auto* dock = destination()->dcast_dock();
+    if (dock && dock->runtime_data().trade_ship == id()) {
+        dock->runtime_data().trade_ship = 0;
+    }
 }
 
 void figure_trade_ship::figure_action() {
@@ -243,6 +258,9 @@ void figure_trade_ship::figure_action() {
         }
 
         if (destination()->state != BUILDING_STATE_VALID) {
+            // Dock demolished mid-approach. Tell the empire-side trader to head home —
+            // otherwise it stays stuck in estate_moving_to_destination with is_active=true.
+            runtime_data().trader.back_to_city();
             advance_action(ACTION_115_TRADE_SHIP_LEAVING, scenario_map_river_exit());
             base.wait_ticks = 0;
         }
@@ -263,6 +281,7 @@ void figure_trade_ship::figure_action() {
             auto &dock = dst->dcast_dock()->runtime_data();
             dock.queued_docker_id = 0;
             dock.num_ships = 0;
+            dock.trade_ship = 0;
         }
 
         switch (destination()->orientation) {

--- a/src/io/gamestate/boilerplate.cpp
+++ b/src/io/gamestate/boilerplate.cpp
@@ -225,6 +225,7 @@ static void post_load() {
     city_resource_calculate_storageyard_stocks();
     building_storage_reset_building_ids();
     g_city.avg_coverage.update();
+    g_empire_traders.purge_dead();
 
     g_city.religion.ra_no_traders_months_left = std::clamp<int>(g_city.religion.ra_no_traders_months_left, 0, 12);
     g_city.religion.ra_harshly_reduced_trading_months_left = std::clamp<int>(g_city.religion.ra_harshly_reduced_trading_months_left, 0, 12);


### PR DESCRIPTION
Fixes #527.

## Summary

In long campaigns trade ships gradually stop appearing because empire-trader slots, dock-trade-ship reservations, and empire-city trader id slots get out of sync with the live figure set. `empire_traders_reset` in the console works around it; this PR fixes the root cause.

Two layers:

1. **Live cleanup** in `figure_trade_ship`: `on_destroy()` is now the single point that releases both the `empire_trader.is_active` slot and the dock's `trade_ship` field. The two paths that previously skipped cleanup (`done_trading` branch in ACTION_112; demolished-dock branch in ACTION_111) are fixed to release state proactively / call `back_to_city()`.

2. **Post-load defensive sweep** `empire_traders_manager::purge_dead()` called from `post_load()` (`io/gamestate/boilerplate.cpp`). Reconciles `traders[].is_active`, `dock.trade_ship`, and `empire_city.trader_figure_ids[]` with the live set of trade ships and caravans on every save load. Old saves with accumulated ghosts heal themselves on first reload; logs a one-line summary when it freed anything.

## Changes

- `src/figuretype/figure_trader_ship.cpp` — release `empire_trader` + `dock.trade_ship` in `on_destroy`; `dock.trade_ship = 0` in the `done_trading` branch; call `back_to_city()` before leaving when destination dock was demolished mid-approach.
- `src/empire/empire_traders.{h,cpp}` — new `empire_traders_manager::purge_dead()` that scans `FIGURE_TRADE_SHIP` and `FIGURE_TRADE_CARAVAN`, then zeroes ghost entries in all three storage locations.
- `src/io/gamestate/boilerplate.cpp` — call `g_empire_traders.purge_dead()` in `post_load()` next to other post-load reconciliations.

Save format unchanged. No content/scenario/UI changes.

## Verification

- Build: `cmake --build --preset macos-clang-relwithdebinfo-ninja-arm64` clean.
- clang-format: `git-clang-format --style=file` clean.
- Runtime: mission 7 Abydos save where trade had stopped — reloaded under the fix, ships start arriving without `empire_traders_reset`. Subsequent ~30 in-game months: trade remained stable, no ghost accumulation; the second dock now reliably receives queued ships.

## Scope

Trade-ship lifecycle cleanup only. Does not touch trade balance, route configuration, or UI.