### PR TITLE
feat(overlays): add missing city_overlay_enemies class

### DIFF
--- a/src/overlays/city_overlay_enemies.cpp
+++ b/src/overlays/city_overlay_enemies.cpp
@@ -1,0 +1,17 @@
+#include "city_overlay_enemies.h"
+
+#include "figure/figure.h"
+
+city_overlay_enemies g_city_overlay_enemies;
+
+bool city_overlay_enemies::show_figure(const figure *f) const {
+    return ((figure *)f)->dcast()->get_overlay() == OVERLAY_ENEMIES;
+}
+
+int city_overlay_enemies::get_column_height(const building *b) const {
+    return COLUMN_TYPE_NONE;
+}
+
+bool city_overlay_enemies::show_building(const building *b) const {
+    return false;
+}

--- a/src/overlays/city_overlay_enemies.h
+++ b/src/overlays/city_overlay_enemies.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "city_overlay.h"
+
+struct city_overlay_enemies : public city_overlay_t<OVERLAY_ENEMIES> {
+    virtual bool show_figure(const figure *f) const override;
+    virtual int get_column_height(const building *b) const override;
+    virtual bool show_building(const building *b) const override;
+};


### PR DESCRIPTION
## Summary

- Added `city_overlay_enemies.h` and `city_overlay_enemies.cpp` implementing the missing `city_overlay_enemies` class
- Fixes a null-dereference crash when switching to `OVERLAY_ENEMIES` mode via the figure info window on any enemy figure