### PR TITLE
fix: dentist laborers 2→5 and add missing labor_category

### DIFF
--- a/src/scripts/buildings.js
+++ b/src/scripts/buildings.js
@@ -742,6 +742,7 @@ building_dentist {
   }
 
   overlay : OVERLAY_DENTIST
+  labor_category : LABOR_CATEGORY_WATER_HEALTH
   min_houses_coverage : 50
   max_serve_clients : 1000
   building_size : 1
@@ -749,7 +750,7 @@ building_dentist {
   info_sound : "Wavs/dentist.wav"
   cost [ 10, 15, 30, 50, 80 ]
   desirability { value[2], step[1], step_size[-1], range[2] }
-  laborers[2]
+  laborers[5]
   fire_risk[4]
   damage_risk[2]
 }


### PR DESCRIPTION
## Summary

- `building_dentist` had `laborers[2]` — corrected to `laborers[5]` to match `apothecary` and `physician`
- Added missing `labor_category: LABOR_CATEGORY_WATER_HEALTH` (all other health buildings have it)

## Test plan

- [ ] Dentist shows correct worker count (5) in building info window
- [ ] Dentist appears in the correct labor category in the Labor advisor