### PR TITLE
fix(ui): guard scenario selection against unported missions

### DIFF
--- a/src/scripts/ui_scenario_selection.js
+++ b/src/scripts/ui_scenario_selection.js
@@ -1,5 +1,16 @@
 log_info("akhenaten: scenario selection window")
 
+// Campaign steps may reference scenario ids that have no JS mission config yet
+// (only a subset of missions are ported). get_mission_config returns undefined
+// for those, so guard against it instead of dereferencing selection_title.
+function mission_selection_title(scenario_id) {
+    var config = get_mission_config(scenario_id)
+    if (config && config.selection_title && config.selection_title.length > 0) {
+        return config.selection_title
+    }
+    return "No title"
+}
+
 [es=(window_scenario_selection, init)]
 function window_scenario_selection_on_init(ev) {
     var list = ev.scenario_map_list
@@ -16,8 +27,7 @@ function window_scenario_selection_on_init(ev) {
             if (sid < 0) {
                 continue
             }
-            var config = get_mission_config(sid)
-            list.add_item(config.selection_title.length > 0 ? config.selection_title : "No title", list.items_count)
+            list.add_item(mission_selection_title(sid), list.items_count)
         }
     }
     window_scenario_selection.scores_or_goals = 0
@@ -37,10 +47,12 @@ function window_scenario_selection_on_mission_changed(ev) {
     ev.img_scenario_thumb.image = get_image({ pack:PACK_UNLOADED, id:28, offset:scenario.campaign_scenario_id }).tid
 
     var sub = window_scenario_selection.campaign_sub_dialog
-    var config = get_mission_config(scenario.campaign_scenario_id)
     ev.side_hdr_period.text = __loc(294, sub * 4)
-    ev.side_mission_title.text = config.selection_title
-    ev.side_subtitle.text = scenario.subtitle
+    ev.side_mission_title.text = mission_selection_title(scenario.campaign_scenario_id)
+    // Mission subtitle comes from its intro message (id 200 + scenario_id), the same
+    // short one-line tagline the briefing window shows (see ui_mission_briefing_window.js).
+    // g_scenario.subtitle is the editor description for custom maps and is garbage ("?s") here.
+    ev.side_subtitle.text = __lang_message_subtitle_text(200 + scenario.campaign_scenario_id)
     ev.side_year.text = scenario_selection_format_start_year(scenario.start_year)
 }
 
@@ -196,6 +208,24 @@ function window_scenario_selection_update_goals(ev) {
             goal_lines.push(scenario_info_housing_goal_line(scenario.housing_count_goal, 29, scenario.housing_level_goal))
     }
     ev.info_goals_body.text = goal_lines.join("\n")
+
+    // Goals are a variable-length multiline block, so the time-limit line and the
+    // monuments section must flow right below it instead of sitting at fixed Y
+    // (otherwise they overlap the last goal lines). Multiline step for FONT_NORMAL
+    // is line_height(14) + 5 = 19px (see text_draw_multiline in graphics/text.cpp).
+    var LINE_STEP = 19
+    var anchor = ev.info_goals_body.pos
+    var y = anchor.y + goal_lines.length * LINE_STEP + 6
+
+    var time_shown = !scenario.is_open_play &&
+        (__win_criteria.survival_time.enabled || __win_criteria.time_limit.enabled)
+    if (time_shown) {
+        ev.info_time_limit.pos = { x: anchor.x, y: y }
+        y += LINE_STEP
+    }
+
+    ev.info_hdr_monuments.pos = { x: anchor.x, y: y }
+    ev.info_monuments_body.pos = { x: anchor.x, y: y + 22 }
 }
 
 [es=(window_scenario_selection, show_scores)]
@@ -266,7 +296,7 @@ window_scenario_selection {
         info_line_start_region : text({ pos[545, 352], size[265, 17], text[2, 6], font:FONT_NORMAL_BLACK_ON_DARK })
 
         info_hdr_goals         : text_center({ pos[545, 377], size[265, 17], align:"center", text[44, 127], font:FONT_NORMAL_WHITE_ON_DARK })
-        info_goals_body        : text({ pos[545, 404], size[265, 100], wrap:px(16), font:FONT_NORMAL_BLACK_ON_DARK, multiline:true, clip_area:true })
+        info_goals_body        : text({ pos[545, 404], size[265, 130], wrap:px(16), font:FONT_NORMAL_BLACK_ON_DARK, multiline:true, clip_area:true })
         info_time_limit        : text({ pos[545, 484], size[265, 17], font:FONT_NORMAL_YELLOW })
 
         info_hdr_monuments     : text_center({ pos[545, 477], size[265, 17], align:"center", text[41, 48], font:FONT_NORMAL_WHITE_ON_DARK })

--- a/src/scripts/ui_scenario_selection_custom.js
+++ b/src/scripts/ui_scenario_selection_custom.js
@@ -34,8 +34,7 @@ function window_scenario_selection_custom_btn_start() {
 [es=(window_scenario_selection_custom, mission_changed)]
 function window_scenario_selection_custom_on_mission_changed(ev) {
     ev.img_scenario_thumb.image = get_image({ pack:PACK_UNLOADED, id:28, offset:scenario.campaign_scenario_id }).tid
-    var config = get_mission_config(scenario.campaign_scenario_id)
-    ev.side_mission_title.text = config.selection_title
+    ev.side_mission_title.text = mission_selection_title(scenario.campaign_scenario_id)
     ev.side_subtitle.text = scenario.subtitle
     ev.side_year.text = scenario_selection_format_start_year(scenario.start_year)
 }


### PR DESCRIPTION
Fixes #545.

`get_mission_config(sid)` returns `undefined` for campaign scenarios without a JS config (only 0–10 of 53 are ported), and the scenario selection list dereferenced `config.selection_title` unconditionally → crash when opening such a period.

- Add a `mission_selection_title()` guard → `"No title"` fallback (campaign list, side panel, and custom-maps window).
- Flow the monuments block / time-limit line below the goals via runtime `.pos` so they no longer overlap the last goal lines (they sat at fixed Y while the goals are a variable-length multiline block).
- Source the mission subtitle from its intro message (`200 + scenario_id`, same source the briefing window uses) instead of `g_scenario.subtitle`, which is the editor description and renders as garbage for campaign missions.

JS-only; no save-format or C++ changes. Tested in-game via `--mixed`.