### PR TITLE
refactor: remove redundant draw_ornaments_and_animations_height overrides

### DIFF
--- a/src/building/building_bricklayers_guild.cpp
+++ b/src/building/building_bricklayers_guild.cpp
@@ -160,8 +160,3 @@ void building_bricklayers_guild::spawn_figure() {
     }
 }
 
-bool building_bricklayers_guild::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {
-    building_impl::draw_ornaments_and_animations_height(ctx, point, tile, color_mask);
-
-    return true;
-}

--- a/src/building/building_bricklayers_guild.h
+++ b/src/building/building_bricklayers_guild.h
@@ -13,8 +13,6 @@ public:
     virtual void on_create(int orientation) override;
     virtual void spawn_figure() override;
     virtual void update_graphic() override;
-    virtual bool draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) override;
-
     bool can_spawn_bricklayer_man();
 };
 ANK_CONFIG_STRUCT(building_bricklayers_guild::static_params, max_workers)

--- a/src/building/building_guild_carpenters.cpp
+++ b/src/building/building_guild_carpenters.cpp
@@ -121,8 +121,3 @@ void building_carpenters_guild::spawn_figure() {
     }
 }
 
-bool building_carpenters_guild::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {
-    building_impl::draw_ornaments_and_animations_height(ctx, point, tile, color_mask);
-
-    return true;
-}

--- a/src/building/building_guild_carpenters.h
+++ b/src/building/building_guild_carpenters.h
@@ -9,7 +9,5 @@ public:
     virtual void on_create(int orientation) override;
     virtual void spawn_figure() override;
     virtual void update_graphic() override;
-    virtual bool draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) override;
-
     bool can_spawn_carpenter(int max_gatherers_per_building);
 };

--- a/src/building/building_jewels_workshop.cpp
+++ b/src/building/building_jewels_workshop.cpp
@@ -60,10 +60,7 @@ bool building_jewels_workshop::draw_ornaments_and_animations_height(painter &ctx
 }
 
 void building_jewels_workshop::update_graphic() {
-    const xstring &animkey = can_play_animation()
-                                ? animkeys().work
-                                : animkeys().none;
-    set_animation(animkey);
+    update_graphic_work_anim();
 }
 
 int building_jewels_workshop::count_nearby_workshops() const {

--- a/src/building/building_stonemason_guild.cpp
+++ b/src/building/building_stonemason_guild.cpp
@@ -125,8 +125,3 @@ void building_stonemason_guild::spawn_figure() {
     }
 }
 
-bool building_stonemason_guild::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {
-    building_impl::draw_ornaments_and_animations_height(ctx, point, tile, color_mask);
-
-    return true;
-}

--- a/src/building/building_stonemason_guild.h
+++ b/src/building/building_stonemason_guild.h
@@ -9,7 +9,5 @@ public:
     virtual void on_create(int orientation) override;
     virtual void spawn_figure() override;
     virtual void update_graphic() override;
-    virtual bool draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) override;
-
     bool can_spawn_stonemason_man(int max_gatherers_per_building);
 };

--- a/src/building/building_storage_yard.cpp
+++ b/src/building/building_storage_yard.cpp
@@ -1017,9 +1017,7 @@ void building_storage_yard::spawn_figure() {
 }
 
 void building_storage_yard::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().none;
-
-    set_animation(animkey);
+    update_graphic_work_anim();
 }
 
 building_storage_yard *storage_yard_cast(building *b) {

--- a/src/building/building_work_camp.cpp
+++ b/src/building/building_work_camp.cpp
@@ -73,12 +73,6 @@ void building_work_camp::spawn_figure() {
     dest->dcast()->add_workers(f->id);
 }
 
-bool building_work_camp::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color color_mask) {
-    building_impl::draw_ornaments_and_animations_height(ctx, point, tile, color_mask);
-
-    return true;
-}
-
 void building_work_camp::update_graphic() {
     update_graphic_work_anim();
 }

--- a/src/building/building_work_camp.h
+++ b/src/building/building_work_camp.h
@@ -11,7 +11,5 @@ public:
     virtual void spawn_figure() override;
     virtual void update_graphic() override;
     virtual void update_month() override;
-    virtual bool draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color mask) override;
-
     building *determine_worker_needed();
 };


### PR DESCRIPTION
## Summary

- Removed 4 trivially redundant `draw_ornaments_and_animations_height()` overrides in `bricklayers_guild`, `carpenters_guild`, `stonemason_guild`, `work_camp` — they only called the base and returned `true`, but the caller (`widget_city.cpp`) never uses the return value
- Unified `update_graphic()` in `storage_yard` and `jewels_workshop` to use `update_graphic_work_anim()` (introduced in #533), closing the open question from that PR — the missing base call in those two was unintentional duplication, not intentional omission
