### PR TITLE
fix(missions): correct Selima/Saqqara win criteria to match the pak

### DIFF
--- a/docs/wiki/player/missions/index.html
+++ b/docs/wiki/player/missions/index.html
@@ -239,10 +239,10 @@
               <td class="mission-city">Selima</td>
               <td>The Road to Africa</td>
               <td class="goals-cell">
-                <strong>Pop</strong> <span>2 500</span>
-                <strong>C</strong> <span>25</span>
-                <strong>Pr</strong> <span>25</span>
-                <strong>M</strong> <span>18</span>
+                <strong>Pop</strong> <span>3 000</span>
+                <strong>C</strong> <span>20</span>
+                <strong>Pr</strong> <span>20</span>
+                <strong>K</strong> <span>55</span>
               </td>
               <td>Kerma · Behdet · Abedju · Men-nefer · Timna (land)</td>
               <td>
@@ -254,7 +254,12 @@
               <td>9</td>
               <td class="mission-city">Abu</td>
               <td>The Nubian Border</td>
-              <td class="goals-cell">See briefing</td>
+              <td class="goals-cell">
+                <strong>Pop</strong> <span>4 000</span>
+                <strong>C</strong> <span>30</span>
+                <strong>Pr</strong> <span>30</span>
+                <strong>K</strong> <span>50</span>
+              </td>
               <td>Byblos · Behdet · Abedju · Nubt · Men-nefer · Timna · Kyrene · Selima Oasis</td>
               <td>
                 <span class="mission-badge badge-choice">Choice B</span>
@@ -267,7 +272,6 @@
               <td>The First Pyramid</td>
               <td class="goals-cell">
                 <strong>Pop</strong> <span>3 500</span>
-                <strong>C</strong> <span>25</span>
                 <strong>Pr</strong> <span>15</span>
                 <strong>M</strong> <span>19</span>
                 <strong>K</strong> <span>50</span>

--- a/src/scripts/mission_10_saqqara.js
+++ b/src/scripts/mission_10_saqqara.js
@@ -50,12 +50,14 @@ mission10 { // Saqqara
                 BUILDING_SCRIBAL_SCHOOL,
 			  ]
 
+	// Goals match the original Pharaoh 1.3 mission pak (verified against raw pak
+	// values): pop 3500, prosperity 15, monument 19, kingdom 50, NO culture goal.
 	win_criteria {
 		population {enabled : true, goal : 3500 }
-		culture    {enabled : true, goal : 25 }
+		culture    {enabled : false }
 		prosperity {enabled : true, goal : 15 }
 		monuments  {enabled : true, goal : 19 }
-        kingdom    {enabled : true, goal : 50 }
+		kingdom    {enabled : true, goal : 50 }
 	}
 
 	cities [

--- a/src/scripts/mission_8_selima.js
+++ b/src/scripts/mission_8_selima.js
@@ -40,11 +40,15 @@ mission8 { // Selima
                 BUILDING_SCRIBAL_SCHOOL,
 			  ]
 
+	// Goals match the original Pharaoh 1.3 mission pak (verified against the raw
+	// pak values and the HeavenGames/Sierra walkthroughs): pop 3000, culture 20,
+	// prosperity 20, kingdom 55, no monument rating goal.
 	win_criteria {
-		population {enabled : true, goal : 2500 }
-		culture    {enabled : true, goal : 25 }
-		prosperity {enabled : true, goal : 25 }
-		monuments  {enabled : true, goal : 18 }
+		population {enabled : true, goal : 3000 }
+		culture    {enabled : true, goal : 20 }
+		prosperity {enabled : true, goal : 20 }
+		kingdom    {enabled : true, goal : 55 }
+		monuments  {enabled : false }
 	}
 
     enable_scenario_events : true


### PR DESCRIPTION
Fixes #546.

The `win_criteria` blocks for Selima (8) and Saqqara (10) overrode the `mission1.pak` values with incorrect ones. Verified against the raw pak (block temporarily removed → selection screen shows the pak goals) and cross-checked with walkthroughs.

- Selima: `pop2500/culture25/prosperity25/monument18` → `pop3000/culture20/prosperity20/kingdom55`, no monument goal.
- Saqqara: drop the spurious `culture@25` (pop 3500 / prosperity 15 / monument 19 / kingdom 50 were already correct).
- Wiki mission table updated to match; Abu (9) row filled in from the pak (4000/30/30/50).

Note on mechanism: `arch.r` merges `win_criteria` per field over the pak — `r_section_impl` (`src/core/archive.h:207-223`) no-ops on absent keys. So an absent block is harmless (correct pak values used), but a block with wrong values overwrites them, which is what happened here. Details in #546.