### PR TITLE
feat(overlays): implement brewery overlay for house beer inventory

### DIFF
--- a/src/overlays/city_overlay_brewery.cpp
+++ b/src/overlays/city_overlay_brewery.cpp
@@ -1,0 +1,38 @@
+#include "city_overlay_brewery.h"
+
+#include "grid/building.h"
+#include "figure/figure.h"
+#include "building/building_house.h"
+#include "game/resource.h"
+
+city_overlay_brewery g_city_overlay_brewery;
+
+int city_overlay_brewery::get_column_height(const building* b) const {
+    auto house = ((building*)b)->dcast_house();
+
+    if (!house || house->house_population() <= 0) {
+        return COLUMN_TYPE_NONE;
+    }
+
+    const auto& housed = house->runtime_data();
+    return std::clamp<int>(housed.inventory[INVENTORY_GOOD4] / 10, 0, 10);
+}
+
+xstring city_overlay_brewery::get_tooltip_for_building(tooltip_context* c, const building* b) {
+    auto house = ((building*)b)->dcast_house();
+
+    if (!house) {
+        return ui::str(66, 90);
+    }
+
+    const auto& housed = house->runtime_data();
+    if (housed.inventory[INVENTORY_GOOD4] <= 0) {
+        return ui::str(66, 87);
+    } else if (housed.inventory[INVENTORY_GOOD4] <= 30) {
+        return ui::str(66, 88);
+    } else if (housed.inventory[INVENTORY_GOOD4] <= 70) {
+        return ui::str(66, 89);
+    } else {
+        return ui::str(66, 90);
+    }
+}

--- a/src/overlays/city_overlay_brewery.h
+++ b/src/overlays/city_overlay_brewery.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "city_overlay.h"
+
+struct city_overlay_brewery : public city_overlay_t<OVERLAY_BREWERY> {
+    virtual int get_column_height(const building* b) const override;
+    virtual xstring get_tooltip_for_building(tooltip_context* c, const building* b) override;
+};

--- a/src/scripts/ui_overlay_menu.js
+++ b/src/scripts/ui_overlay_menu.js
@@ -104,7 +104,7 @@ overlay_menu {
 				// OVERLAY_POTTERY
 				// OVERLAY_JEWELRY
 				// OVERLAY_LINEN
-				// OVERLAY_BEER
+				OVERLAY_BREWERY,
 	    	]
 	    }
 


### PR DESCRIPTION
## Summary

- Added `city_overlay_brewery.h` and `city_overlay_brewery.cpp` implementing `city_overlay_brewery` (`OVERLAY_BREWERY = 41`)
- Column height on house tiles reflects the house's beer inventory level
- Enabled the overlay in the Food section of `ui_overlay_menu.js`