### PR TITLE
fix(religion): show correct Bast no-effect message when houses are not destroyed

### DIFF
--- a/src/city/city_religion_bast.cpp
+++ b/src/city/city_religion_bast.cpp
@@ -13,9 +13,11 @@ bool god_bast_t::perform_houses_destruction() {
 }
 
 void god_bast_t::perform_major_curse() {
-    // destroy some of the best houses
-    perform_houses_destruction();
-    messages::popup("message_wrath_of_bast", 0, 0);
+    if (perform_houses_destruction()) {
+        messages::popup("message_wrath_of_bast", 0, 0);
+    } else {
+        messages::popup("message_wrath_of_bast_2", 0, 0);
+    }
 }
 
 void god_bast_t::perform_malaria_plague() {
@@ -29,7 +31,7 @@ void god_bast_t::perform_malaria_plague() {
 void god_bast_t::perform_minor_curse() {
     // plague
     perform_malaria_plague();
-    events::emit(event_message_god{ GOD_BAST, "message_bast_is_upset" });
+    events::emit(event_message_god{GOD_BAST, "message_bast_is_upset"});
 }
 
 void god_bast_t::perform_festival_for_other_gods() {
@@ -49,4 +51,3 @@ void god_bast_t::perform_minor_blessing() {
     // throws a festival for the other gods
     perform_festival_for_other_gods();
 }
-

--- a/src/scripts/game_messages_en.js
+++ b/src/scripts/game_messages_en.js
@@ -3834,10 +3834,10 @@ game_messages_en {
     message_wrath_of_bast_2 {
         id: 335,
         type: 2,
-        
+
         size [30, 20]
         title { text: "Wrath of Bast", }
-        content { text: "placeholder - report this to Ken if it appears" }
+        content { text: "Your city escaped the wrath of Bast -- the goddess sought to level your finest houses, but found no homes worthy of her fury this day. Be wary, nonetheless, of provoking the Goddess of the Home, for she is patient and her memory is long. Show Bast the respect she demands before she returns." }
     }
     message_wrath_of_ra_4 {
         id: 336,


### PR DESCRIPTION
## Summary

- Replaced placeholder text in `message_wrath_of_bast_2` (id 335, `MESSAGE_CURSE_BAST_NOEFFECT`) in `game_messages_en.js`
- Fixed `city_religion_bast.cpp` to show `MESSAGE_CURSE_BAST_NOEFFECT` when `BAST_houses_destruction()` returns `false` — previously the "houses leveled" message was shown unconditionally