### PR TITLE
refactor: extract update_graphic_work_anim() helper, deduplicate 14 overrides

### DIFF
--- a/src/building/building_academy.cpp
+++ b/src/building/building_academy.cpp
@@ -12,10 +12,7 @@ void building_academy::spawn_figure() {
 }
 
 void building_academy::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bool building_academy::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color mask) {

--- a/src/building/building_bricklayers_guild.cpp
+++ b/src/building/building_bricklayers_guild.cpp
@@ -24,10 +24,7 @@ REPLICATE_STATIC_PARAMS_FROM_CONFIG(building_bricklayers_guild);
 declare_console_command(add_bricks, game_cheat_add_resource<RESOURCE_BRICKS>);
 
 void building_bricklayers_guild::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 void building_bricklayers_guild::on_create(int orientation) {

--- a/src/building/building_dance_school.cpp
+++ b/src/building/building_dance_school.cpp
@@ -84,13 +84,7 @@ void building_dancer_school::spawn_figure() {
 }
 
 void building_dancer_school::update_graphic() {
-    const xstring &animkey = can_play_animation()
-                                ? animkeys().work
-                                : animkeys().none;
-
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bool building_dancer_school::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {

--- a/src/building/building_dentist.cpp
+++ b/src/building/building_dentist.cpp
@@ -10,13 +10,7 @@
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(building_dentist);
 
 void building_dentist::update_graphic() {
-    const xstring &animkey = can_play_animation()
-                                ? animkeys().work
-                                : animkeys().none;
-
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bool building_dentist::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {

--- a/src/building/building_guild_carpenters.cpp
+++ b/src/building/building_guild_carpenters.cpp
@@ -16,10 +16,7 @@ REPLICATE_STATIC_PARAMS_FROM_CONFIG(building_carpenters_guild);
 declare_console_command(add_timber, game_cheat_add_resource<RESOURCE_TIMBER>);
 
 void building_carpenters_guild::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 void building_carpenters_guild::on_create(int orientation) {

--- a/src/building/building_impl.cpp
+++ b/src/building/building_impl.cpp
@@ -84,6 +84,11 @@ void building_impl::update_graphic() {
     base.minimap_anim = anim("minimap");
 }
 
+void building_impl::update_graphic_work_anim() {
+    set_animation(can_play_animation() ? animkeys().work : animkeys().none);
+    building_impl::update_graphic();
+}
+
 void building_impl::remove_dead_figures() {
     for (int i = 0; i < base.max_figures; i++) {
         figure *f = this->get_figure(i);

--- a/src/building/building_impl.h
+++ b/src/building/building_impl.h
@@ -165,6 +165,7 @@ public:
     void common_spawn_labor_seeker(int min_houses);
     bool common_spawn_figure_trigger(int min_houses, int slot = BUILDING_SLOT_SERVICE);
     bool common_spawn_roamer(e_figure_type type, int min_houses, e_figure_action created_action);
+    void update_graphic_work_anim();
     int max_workers() const;
     int pct_workers() const;
     int get_figure_id(int i) const;

--- a/src/building/building_industry.cpp
+++ b/src/building/building_industry.cpp
@@ -71,10 +71,7 @@ bool building_industry::can_play_animation() const {
 }
 
 void building_industry::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 void building_industry::production_finished() {

--- a/src/building/building_jugler_school.cpp
+++ b/src/building/building_jugler_school.cpp
@@ -20,10 +20,7 @@ void building_juggler_school::update_day() {
 }
 
 void building_juggler_school::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 void building_juggler_school::spawn_figure() {

--- a/src/building/building_mine.cpp
+++ b/src/building/building_mine.cpp
@@ -9,13 +9,7 @@ void building_mine::on_create(int orientation) {
 }
 
 void building_mine::update_graphic() {
-    const xstring &animkey = can_play_animation()
-                                ? animkeys().work
-                                : animkeys().none;
-
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bool building_mine::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {

--- a/src/building/building_mortuary.cpp
+++ b/src/building/building_mortuary.cpp
@@ -77,10 +77,7 @@ bool building_mortuary::can_play_animation() const {
 }
 
 void building_mortuary::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bool building_mortuary::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {

--- a/src/building/building_palace.cpp
+++ b/src/building/building_palace.cpp
@@ -62,10 +62,7 @@ bool building_palace::can_play_animation() const {
 }
 
 void building_palace::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bool building_palace::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {

--- a/src/building/building_scribal_school.cpp
+++ b/src/building/building_scribal_school.cpp
@@ -60,10 +60,7 @@ void building_scribal_school::spawn_figure() {
 }
 
 void building_scribal_school::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bool building_scribal_school::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color mask) {

--- a/src/building/building_stonemason_guild.cpp
+++ b/src/building/building_stonemason_guild.cpp
@@ -25,10 +25,7 @@ declare_console_command(addgranite, game_cheat_add_resource<RESOURCE_GRANITE>);
 declare_console_command(addsandstone, game_cheat_add_resource<RESOURCE_SANDSTONE>);
 
 void building_stonemason_guild::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 void building_stonemason_guild::on_create(int orientation) {

--- a/src/building/building_tax_collector.cpp
+++ b/src/building/building_tax_collector.cpp
@@ -84,10 +84,7 @@ void building_tax_collector::update_month() {
 }
 
 void building_tax_collector::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 bvariant building_tax_collector::get_property(const xstring &domain, const xstring &name) const {

--- a/src/building/building_work_camp.cpp
+++ b/src/building/building_work_camp.cpp
@@ -80,9 +80,7 @@ bool building_work_camp::draw_ornaments_and_animations_height(painter &ctx, vec2
 }
 
 void building_work_camp::update_graphic() {
-    set_animation(can_play_animation() ? animkeys().work : animkeys().none);
-
-    building_impl::update_graphic();
+    update_graphic_work_anim();
 }
 
 void building_work_camp::update_month() {


### PR DESCRIPTION
## Summary

- Added `building_impl::update_graphic_work_anim()` helper that encapsulates the repeated pattern: toggle animation between `work` and `none` based on `can_play_animation()`, then call `building_impl::update_graphic()`
- Collapsed 14 identical `update_graphic()` overrides across academy, bricklayers_guild, carpenters_guild, dance_school, dentist, industry, juggler_school, mine, mortuary, palace, scribal_school, stonemason_guild, tax_collector, and work_camp
- Net: −64 / +20 lines, no logic changes

## Notes

Two buildings intentionally left out:
- `building_storage_yard` and `building_jewels_workshop` have the same animation toggle but **skip** the `building_impl::update_graphic()` base call — needs manual verification before unifying

