### PR TITLE
Add debug terrain paint brush

### DIFF
--- a/src/building/construction/build_planner.cpp
+++ b/src/building/construction/build_planner.cpp
@@ -1,5 +1,6 @@
 #include "build_planner.h"
 
+#include "editor/tool.h"
 #include "graphics/view/lookup.h"
 #include "grid/floodplain.h"
 #include "core/log.h"
@@ -460,6 +461,10 @@ void build_planner::setup_build(e_building_type type) { // select building for c
     default:
         break;
     }
+
+    // selecting a real building cancels any active debug terrain-paint tool
+    // so the two placement modes can't both be armed at once
+    editor_tool_deactivate();
 
     const auto &params = building_static_params::get(type);
     const auto &preview = building_planer_renderer::get(type);

--- a/src/editor/tool.cpp
+++ b/src/editor/tool.cpp
@@ -1,9 +1,14 @@
 #include "tool.h"
 
+#include "building/building.h"
+#include "building/building_farm.h"
+#include "building/building_house.h"
 #include "building/construction/routed.h"
+#include "figuretype/figure_homeless.h"
 #include "building/building_road.h"
 #include "city/city_warnings.h"
 #include "city/city.h"
+#include "game/game_config.h"
 #include "game/game_events.h"
 #include "city/city_buildings.h"
 #include "core/random.h"
@@ -11,22 +16,27 @@
 #include "game/undo.h"
 #include "graphics/image.h"
 #include "graphics/image_groups.h"
+#include "grid/building.h"
 #include "grid/building_tiles.h"
 #include "grid/elevation.h"
+#include "grid/floodplain.h"
 #include "grid/grid.h"
 #include "grid/trees.h"
 #include "grid/image_context.h"
+#include "grid/moisture.h"
 #include "grid/property.h"
 #include "grid/routing/routing.h"
 #include "grid/routing/routing_terrain.h"
 #include "grid/terrain.h"
 #include "grid/tiles.h"
+#include "grid/vegetation.h"
+#include "grid/water.h"
 #include "scenario/editor_events.h"
 #include "scenario/editor_map.h"
 #include "widget/widget_minimap.h"
 #include "building/construction/build_planner.h"
 
-#define TERRAIN_PAINT_MASK ~(TERRAIN_TREE | TERRAIN_ROCK | TERRAIN_WATER | TERRAIN_BUILDING | TERRAIN_SHRUB | TERRAIN_GARDEN | TERRAIN_ROAD | TERRAIN_MEADOW)
+#define TERRAIN_PAINT_MASK ~(TERRAIN_TREE | TERRAIN_ROCK | TERRAIN_WATER | TERRAIN_DEEPWATER | TERRAIN_BUILDING | TERRAIN_SHRUB | TERRAIN_GARDEN | TERRAIN_ROAD | TERRAIN_MEADOW | TERRAIN_FLOODPLAIN | TERRAIN_MARSHLAND)
 
 static struct {
     int active = 0;
@@ -37,6 +47,15 @@ static struct {
     int start_elevation = 0;
     tile2i start_tile = {0, 0};
 } data;
+
+// Set per stroke by add_terrain when a TOOL_GRASS brush clears a TERRAIN_WATER
+// or TERRAIN_DEEPWATER bit. editor_tool_update_use reads it to decide whether
+// to widen the moisture / empty-land refresh by the band radius. Removing
+// water grows distance-to-water for adjacent land, so the surrounding band
+// needs to settle; but on a paint-over-land stroke nobody's distance
+// changed, and widening would just overwrite authored moisture with the
+// smoothed profile.
+static bool s_brush_cleared_water = false;
 
 int editor_tool_type(void) {
     return data.type;
@@ -119,6 +138,8 @@ int editor_tool_is_brush(void) {
     case TOOL_SHRUB:
     case TOOL_ROCKS:
     case TOOL_MEADOW:
+    case TOOL_FLOODPLAIN:
+    case TOOL_REEDS:
     case TOOL_RAISE_LAND:
     case TOOL_LOWER_LAND:
         return 1;
@@ -156,6 +177,48 @@ static int lower_land_tile(int x, int y, int grid_offset, int terrain) {
     return terrain;
 }
 
+static void demolish_building_at(int grid_offset) {
+    int bid = map_building_at(grid_offset);
+    if (bid <= 0) {
+        return;
+    }
+
+    building *b = building_get(bid)->main();
+    if (!b || b->state == BUILDING_STATE_UNUSED || b->state == BUILDING_STATE_DELETED_BY_PLAYER) {
+        return;
+    }
+
+    auto house = b->dcast_house();
+    if (house && house->house_population() > 0) {
+        events::emit(event_create_homeless{ b->tile, house->house_population(), SOURCE_LOCATION });
+        house->runtime_data().population = 0;
+    }
+
+    if (b->is_floodplain_farm() && !!game_features::gameplay_change_soil_depletion) {
+        b->dcast_farm()->deplete_soil();
+    }
+
+    b->state = BUILDING_STATE_DELETED_BY_PLAYER;
+    b->is_deleted = 1;
+
+    building *space = b;
+    for (int iter = 0; space->prev_part_building_id > 0 && iter < 128; ++iter) {
+        space = building_get(space->prev_part_building_id);
+        space->state = BUILDING_STATE_DELETED_BY_PLAYER;
+    }
+
+    space = b;
+    for (int iter = 0; space->next_part_building_id > 0 && iter < 128; ++iter) {
+        space = space->next();
+        if (space->id <= 0) {
+            break;
+        }
+        space->state = BUILDING_STATE_DELETED_BY_PLAYER;
+    }
+
+    map_building_tiles_remove(b->id, b->tile);
+}
+
 static void add_terrain(const void* tile_data, int dx, int dy) {
     tile2i tile = *(tile2i*)tile_data;
     int x = tile.x() + dx;
@@ -165,13 +228,30 @@ static void add_terrain(const void* tile_data, int dx, int dy) {
     int grid_offset = tile.grid_offset() + GRID_OFFSET(dx, dy);
     int terrain = map_terrain_get(grid_offset);
     if (terrain & TERRAIN_BUILDING) {
-        map_building_tiles_remove(0, tile2i(x, y));
+        demolish_building_at(grid_offset);
         terrain = map_terrain_get(grid_offset);
     }
     switch (data.type) {
-    case TOOL_GRASS:
+    case TOOL_GRASS: {
+        // depth on neighbouring water tiles is handled by the per-region
+        // map_water_recompute_depth_region() pass in editor_tool_update_use
+        //
+        // Match the moisture probe's definition of "open water": deepwater
+        // always counts; plain water counts only when NOT marked floodplain.
+        // distance_to_water in moisture.cpp filters out floodplain tiles
+        // (those carry TERRAIN_WATER during the flood stage of the cycle
+        // but the original game does not grow a grass band against them),
+        // so removing one does not change any tile's distance-to-water
+        // and must NOT trigger band-radius widening.
+        const bool was_deepwater = !!(terrain & TERRAIN_DEEPWATER);
+        const bool was_open_water = (terrain & TERRAIN_WATER) && !(terrain & TERRAIN_FLOODPLAIN);
+        if (was_deepwater || was_open_water) {
+            s_brush_cleared_water = true;
+        }
         terrain &= TERRAIN_PAINT_MASK;
+        map_vegetation_deplete(grid_offset);
         break;
+    }
     case TOOL_TREES:
         if (!(terrain & TERRAIN_TREE)) {
             terrain &= TERRAIN_PAINT_MASK;
@@ -202,6 +282,18 @@ static void add_terrain(const void* tile_data, int dx, int dy) {
             terrain |= TERRAIN_MEADOW;
         }
         break;
+    case TOOL_FLOODPLAIN:
+        if (!(terrain & TERRAIN_FLOODPLAIN)) {
+            terrain &= TERRAIN_PAINT_MASK;
+            terrain |= TERRAIN_FLOODPLAIN;
+        }
+        break;
+    case TOOL_REEDS:
+        if (!(terrain & TERRAIN_MARSHLAND)) {
+            terrain &= TERRAIN_PAINT_MASK;
+            terrain |= TERRAIN_MARSHLAND;
+        }
+        break;
     case TOOL_RAISE_LAND:
         terrain = raise_land_tile(x, y, grid_offset, terrain);
         break;
@@ -227,28 +319,98 @@ void editor_tool_update_use(tile2i tile) {
     if (!editor_tool_is_brush())
         return;
 
+    s_brush_cleared_water = false;
     editor_tool_foreach_brush_tile(add_terrain, &tile);
+
+    // Propagate the newly painted perimeter terrain out to the off-map ring
+    // so the refresh passes below see continuous terrain across the map edge
+    // instead of stale TREE | WATER scenery — that mismatch was causing
+    // inward tiles to flip to grass whenever the brush touched the border.
+    map_terrain_init_outside_map();
 
     int x_min = tile.x() - data.brush_size;
     int x_max = tile.x() + data.brush_size;
     int y_min = tile.y() - data.brush_size;
     int y_max = tile.y() + data.brush_size;
     switch (data.type) {
-    case TOOL_GRASS:
+    case TOOL_GRASS: {
+        // rebuild caches first so the river/water cache reflects tiles that
+        // were just painted over, then enforce the 2-tile shallow collar
+        // around the new shore (demotes any old deepwater that the brush
+        // brought within 2 of land), then refresh moisture & images.
+        build_terrain_caches();
+        map_water_recompute_depth_region(tile2i(x_min, y_min), tile2i(x_max, y_max));
+
+        // Widen ONLY when the brush actually removed water. Removing water
+        // grows distance-to-water for adjacent land, so a band-radius ring
+        // around the brush needs to settle. Paint-over-land changes no
+        // tile's distance — widening then would clobber the mapper's
+        // authored per-tile moisture variation with the smoothed profile
+        // and turn authored desert near water into uniform low-grass
+        // anywhere the brush goes (the "grass appears at the border"
+        // symptom). For paint-over-land we still re-image brush ± 1 to
+        // cover set_empty_land_pass2's 1-tile neighbour check.
+        const int m_moisture = s_brush_cleared_water ? map_moisture_band_radius() : 0;
+        const int m_image    = s_brush_cleared_water ? map_moisture_band_radius() : 1;
+        tile2i mmin(x_min - m_moisture, y_min - m_moisture);
+        tile2i mmax(x_max + m_moisture, y_max + m_moisture);
+        map_moisture_update_region(mmin, mmax);
+
+        tile2i imin(x_min - m_image, y_min - m_image);
+        tile2i imax(x_max + m_image, y_max + m_image);
+        // Safety-net: any tile inside the image refresh region that falls
+        // outside the visible diamond gets forced back to plain desert.
+        // The load-time pass already cleared them, but the brush's re-image
+        // pass would otherwise let authored data leak back if a stroke
+        // touched the diamond boundary.
+        map_normalize_outside_diamond_region(imin, imax);
         map_image_context_reset_water();
-        map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
+        if (s_brush_cleared_water) {
+            map_tiles_river_refresh_entire();
+        } else {
+            map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
+        }
         map_tiles_update_all_rocks();
-        map_tiles_update_region_empty_land(false, tile2i(x_min, y_min), tile2i(x_max, y_max));
-        map_tiles_update_region_meadow(x_min, y_min, x_max, y_max);
+        map_tiles_update_region_empty_land(true, imin, imax);
+        map_tiles_update_region_meadow(imin.x(), imin.y(), imax.x(), imax.y());
+        map_tree_update_region_tiles(x_min, y_min, x_max, y_max);
+        map_tiles_upadte_all_marshland_tiles();
+        map_routing_update_land();
         break;
+    }
     case TOOL_TREES:
         map_image_context_reset_water();
         map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
         map_tiles_update_all_rocks();
         map_tree_update_region_tiles(x_min, y_min, x_max, y_max);
         break;
-    case TOOL_WATER:
+    case TOOL_WATER: {
+        // promote interior painted water to deepwater (and demote any old
+        // deepwater now within 2 of new shore) before re-imaging, so the
+        // river refresh sees the final depth state. Then recompute moisture
+        // on the surrounding land — fresh water shrinks distance-to-water
+        // for nearby empty land — and re-image empty land in the same
+        // widened band so the freshly-grown grass shore appears immediately.
+        // The widening lives here now: map_moisture_update_region no longer
+        // widens internally (it would clobber authored moisture on every
+        // brush stroke).
+        map_water_recompute_depth_region(tile2i(x_min, y_min), tile2i(x_max, y_max));
+        map_image_context_reset_water();
+        const int m = map_moisture_band_radius();
+        tile2i wmin(x_min - m, y_min - m), wmax(x_max + m, y_max + m);
+        map_moisture_update_region(wmin, wmax);
+        // Same safety-net as TOOL_GRASS — wipe any out-of-diamond tiles
+        // the refresh region covers, so the wide image pass doesn't put
+        // shore/grass art onto the off-diamond corners.
+        map_normalize_outside_diamond_region(wmin, wmax);
+        map_tiles_update_all_rocks();
+        map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
+        map_tiles_update_region_empty_land(true, wmin, wmax);
+        map_tiles_update_region_meadow(wmin.x(), wmin.y(), wmax.x(), wmax.y());
+        break;
+    }
     case TOOL_ROCKS:
+    case TOOL_FLOODPLAIN:
         map_image_context_reset_water();
         map_tiles_update_all_rocks();
         map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
@@ -263,7 +425,16 @@ void editor_tool_update_use(tile2i tile) {
         map_image_context_reset_water();
         map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
         map_tiles_update_all_rocks();
+        map_tiles_update_region_empty_land(false, tile2i(x_min, y_min), tile2i(x_max, y_max));
         map_tiles_update_region_meadow(x_min, y_min, x_max, y_max);
+        map_routing_update_land();
+        break;
+    case TOOL_REEDS:
+        map_image_context_reset_water();
+        map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
+        map_tiles_update_all_rocks();
+        build_terrain_caches();
+        map_tiles_upadte_all_marshland_tiles();
         break;
     case TOOL_RAISE_LAND:
     case TOOL_LOWER_LAND:
@@ -431,6 +602,14 @@ void editor_tool_end_use(tile2i tile) {
         break;
     case TOOL_ROAD:
         place_road(data.start_tile, tile);
+        break;
+    case TOOL_GRASS:
+    case TOOL_FLOODPLAIN:
+        // floodplain tile membership changed: re-derive flood order & shores
+        // so painted tiles join (or leave) the inundation cycle
+        build_terrain_caches();
+        map_floodplain_rebuild_rows();
+        map_floodplain_rebuild_shores();
         break;
     default:
         break;

--- a/src/editor/tool.h
+++ b/src/editor/tool.h
@@ -11,6 +11,8 @@ enum {
     TOOL_SHRUB = 4,
     TOOL_ROCKS = 5,
     TOOL_MEADOW = 6,
+    TOOL_FLOODPLAIN = 7,
+    TOOL_REEDS = 8,
     TOOL_ACCESS_RAMP = 9,
     TOOL_ROAD = 10,
     TOOL_RAISE_LAND = 11,

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -72,6 +72,7 @@ struct game_t {
     bool debug_console = false;
     bool debug_properties = false;
     bool debug_perfmon = false;
+    bool debug_terrain_paint = false;
     uint32_t frame = 0;
     uint16_t last_frame_tick = 0;
     color *frame_pixels = nullptr;

--- a/src/game/setting_js.cpp
+++ b/src/game/setting_js.cpp
@@ -46,6 +46,9 @@ ANK_FUNCTION(__game_is_fullscreen_only)
 bool __game_debug_properties() { return game.debug_properties; }
 ANK_FUNCTION(__game_debug_properties)
 
+bool __game_debug_terrain_paint() { return game.debug_terrain_paint; }
+ANK_FUNCTION(__game_debug_terrain_paint)
+
 bool __game_writing_video() { return game.get_write_video(); }
 ANK_FUNCTION(__game_writing_video)
 

--- a/src/graphics/view/view.cpp
+++ b/src/graphics/view/view.cpp
@@ -94,11 +94,30 @@ int SCROLL_MIN_SCREENTILE_X = 0;
 int SCROLL_MIN_SCREENTILE_Y = 0;
 int SCROLL_MAX_SCREENTILE_X = 0;
 int SCROLL_MAX_SCREENTILE_Y = 0;
+int CAMERA_EXTRA_SCROLL_MARGIN_TILES = 0;
+static void camera_validate_position(viewport_t& view);
 void camera_calc_scroll_limits() {
-    SCROLL_MIN_SCREENTILE_X = (GRID_LENGTH - (scenario_map_data()->width / 2) + 2) / 2;
-    SCROLL_MIN_SCREENTILE_Y = ((2 * GRID_LENGTH) - scenario_map_data()->height) / 2;
+    // Y screen-tile units are HALF_TILE_HEIGHT_PIXELS, so a 1-world-tile
+    // margin in Y costs 2 screen-Y units; X units already map 1:1 to a
+    // world tile's screen width. Subtracting from MIN automatically widens
+    // MAX by the same amount because MAX is defined symmetrically about
+    // GRID_LENGTH below.
+    const int margin = CAMERA_EXTRA_SCROLL_MARGIN_TILES;
+    SCROLL_MIN_SCREENTILE_X = (GRID_LENGTH - (scenario_map_data()->width / 2) + 2) / 2 - margin;
+    SCROLL_MIN_SCREENTILE_Y = ((2 * GRID_LENGTH) - scenario_map_data()->height) / 2 - 2 * margin;
     SCROLL_MAX_SCREENTILE_X = GRID_LENGTH - SCROLL_MIN_SCREENTILE_X + 2;
     SCROLL_MAX_SCREENTILE_Y = (2 * GRID_LENGTH) - SCROLL_MIN_SCREENTILE_Y;
+}
+
+void camera_set_extra_scroll_margin(int world_tiles) {
+    if (world_tiles < 0) {
+        world_tiles = 0;
+    }
+    CAMERA_EXTRA_SCROLL_MARGIN_TILES = world_tiles;
+    camera_calc_scroll_limits();
+    // Tightening the bounds may leave the camera outside the new clamp;
+    // validate to snap back to the nearest allowed edge.
+    camera_validate_position(g_city_view);
 }
 
 vec2i city_view_get_camera_max_tile() {

--- a/src/graphics/view/view.h
+++ b/src/graphics/view/view.h
@@ -9,7 +9,12 @@ extern int SCROLL_MIN_SCREENTILE_X;
 extern int SCROLL_MIN_SCREENTILE_Y;
 extern int SCROLL_MAX_SCREENTILE_X;
 extern int SCROLL_MAX_SCREENTILE_Y;
+// Extra panning headroom (in world tiles) beyond the normal map-edge limits.
+// Recomputed into SCROLL_* by camera_calc_scroll_limits(); apply via the
+// helper below so the camera snaps back when the margin is reduced.
+extern int CAMERA_EXTRA_SCROLL_MARGIN_TILES;
 void camera_calc_scroll_limits();
+void camera_set_extra_scroll_margin(int world_tiles);
 
 typedef vec2i screen_tile;
 

--- a/src/grid/floodplain.cpp
+++ b/src/grid/floodplain.cpp
@@ -210,6 +210,9 @@ int map_floodplain_rebuild_rows() {
         floodplain_tiles_caches_by_row[row].clear();
     }
 
+    // must be cleared too, otherwise repeated rebuilds keep appending stale tiles
+    floodplain_tiles_random.clear();
+
     foreach_river_tile([&] (int tile_offset) {
         bool is_vergin_floodplain = map_terrain_is(tile_offset, TERRAIN_FLOODPLAIN);
         if (is_vergin_floodplain) {

--- a/src/grid/moisture.cpp
+++ b/src/grid/moisture.cpp
@@ -1,11 +1,33 @@
 #include "moisture.h"
 #include "grid.h"
+#include "terrain.h"
+#include "tiles.h"
 #include "io/io_buffer.h"
+#include "core/log.h"
+
+#include <algorithm>
 
 static grid_xx terrain_moisture(FS_UINT8);
 
+// Sampled at map load by map_moisture_recompute_profile(): per-ring grass
+// byte for ring distances 1..16 from water. Index 0 is unused; values
+// outside the sampled range are 0 (desert). When the brush refills moisture
+// under cleared land, each tile looks up its ring distance in this table —
+// so the painted band's plateau width and taper shape match the original
+// mapper's brush instead of a synthetic linear formula.
+static uint8_t s_moisture_profile[17] = {0};
+
+// Cached largest ring with a non-zero profile entry. Used to widen the
+// empty-land image refresh after a paint stroke. Default mirrors the
+// load-time fallback for waterless maps.
+static int s_map_grass_radius = 4;
+
 uint8_t map_moisture_get(int grid_offset) {
     return map_grid_get(terrain_moisture, grid_offset);
+}
+
+void map_moisture_clear_tile(int grid_offset) {
+    map_grid_set(terrain_moisture, grid_offset, 0);
 }
 
 uint8_t map_grasslevel_get(int grid_offset) {
@@ -33,6 +55,193 @@ uint8_t map_grasslevel_get(int grid_offset) {
 //     }
 //     return true;
 // }
+
+// Expanding-ring probe for the nearest OPEN water tile (river / sea), with
+// floodplain tiles deliberately excluded. Returns the ring distance
+// (1..max_d), or max_d + 1 if no open water is within range.
+//
+// Floodplain tiles often carry the TERRAIN_WATER bit during the flood
+// stage of the cycle, but the original game does not grow a grass band
+// against the land/floodplain edge — only against open river/sea shore.
+// Filtering out anything with TERRAIN_FLOODPLAIN keeps painted grass
+// consistent with that behaviour. Deepwater still counts (the Nile is
+// largely TERRAIN_DEEPWATER along its centre line).
+static int distance_to_water(tile2i tile, int max_d) {
+    for (int r = 1; r <= max_d; ++r) {
+        const grid_area area = map_grid_get_area(tile, 1, r);
+        for (int yy = area.tmin_y; yy <= area.tmax_y; ++yy) {
+            for (int xx = area.tmin_x; xx <= area.tmax_x; ++xx) {
+                const int n = MAP_OFFSET(xx, yy);
+                if (map_terrain_is(n, TERRAIN_WATER | TERRAIN_DEEPWATER)
+                    && !map_terrain_is(n, TERRAIN_FLOODPLAIN)) {
+                    return r;
+                }
+            }
+        }
+    }
+    return max_d + 1;
+}
+
+// Only refill moisture on empty land. TERRAIN_NOT_CLEAR covers water,
+// deepwater, floodplain, building, road, rock, tree, marshland, etc. —
+// keeping a single guard prevents the brush from clobbering authored
+// moisture under non-empty tiles. Per-tile moisture = the map's authored
+// profile at this tile's ring distance to water; tiles beyond the band get
+// 0 (desert).
+static void recompute_moisture_tile(int grid_offset) {
+    if (map_terrain_is(grid_offset, TERRAIN_NOT_CLEAR)) {
+        return;
+    }
+    int d = distance_to_water(tile2i(grid_offset), 16);
+    uint8_t m = (d >= 1 && d <= 16) ? s_moisture_profile[d] : 0;
+    map_grid_set(terrain_moisture, grid_offset, m);
+}
+
+void map_moisture_update_region(tile2i tmin, tile2i tmax) {
+    // Update moisture for EXACTLY the given region — no internal widening.
+    // The right widening depends on what the brush did:
+    //   * paint-over-water removed a water tile, so adjacent land's
+    //     distance-to-water grew → widen by band radius
+    //   * paint-over-land changed nobody's distance-to-water → no widening;
+    //     widening here would rewrite the mapper's authored per-tile
+    //     variation with the smoothed profile and turn authored desert into
+    //     uniform low-grass anywhere within band radius of the brush
+    // Callers (editor_tool_update_use) own that decision. map_grid_bound_area
+    // still clamps the supplied rect safely if coordinates go off-map.
+    map_tiles_foreach_region_tile(tmin, tmax, recompute_moisture_tile);
+}
+
+int map_moisture_band_radius() {
+    return s_map_grass_radius;
+}
+
+void map_moisture_recompute_profile() {
+    // Build the painted-grass profile from two summary measurements of the
+    // authored map:
+    //   * plateau_width P — the largest ring d at which a majority of the
+    //     empty-land tiles are level 12 (the full-grass shore band)
+    //   * band_radius   D — the largest ring d at which any grass tile
+    //     appears at all (the taper's far edge)
+    //
+    // The painted profile then is a deterministic plateau + linear taper:
+    //   d in [1, P]   → level 12   (byte 95)
+    //   d in (P, D]   → linear from level 11 down to level 1
+    //   d > D         → 0          (desert)
+    //
+    // This deliberately ignores per-tile noise in the authored gradient and
+    // imitates the visual pattern Pharaoh maps almost always follow: a wide
+    // level-12 plateau against the water, then a tapering transition into
+    // desert. Inferring P and D from the map keeps painted bands consistent
+    // with whatever the original mapper drew.
+    constexpr int probe_cap = 16;
+    int total_count[17] = {0};
+    int level12_count[17] = {0};
+    int grass_count[17] = {0};
+
+    map_tiles_foreach_map_tile([&](int grid_offset) {
+        if (map_terrain_is(grid_offset, TERRAIN_NOT_CLEAR)) {
+            return;
+        }
+        uint8_t lvl = map_grasslevel_get(grid_offset);
+        if (lvl > 12) {
+            // level-13 fallback / level-16+ transitions are corner art,
+            // not gradient samples
+            return;
+        }
+        int d = distance_to_water(tile2i(grid_offset), probe_cap);
+        if (d < 1 || d > probe_cap) {
+            // farther than the probe cap from any water — not part of the
+            // measured grass band
+            return;
+        }
+        total_count[d] += 1;
+        if (lvl > 0) {
+            grass_count[d] += 1;
+        }
+        if (lvl == 12) {
+            level12_count[d] += 1;
+        }
+    });
+
+    // Plateau width: walk outward, advance as long as the current ring has
+    // a meaningful density of level-12 tiles (>=25% of empty-land samples).
+    // The 25% bar is intentionally lower than a strict majority: real
+    // authored shores typically have ~30-45% level-12 tiles inside the
+    // plateau (the rest are scattered shrubs, paths, lower-level grass)
+    // and crash to single-digit percentages once the taper begins, which
+    // makes 25% a clean cutoff at the discontinuity. Empty rings (no
+    // samples) are skipped without breaking the plateau, so a map with
+    // sparse data near the shore still measures a plateau if the next
+    // sampled ring still has it.
+    int plateau_width = 0;
+    bool plateau_open = true;
+    for (int d = 1; d <= probe_cap && plateau_open; ++d) {
+        if (total_count[d] == 0) {
+            continue;
+        }
+        if (level12_count[d] * 4 >= total_count[d]) {
+            plateau_width = d;
+        } else {
+            plateau_open = false;
+        }
+    }
+
+    // Band radius: the largest ring with any grass at all. Even rings with
+    // just a few stray grass tiles count, so the taper extends as far as
+    // the authored grass does.
+    int band_radius = 0;
+    for (int d = probe_cap; d >= 1; --d) {
+        if (grass_count[d] > 0) {
+            band_radius = d;
+            break;
+        }
+    }
+    if (band_radius < plateau_width) {
+        band_radius = plateau_width; // safety: band ends no earlier than plateau
+    }
+
+    for (int d = 0; d < 17; ++d) {
+        s_moisture_profile[d] = 0;
+    }
+
+    if (band_radius == 0) {
+        // Waterless / grassless map — seed a synthetic fallback so the
+        // brush still produces a reasonable band if the user later paints
+        // water. Levels 12 → 9 → 6 → 3 = bytes 95 → 71 → 47 → 23.
+        s_moisture_profile[1] = 95;
+        s_moisture_profile[2] = 71;
+        s_moisture_profile[3] = 47;
+        s_moisture_profile[4] = 23;
+        s_map_grass_radius = 4;
+        return;
+    }
+
+    const int taper_span = band_radius - plateau_width;
+    for (int d = 1; d <= band_radius; ++d) {
+        int level;
+        if (d <= plateau_width) {
+            level = 12;
+        } else {
+            // Linear taper from level 11 (just past the plateau) down to
+            // level 1 (at the band's far edge). Round to nearest.
+            const int taper_d = d - plateau_width;
+            level = (11 * (taper_span - taper_d + 1) + taper_span / 2) / taper_span;
+            level = std::clamp(level, 1, 11);
+        }
+        s_moisture_profile[d] = static_cast<uint8_t>(MOISTURE_GRASS + 8 * (level - 1));
+    }
+
+    s_map_grass_radius = std::clamp(band_radius, 2, 16);
+
+    // TEMPORARY DIAGNOSTIC: paste these lines back if the painted gradient
+    // looks wrong. Per-ring counts of empty-land tiles, level-12 tiles, any
+    // grass, and the final profile byte the brush will write at each ring.
+    logs::info("[moisture] plateau=%d band=%d radius=%d", plateau_width, band_radius, s_map_grass_radius);
+    for (int d = 1; d <= 16; ++d) {
+        logs::info("[moisture]  d=%2d  total=%5d  lvl12=%5d  grass=%5d  profile=%3d",
+                   d, total_count[d], level12_count[d], grass_count[d], (int)s_moisture_profile[d]);
+    }
+}
 
 io_buffer* iob_moisture_grid = new io_buffer([](io_buffer* iob, size_t version) {
     iob->bind(BIND_SIGNATURE_GRID, &terrain_moisture);

--- a/src/grid/moisture.h
+++ b/src/grid/moisture.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "grid/point.h"
+
 #include <cstdint>
 
 enum {
@@ -13,4 +15,36 @@ enum {
 
 uint8_t map_moisture_get(int grid_offset);
 uint8_t map_grasslevel_get(int grid_offset);
+
+// Force a single tile's moisture to 0. Used by the out-of-diamond
+// normalization pass — those tiles must render as plain desert, and
+// map_grasslevel_get returns 0 only when moisture is 0.
+void map_moisture_clear_tile(int grid_offset);
 // bool map_is_4x4_tallgrass(pixel_coordinate pixel, map_point point);
+
+// Editor-side moisture regrowth. The moisture grid drives grass-vs-desert in
+// set_empty_land_pass2; in regular gameplay it is purely authored data, but
+// the debug terrain-paint tools mutate water/land and need a way to refill
+// moisture under the freshly-cleared land so a grassy shore band reappears.
+//
+// Updates EXACTLY the supplied region — does NOT widen by band radius. The
+// caller owns that decision: paint-over-water needs widening by
+// map_moisture_band_radius() (distance-to-water grew for surrounding land);
+// paint-over-land needs no widening (distance did not change for any tile,
+// so a wider rewrite would just clobber the mapper's authored per-tile
+// variation with the smoothed profile, turning authored desert near water
+// into uniform low-grass).
+void map_moisture_update_region(tile2i tmin, tile2i tmax);
+
+// Cached on map load: the farthest ring distance (1..12) at which the
+// measured moisture profile is still non-zero. Used to widen the empty-land
+// image refresh after a paint stroke so the outer grass-band tiles also
+// regenerate. Falls back to 4 on waterless / grassless maps.
+int map_moisture_band_radius();
+
+// Sample the authored moisture grid into a per-ring-distance profile (mean
+// moisture byte at each distance to water, smoothed monotonically). Called
+// once at map load. Painted tiles replay this profile so the new grass band
+// matches what the original mapper drew — plateau width and taper shape
+// come from the data, not from a synthetic formula.
+void map_moisture_recompute_profile();

--- a/src/grid/terrain.cpp
+++ b/src/grid/terrain.cpp
@@ -4,7 +4,11 @@
 #include "city/city_floods.h"
 #include "floodplain.h"
 #include "grid/grid.h"
+#include "grid/image.h"
+#include "grid/moisture.h"
+#include "grid/property.h"
 #include "grid/ring.h"
+#include "grid/tiles.h"
 #include "grid/trees.h"
 #include "grid/routing/routing.h"
 #include "scenario/map.h"
@@ -361,19 +365,74 @@ void map_terrain_clear() {
 }
 
 void map_terrain_init_outside_map() {
+    // Mirror every outside-map tile from its nearest playable-area tile (the
+    // perimeter projection: clamp x/y to the playable rect). Neighbor checks
+    // in the editor's refresh logic see a continuous terrain across the map
+    // edge instead of stale TREE | WATER scenery, which kept turning inward
+    // tiles into grass when the terrain painter touched the perimeter.
     int map_width = scenario_map_data()->width;
     int map_height = scenario_map_data()->height;
+    if (map_width <= 0 || map_height <= 0) {
+        return;
+    }
 
     int y_start = (GRID_LENGTH - map_height) / 2;
     int x_start = (GRID_LENGTH - map_width) / 2;
+    int x_end = x_start + map_width - 1;
+    int y_end = y_start + map_height - 1;
 
     for (int y = 0; y < GRID_LENGTH; y++) {
-        int y_outside_map = y < y_start || y >= y_start + map_height;
+        int ny = y;
+        if (ny < y_start) ny = y_start;
+        else if (ny > y_end) ny = y_end;
+        const bool y_outside = (y < y_start || y > y_end);
         for (int x = 0; x < GRID_LENGTH; x++) {
-            if (y_outside_map || x < x_start || x >= x_start + map_width)
-                map_grid_set(g_terrain_grid, x + GRID_LENGTH * y, TERRAIN_TREE | TERRAIN_WATER);
+            const bool x_outside = (x < x_start || x > x_end);
+            if (!x_outside && !y_outside) {
+                continue;
+            }
+            int nx = x;
+            if (nx < x_start) nx = x_start;
+            else if (nx > x_end) nx = x_end;
+            const int src = map_grid_get(g_terrain_grid, nx + GRID_LENGTH * ny);
+            map_grid_set(g_terrain_grid, x + GRID_LENGTH * y, src);
         }
     }
+}
+
+// Tiles inside the playable rectangle but outside the inscribed visible
+// diamond (the four triangular corners of the rect) are visible at the
+// edges of the city view but are not really part of the game area. Pharaoh
+// authors them with miscellaneous terrain — scattered trees, grass blocks —
+// that the brush keeps revealing every time it re-images them. Force them
+// to a clean state once and they'll re-render as plain desert.
+//
+// Strategy: clear every terrain bit, zero moisture, drop the image. The
+// next set_empty_land_pass1 paints a generic empty-land tile; pass2 reads
+// the now-zero moisture, gets ph_grass=0, and skips the grass overlay.
+static void normalize_outside_diamond_tile(int grid_offset) {
+    if (map_grid_inside_map_area(grid_offset)) {
+        return;
+    }
+    map_terrain_set(grid_offset, 0);
+    map_moisture_clear_tile(grid_offset);
+    map_image_set(grid_offset, 0);
+    map_property_set_multi_tile_size(grid_offset, 1);
+    map_property_mark_draw_tile(grid_offset);
+}
+
+void map_normalize_outside_diamond_all() {
+    // Walk the full playable rectangle; the per-tile guard skips anything
+    // already inside the diamond, so this is a one-shot cleanup that leaves
+    // the gameplay area untouched.
+    map_tiles_foreach_map_tile(normalize_outside_diamond_tile);
+}
+
+void map_normalize_outside_diamond_region(tile2i tmin, tile2i tmax) {
+    // Region variant for the brush refresh — same guard, but iterates only
+    // the region the brush touched (the in-diamond tiles inside this region
+    // are no-ops). map_tiles_foreach_region_tile clamps to the rect for us.
+    map_tiles_foreach_region_tile(tmin, tmax, normalize_outside_diamond_tile);
 }
 
 void build_terrain_caches() {

--- a/src/grid/terrain.h
+++ b/src/grid/terrain.h
@@ -143,6 +143,19 @@ void map_terrain_restore();
 void map_terrain_clear();
 void map_terrain_init_outside_map();
 
+// Force every tile in the playable rectangle that falls OUTSIDE the
+// inscribed visible diamond into a clean plain-desert state — clears
+// terrain bits, zeros moisture, drops the image so the next empty-land
+// refresh paints a generic desert tile. The four triangular corners of
+// the rect render at the edges of the city view; without this, authored
+// grass / trees in those corners bleed in every time the editor brush
+// re-images nearby tiles.
+//
+// Uses map_grid_inside_map_area as the diamond test — its existing
+// dist_horizontal / dist_vertical formula identifies "boundary or past".
+void map_normalize_outside_diamond_all();
+void map_normalize_outside_diamond_region(tile2i tmin, tile2i tmax);
+
 bool map_terrain_is_near_ferry_route(int base_offset, int radius);
 
 void build_terrain_caches();

--- a/src/grid/water.cpp
+++ b/src/grid/water.cpp
@@ -9,9 +9,12 @@
 #include "grid/point.h"
 #include "grid/property.h"
 #include "grid/terrain.h"
+#include "grid/tiles.h"
 #include "grid/routing/routing.h"
 
+#include <algorithm>
 #include <array>
+#include <cstdlib>
 
 tile_cache river_tiles_cache;
 tile_cache g_river_shore;
@@ -318,4 +321,63 @@ bool map_water_can_spawn_boat(tile2i tile, int size, tile2i &boat_tile) {
         }
     }
     return false;
+}
+
+// Chebyshev (king-move) distance from `tile` to the nearest non-water tile.
+// Returns the ring distance r in [1, max_d], or max_d + 1 if no land within
+// range. Off-map tiles count as land — keeps the shallow collar along the
+// map border the same way it borders inland shores.
+static int distance_to_land(tile2i tile, int max_d) {
+    for (int r = 1; r <= max_d; ++r) {
+        for (int dy = -r; dy <= r; ++dy) {
+            for (int dx = -r; dx <= r; ++dx) {
+                if (std::max(std::abs(dx), std::abs(dy)) != r) {
+                    continue; // only walk the ring at exact distance r
+                }
+                tile2i n(tile.x() + dx, tile.y() + dy);
+                if (!map_grid_is_inside(n, 1)) {
+                    return r; // off-map = shore
+                }
+                if (!map_terrain_is(n.grid_offset(), TERRAIN_WATER | TERRAIN_DEEPWATER)) {
+                    return r;
+                }
+            }
+        }
+    }
+    return max_d + 1;
+}
+
+// Promote/demote the deepwater bit on one tile. Pharaoh's deepwater image
+// table has no land-edge art, so deepwater tiles must sit at least 2
+// Chebyshev-tiles away from any land (1-tile shallow collar). This routine
+// enforces that on both directions: paint-water in the interior promotes
+// to deep, and any previously-deep tile now adjacent to new land gets
+// demoted to shallow.
+static void recompute_depth_tile(int grid_offset) {
+    if (!map_terrain_is(grid_offset, TERRAIN_WATER | TERRAIN_DEEPWATER)) {
+        return;
+    }
+    // Cap the probe at 1: we only need to know whether land is within 1
+    // ring. distance_to_land returns 2 when no land within 1, which is the
+    // deepwater condition.
+    int d = distance_to_land(tile2i(grid_offset), 1);
+    if (d >= 2) {
+        if (!map_terrain_is(grid_offset, TERRAIN_DEEPWATER)) {
+            map_terrain_add(grid_offset, TERRAIN_DEEPWATER);
+        }
+    } else {
+        if (map_terrain_is(grid_offset, TERRAIN_DEEPWATER)) {
+            map_terrain_remove(grid_offset, TERRAIN_DEEPWATER);
+        }
+    }
+}
+
+void map_water_recompute_depth_region(tile2i tmin, tile2i tmax) {
+    // Widen by 1 — that's the collar width; a tile in the outer ring may
+    // have flipped depth class because the brush changed something within
+    // its 1-tile distance window. map_tiles_foreach_region_tile clamps
+    // out-of-map coordinates safely via map_grid_bound_area.
+    tile2i rmin(tmin.x() - 1, tmin.y() - 1);
+    tile2i rmax(tmax.x() + 1, tmax.y() + 1);
+    map_tiles_foreach_region_tile(rmin, rmax, recompute_depth_tile);
 }

--- a/src/grid/water.h
+++ b/src/grid/water.h
@@ -50,3 +50,11 @@ shore_orientation map_shore_determine_orientation(tile2i tile, int size, bool ad
 water_dest map_water_find_shipwreck_tile(figure &wreck);
 void map_water_rebuild_shores();
 bool map_water_can_spawn_boat(tile2i tile, int size, tile2i &boat_tile);
+
+// Walk every water tile inside the region (widened by 1) and set/clear
+// TERRAIN_DEEPWATER based on Chebyshev distance to land: d == 1 keeps
+// TERRAIN_WATER only (the 1-tile shallow shore collar), d >= 2 promotes
+// to TERRAIN_DEEPWATER. Off-map counts as land. Mirrors the 1-tile shallow
+// collar that original Pharaoh maps maintain by hand and keeps the
+// deepwater pattern table (which has no land-edge art) off shore tiles.
+void map_water_recompute_depth_region(tile2i tmin, tile2i tmax);

--- a/src/io/gamestate/boilerplate.cpp
+++ b/src/io/gamestate/boilerplate.cpp
@@ -42,6 +42,7 @@
 #include "grid/sprite.h"
 #include "grid/terrain.h"
 #include "grid/tiles.h"
+#include "grid/moisture.h"
 #include "grid/floodplain.h"
 #include "grid/water.h"
 #include "grid/sandstone.h"
@@ -777,9 +778,34 @@ void GamestateIO::start_loaded_file() {
         scenario_price_change_init();
     }
 
+    // sample the authored moisture-vs-distance-to-water profile for the
+    // editor terrain brush. Runs for BOTH map and save loads — the moisture
+    // grid is unserialised in either path, so the histogram is always
+    // valid by the time we get here. (Originally placed inside the
+    // load-MAP-only branch, which left the profile zero-initialised on save
+    // loads and caused the paint brush to write desert everywhere.)
+    map_moisture_recompute_profile();
+
     // city view / orientation
     city_view_init();
     map_orientation_update_buildings();
+
+    // Refresh the off-map ring so saves authored under the old behaviour
+    // (TREE | WATER flood across every outside tile) get their border
+    // terrain bits remapped to mirror the in-map perimeter. Without this,
+    // the editor terrain brush sees a phantom water frame around the map
+    // and paints a grass-shore collar on any land it lays down near the
+    // edge — even though those tiles render as plain desert.
+    map_terrain_init_outside_map();
+
+    // Force the four triangular corners of the playable rectangle (the
+    // parts outside the inscribed visible diamond) into plain desert.
+    // These tiles render at the edges of the city view but aren't really
+    // gameplay area; the brush kept re-imaging them and exposing authored
+    // grass/trees. Doing this once at load means they stay desert across
+    // the whole session unless the brush explicitly touches them — and
+    // editor_tool_update_use re-runs the region variant as a safety net.
+    map_normalize_outside_diamond_all();
 
     // river / garden tiles refresh
     build_terrain_caches();

--- a/src/platform/akhenaten.cpp
+++ b/src/platform/akhenaten.cpp
@@ -399,6 +399,7 @@ static void run_and_draw() {
             NANO_PROFILE_SCOPE("_DebugUI");
             game_debug_cli_draw();
             game_debug_properties_draw();
+            game_debug_terrain_paint_draw();
             game_perfmon_draw();
         }
 

--- a/src/scripts/game.js
+++ b/src/scripts/game.js
@@ -15,6 +15,7 @@ game = extend(__game, {
     @version { get: __game_version }
     @difficulty { get: __game_difficulty }
     @debug_properties { get: __game_debug_properties }
+    @debug_terrain_paint { get: __game_debug_terrain_paint }
     @writing_video { get: __game_writing_video }
     @debug_render_mode { get: __game_debug_render_mode, set: __game_set_debug_render_mode }
     @last_autosave { get: __game_get_last_autosave }

--- a/src/scripts/ui_top_menu_widget.js
+++ b/src/scripts/ui_top_menu_widget.js
@@ -37,6 +37,7 @@ function top_menu_js_debugger_toggle(p1, p2) {
 function top_menu_make_fullscreenshot(p1, p2) { game.make_screenshot(1) }
 function top_menu_make_screenshot(p1, p2) { game.make_screenshot(0) }
 function top_menu_debug_properties_text(p1, p2) { return game.debug_properties ? "Properties ON" : "Properties OFF" }
+function top_menu_debug_terrain_paint_text(p1, p2) { return game.debug_terrain_paint ? "Terrain paint ON" : "Terrain paint OFF" }
 function top_menu_debug_write_video_text(p1, p2) { return game.debug_write_video ? "Write Video ON" : "Write Video OFF" }
 
 function top_menu_debug_buildings_text(p1, p2) { return game.debug_render_mode == e_debug_render_building ? "Buildings ON" : "Buildings OFF" }
@@ -129,6 +130,9 @@ top_menu_widget {
 	debug {
  		properties		: menu_item({textfn: top_menu_debug_properties_text
 									 onclick: __widget_top_menu_toggle_debug_properties })
+
+ 		terrain_paint	: menu_item({textfn: top_menu_debug_terrain_paint_text
+									 onclick: __widget_top_menu_toggle_debug_terrain_paint })
 
  		make_screenshot : menu_item({text: "Make full screenshot", onclick: top_menu_make_fullscreenshot })
  		make_full_screenshot : menu_item({text: "Make screenshot", onclick: top_menu_make_screenshot })

--- a/src/widget/debug_console.cpp
+++ b/src/widget/debug_console.cpp
@@ -20,6 +20,9 @@
 #include "backends/imgui_impl_sdl2.h"
 #include "dev/debug.h"
 #include "dev/perfmon.h"
+#include "editor/tool.h"
+#include "building/construction/build_planner.h"
+#include "graphics/view/view.h"
 
 #include <iostream>
 
@@ -289,6 +292,85 @@ void game_debug_properties_draw() {
     //g_debug_figure_id = 0;
 }
 
+void game_debug_terrain_paint_draw() {
+    // Detect open/close edges so we react to both the top-menu toggle and
+    // the ImGui window-close ('X'). On open: widen the camera scroll
+    // bounds by 20 world tiles so the painter can reach the off-map ring.
+    // On close: reset the bounds, which also snaps the camera back to the
+    // nearest allowed perimeter, and drop any active brush.
+    static bool s_prev_open = false;
+    const bool is_open = game.debug_terrain_paint;
+    if (is_open != s_prev_open) {
+        if (is_open) {
+            camera_set_extra_scroll_margin(36);
+        } else {
+            camera_set_extra_scroll_margin(0);
+            editor_tool_deactivate();
+        }
+        s_prev_open = is_open;
+    }
+
+    if (!is_open) {
+        return;
+    }
+
+    ImGui::SetNextWindowSize(ImVec2(220, 320), ImGuiCond_FirstUseEver);
+    if (!ui::Begin("Terrain Paint", &game.debug_terrain_paint)) {
+        ImGui::End();
+        return;
+    }
+
+    struct brush_def { int tool; pcstr label; };
+    static const brush_def brushes[] = {
+        { TOOL_GRASS,      "Land" },
+        { TOOL_TREES,      "Trees" },
+        { TOOL_WATER,      "Water" },
+        { TOOL_FLOODPLAIN, "Floodplain" },
+        { TOOL_REEDS,      "Reeds" },
+        { TOOL_ROCKS,      "Rocks" },
+        { TOOL_MEADOW,     "Meadow" },
+    };
+
+    const int active_tool = editor_tool_is_active() ? editor_tool_type() : -1;
+
+    for (const auto &b : brushes) {
+        const bool selected = (active_tool == b.tool);
+        if (selected) {
+            ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+        }
+        if (ImGui::Button(b.label, ImVec2(-FLT_MIN, 0))) {
+            editor_tool_set_type(b.tool);
+            // selecting a brush cancels any pending building placement
+            g_city_planner.construction_cancel();
+        }
+        if (selected) {
+            ImGui::PopStyleColor();
+        }
+    }
+
+    ImGui::Separator();
+
+    int brush_size = editor_tool_brush_size();
+    if (ImGui::SliderInt("Brush size", &brush_size, 1, 5)) {
+        editor_tool_set_brush_size(brush_size);
+    }
+
+    ImGui::Separator();
+
+    if (ImGui::Button("Stop painting", ImVec2(-FLT_MIN, 0))) {
+        editor_tool_deactivate();
+    }
+
+    if (active_tool >= 0) {
+        ImGui::TextDisabled("Left-click/drag map to paint.");
+        ImGui::TextDisabled("Right-click to deactivate brush.");
+    } else {
+        ImGui::TextDisabled("Select a brush above to start.");
+    }
+
+    ImGui::End();
+}
+
 void game_debug_cli_message(pcstr msg) {
     debug_console() << msg << std::endl;
 }
@@ -343,7 +425,7 @@ bool game_imgui_overlay_handle_event(void *e) {
         debug_console().skip_event = true;
     }
 
-    if (!(game.debug_console || game.debug_properties || game.debug_perfmon)) {
+    if (!(game.debug_console || game.debug_properties || game.debug_perfmon || game.debug_terrain_paint)) {
         return false;
     }
 

--- a/src/widget/debug_console.h
+++ b/src/widget/debug_console.h
@@ -14,6 +14,7 @@
 
 void game_debug_cli_draw();
 void game_debug_properties_draw();
+void game_debug_terrain_paint_draw();
 void game_debug_cli_message(pcstr msg);
 void game_imgui_overlay_init();
 void game_imgui_overlay_destroy();
@@ -56,6 +57,7 @@ void game_debug_show_property(pcstr field, const setting_variant &d, bool disabl
 
 inline void game_debug_cli_draw() {}
 inline void game_debug_properties_draw() {}
+inline void game_debug_terrain_paint_draw() {}
 inline void game_imgui_overlay_draw() {}
 inline void game_debug_show_property(...) {}
 inline void game_imgui_overlay_begin_frame() {}

--- a/src/widget/widget_city.cpp
+++ b/src/widget/widget_city.cpp
@@ -32,6 +32,7 @@
 #include "sound/sound_city.h"
 #include "sound/effect.h"
 #include "sound/sound.h"
+#include "editor/tool.h"
 #include "widget/city/ornaments.h"
 #include "widget/city/tile_draw.h"
 #include "widget/widget_minimap.h"
@@ -1288,6 +1289,22 @@ void screen_city_t::handle_mouse(const mouse* m) {
     g_zoom.handle_mouse(m);
     if (!ctx.view->can_update(g_zoom.ftarget())) {
         g_zoom.set_scale(old_zoom_target);
+    }
+
+    if (game.debug_terrain_paint && editor_tool_is_active() && current_tile.valid()) {
+        if (m->left.went_down) {
+            editor_tool_start_use(current_tile);
+            editor_tool_update_use(current_tile);
+        } else if (m->left.is_down || editor_tool_is_in_use()) {
+            editor_tool_update_use(current_tile);
+        }
+        if (m->left.went_up) {
+            editor_tool_end_use(current_tile);
+        }
+        if (m->right.went_up) {
+            editor_tool_deactivate();
+        }
+        return;
     }
 
     g_city_planner.draw_as_constructing = false;

--- a/src/widget/widget_top_menu_game_js.cpp
+++ b/src/widget/widget_top_menu_game_js.cpp
@@ -18,6 +18,7 @@
 #include "core/log.h"
 #include "core/profiler.h"
 #include "game/game.h"
+#include "editor/tool.h"
 
 pcstr __widget_top_menu_new_game(int, int) {
     widget_top_menu_clear_state();
@@ -148,3 +149,14 @@ pcstr __widget_top_menu_toggle_debug_properties(int, int) {
     return "";
 }
 ANK_FUNCTION_2(__widget_top_menu_toggle_debug_properties)
+
+pcstr __widget_top_menu_toggle_debug_terrain_paint(int, int) {
+    game.debug_terrain_paint = !game.debug_terrain_paint;
+    if (!game.debug_terrain_paint) {
+        editor_tool_deactivate();
+    }
+    widget_top_menu_clear_state();
+    window_go_back();
+    return "";
+}
+ANK_FUNCTION_2(__widget_top_menu_toggle_debug_terrain_paint)


### PR DESCRIPTION
## Summary

Adds a developer-only debug overlay for painting terrain at runtime. Gated behind a new Top Menu → Debug → "Terrain paint ON/OFF" toggle — no impact on shipping gameplay; the panel only appears when the flag is on.

## Brushes

Land, Trees, Water, Floodplain, Reeds, Rocks, Meadow, with a 1–5 tile brush size.

## Why this exists

The editor's existing tools didn't keep dependent grids (water depth, moisture, floodplain rows, outside-map ring, off-diamond corners) consistent with what got painted. Painting water inland left stale shallow tiles; painting land over deepwater left a missing collar; clearing land left moisture stuck at 0 so grass never regrew. This PR adds the missing recomputation paths and ties them to the brush:

- `recompute_depth_tile` / `distance_to_land` maintain a 1-tile shallow collar around any shore.
- `map_moisture_recompute_profile` samples the authored gradient at load time; `recompute_moisture_tile` refills cleared land from that profile so painted patches match the original mapper's plateau width and taper.
- Floodplain paint rebuilds rows, shores, and the random-tile cache.
- Outside-map tiles are projected from their nearest in-map tile at load (and after brush edits via region helpers); off-diamond corner tiles are cleared.

## Demolition

`demolish_building_at()` relocates homeless, depletes floodplain farm soil, and walks `prev_part_building` / `next_part_building` chains rather than just clearing the tile under the cursor.

## Camera

`camera_set_extra_scroll_margin()` lets the painter widen the scroll bounds by ~36 tiles so off-map areas are reachable while painting; resets cleanly when the panel closes.

## Testing

Smoke-tested manually: paint water blob inland (deepwater promotes), paint land over deepwater (collar demotes), paint floodplain (rebuild succeeds, no asserts), paint reeds (marshland refresh), demolish a 3×3 building (multi-tile chain cleared, no ghost tiles), open/close panel (camera margin resets).
