### PR TITLE
fix: add missing labor_category to building_mortuary

### DIFF
--- a/src/scripts/buildings.js
+++ b/src/scripts/buildings.js
@@ -771,6 +771,7 @@ building_mortuary {
   monthly_linen_consumption : 20
   min_houses_coverage : 50
   building_size : 2
+  labor_category : LABOR_CATEGORY_WATER_HEALTH
   meta { help_id:66, text_id:82 }
   info_sound : "Wavs/mortuary.wav"
   cost [ 20, 30, 50, 100, 200 ]


### PR DESCRIPTION
## Summary

- `building_mortuary` was missing `labor_category: LABOR_CATEGORY_WATER_HEALTH`
- All other health buildings (apothecary, physician, dentist, water_supply, well) define it — mortuary was the only exception
- Without it the mortuary workers were not counted in the correct labor category

## Test plan

- [ ] Mortuary workers appear under the correct category in the Labor advisor