### PR TITLE
ci: fix remaining integral-tests failures on Linux (download race + inactive-window stall)

### DIFF
--- a/src/platform/akhenaten.cpp
+++ b/src/platform/akhenaten.cpp
@@ -573,7 +573,12 @@ void application_t::pump_one_frame() {
         return;
     }
 
-    if (active) {
+    // Under --integraltests the test driver pumps frames manually and must
+    // always advance the game loop. The dummy SDL video driver used in CI
+    // fires spurious SDL_WINDOWEVENT_HIDDEN events that flip `active` to false;
+    // skipping run_and_draw() there would stop processing simulated input (so
+    // clicks never reach the UI) and SDL_WaitEvent() could block the run.
+    if (active || g_args.is_integral_tests()) {
         run_and_draw();
     } else {
         SDL_WaitEvent(NULL);

--- a/src/window/main_menu.cpp
+++ b/src/window/main_menu.cpp
@@ -21,6 +21,7 @@
 #include "graphics/elements/ui_js.h"
 #include "resource/icons.h"
 #include "platform/renderer.h"
+#include "platform/arguments.h"
 #include "js/js_game.h"
 #include <regex>
 
@@ -184,25 +185,34 @@ void main_menu_screen::draw_foreground(UiFlags flags) {
 }
 
 void main_menu_screen::init() {
-    // Download changelog in background
-    game.mt.detach_task([&, this] () {
-        xstring changelog = main_menu_download_changelog().c_str();
-        game.add_frame_end_event([this, changelog] () {
-            ui.begin_widget(pos);
-            ui.event(event_changelog_loaded{ changelog });
-            ui.end_widget();
+    // show() calls init() on every (re)show of the main menu, so each of these
+    // detached network tasks is spawned again whenever the player navigates back
+    // here. Their completion fires a frame-end event into this window's ui tree.
+    // Under --integraltests the menu is shown and re-shown rapidly by the input
+    // simulation, so multiple in-flight downloads land on a rebuilt ui tree and
+    // crash. The downloads are also pointless in a headless test run, so skip
+    // them entirely in that mode (keeps the test deterministic and offline).
+    if (!g_args.is_integral_tests()) {
+        // Download changelog in background
+        game.mt.detach_task([&, this] () {
+            xstring changelog = main_menu_download_changelog().c_str();
+            game.add_frame_end_event([this, changelog] () {
+                ui.begin_widget(pos);
+                ui.event(event_changelog_loaded{ changelog });
+                ui.end_widget();
+            });
         });
-    });
 
-    // Check for updates
-    game.mt.detach_task([&] () {
-        int current_commit = main_menu_get_total_commits("dalerank", "Akhenaten");
-        game.add_frame_end_event([this, current_commit] () {
-            ui.begin_widget(pos);
-            ui.event(event_totals_commits_loaded{ current_commit });
-            ui.end_widget();
+        // Check for updates
+        game.mt.detach_task([&] () {
+            int current_commit = main_menu_get_total_commits("dalerank", "Akhenaten");
+            game.add_frame_end_event([this, current_commit] () {
+                ui.begin_widget(pos);
+                ui.event(event_totals_commits_loaded{ current_commit });
+                ui.end_widget();
+            });
         });
-    });
+    }
 
     autoconfig_window::init();
 }


### PR DESCRIPTION
Follow-up to #549. With the config dialog skipped, the `Linux / integral tests` job runs but `02_main_menu_buttons` failed in two further ways that only reproduce on the headless Linux runner (the dummy SDL video driver), not on Windows. This PR fixes both so the job goes green.

## 1. SIGSEGV from the main-menu download race

`main_menu_screen::show()` calls `init()` on **every** (re)show (`main_menu.cpp:225`), and `init()` spawns two detached background threads — a changelog HTTP download and a GitHub version check — each of which posts a frame-end event into this window's `ui` element tree on completion.

`02_main_menu_buttons` navigates main-menu → sub-window → back repeatedly, so `init()` runs several times and multiple downloads are in flight at once (visible as doubled `Changelog downloaded successfully` / `main_menu_download_version` lines in the crash log). When a download finishes after the `ui` tree has been rebuilt by a re-show, the completion event dispatches into a stale element and crashes during the recursive `ui` traversal. Timing-dependent, hence Linux-only.

**Fix:** skip both network tasks under `--integraltests`. They are pointless in a headless CI run and make the test depend on live network timing.

## 2. Simulated clicks dropped on an "inactive" window

After the crash was fixed, the test ran to completion but failed: the clicks never opened their sub-windows (`missing marker: window_show:window_player_selection`, etc.).

`pump_one_frame()` only calls `run_and_draw()` when `active` is true, otherwise it parks in `SDL_WaitEvent()`. The dummy SDL video driver fires spurious `SDL_WINDOWEVENT_HIDDEN` events (the `Window 1 hidden` log lines) that flip `active` to false. The test driver keeps pumping frames, but with `run_and_draw()` skipped the simulated mouse input is never processed, so no button is clicked.

**Fix:** always call `run_and_draw()` under `--integraltests` so manually pumped frames advance the game regardless of the window's reported active state.

## Verification

Locally on Windows both tests pass and no downloads are issued. The Linux CI on this PR is the real confirmation that the crash is gone **and** the markers now appear:

```
[test:01_main_menu] PASS
[test:02_main_menu_buttons] PASS
[integraltests] 2 passed, 0 failed
[integraltests] all checks passed
```

## Note (out of scope)

The underlying dangling-reference-on-async-completion in the main menu can in principle affect real players (navigate away before the changelog download finishes). A robust fix — cancelling/guarding pending tasks when the menu is hidden — is a larger game-logic change and is intentionally left out of this CI-focused PR.
