### PR TITLE
fix: artisans guild cost scalar → 5-element array

### DIFF
--- a/src/scripts/buildings.js
+++ b/src/scripts/buildings.js
@@ -411,9 +411,15 @@ building_wood_cutter {
 }
 
 building_artisans_guild = {
-  cost: 30
+  labor_category : LABOR_CATEGORY_INFRASTRUCTURE
+  building_size: 2
+  cost: [ 30, 50, 80, 100, 150 ]
   desirability : { value:[-6], step:[1], step_size:[1], range: [4] }
   laborers:[15], fire_risk:[2], damage_risk: [2]
+  flags {
+    is_guild: true
+    is_industry: true
+  }
 }
 
 building_tax_collector = {


### PR DESCRIPTION
## Summary

- `building_artisans_guild` had `cost: 30` (scalar) instead of the required 5-element difficulty array
- The archive reader leaves `value_dcy` empty for scalars, so the building showed **0 deben** cost in the build menu on all difficulty levels
- Fixed to `cost: [30, 50, 80, 100, 150]`
- Also added missing `building_size: 2`, `labor_category`, and guild flags

## Test plan

- [ ] Open build menu — Artisans' Guild should show correct cost (30 deben on Normal)
- [ ] Verify cost scales correctly across difficulty levels