### PR TITLE
ci: skip configuration dialog in --integraltests mode

### DIFF
--- a/src/platform/akhenaten.cpp
+++ b/src/platform/akhenaten.cpp
@@ -195,8 +195,11 @@ static void setup() {
     g_args.set_data_directory("");
 #endif
 
-    // Show configuration window if --config flag is set or config file doesn't exist
-    const bool support_window_options = !(platform.is_android() || platform.is_emscripten());
+    // Show configuration window if --config flag is set or config file doesn't exist.
+    // Skip in integral-tests mode: the dialog would block forever in a headless CI runner,
+    // and SDL_CreateRenderer there fails because the dummy video driver doesn't support
+    // SDL_RENDERER_ACCELERATED, which is what options_window.cpp requests.
+    const bool support_window_options = !(platform.is_android() || platform.is_emscripten() || g_args.is_integral_tests());
     if (g_args.should_show_config_window() || !g_args.config_file_exists()) {
         if (support_window_options) {
             show_options_window(g_args);


### PR DESCRIPTION
## Problem

The `Linux / integral tests` CI job has never passed since it was added — every run on `master` (and every pull request branched from it) fails with this 4-line log:

```
Akhenaten version …
Initializing SDL
SDL initialized
Error creating SDL_Renderer!
```

The previous fix attempt (339caa2e2 "ci: fix integral tests SDL init failure on Linux runners") addressed an SDL **audio** init failure, but the **renderer** failure happens before any test runs.

## Root cause

On a fresh CI checkout no config file exists, so `akhenaten.cpp:200` invokes `show_options_window()` — the imgui-based first-run configuration dialog. `options_window.cpp:27` creates its renderer with:

```cpp
SDL_CreateRenderer(platform_window, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
if (renderer == nullptr) {
    logs::info("Error creating SDL_Renderer!");
    exit(-1);
}
```

On a headless runner with `SDL_VIDEODRIVER=dummy`, accelerated renderer creation fails and there is no software-renderer fallback (unlike `platform_renderer_init` in `renderer.cpp:967`, which does fall back). The dialog also has no purpose in integraltests mode — it would block waiting for a "RUN GAME" click that no one can make.

## Fix

Extend the existing `support_window_options` gate — which already excludes Android and Emscripten — to also exclude `--integraltests`. This matches the gate used at the `pre_init` retry site a few lines down, so both dialog call sites are consistently skipped under test mode.

```diff
-    const bool support_window_options = !(platform.is_android() || platform.is_emscripten());
+    const bool support_window_options = !(platform.is_android() || platform.is_emscripten() || g_args.is_integral_tests());
```

## Verification

Locally on Windows (which exposes the same first-run code path when no config exists):

```
$ akhenaten.exe --integraltests --no-logo --no-resource --nosound --window --size 800x600
[integraltests] start
[integraltests] >> 01_main_menu
[test:01_main_menu] PASS
[integraltests] >> 02_main_menu_buttons
[test:02_main_menu_buttons] PASS
[integraltests] 2 passed, 0 failed
[integraltests] all checks passed
exit=0
```

The integraltests workflow itself does not need any changes; with this fix the existing `./build/akhenaten --integraltests --no-logo --no-resource --nosound --window --size 800x600` invocation in `.github/workflows/akhenaten_integral_tests.yml` is enough.

## Follow-up suggestion (separate PR if you want)

`options_window.cpp` could also grow a software-renderer fallback (mirroring the pattern in `renderer.cpp:967`) so that anyone running the dialog on a system without accelerated rendering doesn't hit the same hard crash. Independent of CI.