### PR TITLE
Add dunes and orebearing rock to debug terrain paint brush

### DIFF
--- a/src/editor/tool.cpp
+++ b/src/editor/tool.cpp
@@ -36,7 +36,10 @@
 #include "widget/widget_minimap.h"
 #include "building/construction/build_planner.h"
 
-#define TERRAIN_PAINT_MASK ~(TERRAIN_TREE | TERRAIN_ROCK | TERRAIN_WATER | TERRAIN_DEEPWATER | TERRAIN_BUILDING | TERRAIN_SHRUB | TERRAIN_GARDEN | TERRAIN_ROAD | TERRAIN_MEADOW | TERRAIN_FLOODPLAIN | TERRAIN_MARSHLAND)
+#define TERRAIN_PAINT_MASK                                                                                     \
+    ~(TERRAIN_TREE | TERRAIN_ROCK | TERRAIN_WATER | TERRAIN_DEEPWATER | TERRAIN_BUILDING | TERRAIN_SHRUB       \
+      | TERRAIN_GARDEN | TERRAIN_ROAD | TERRAIN_MEADOW | TERRAIN_FLOODPLAIN | TERRAIN_MARSHLAND | TERRAIN_DUNE \
+      | TERRAIN_ORE)
 
 static struct {
     int active = 0;
@@ -140,6 +143,8 @@ int editor_tool_is_brush(void) {
     case TOOL_MEADOW:
     case TOOL_FLOODPLAIN:
     case TOOL_REEDS:
+    case TOOL_DUNES:
+    case TOOL_ORE:
     case TOOL_RAISE_LAND:
     case TOOL_LOWER_LAND:
         return 1;
@@ -294,6 +299,26 @@ static void add_terrain(const void* tile_data, int dx, int dy) {
             terrain |= TERRAIN_MARSHLAND;
         }
         break;
+    case TOOL_ORE:
+        // Ore-bearing rock is a rock variant: set_ore_rock_image in
+        // map_tiles_update_all_rocks() keys off TERRAIN_ORE but only images
+        // tiles that also carry TERRAIN_ROCK (is_updatable_rock), so set both.
+        if (!(terrain & TERRAIN_ORE)) {
+            terrain &= TERRAIN_PAINT_MASK;
+            terrain |= TERRAIN_ROCK | TERRAIN_ORE;
+        }
+        break;
+    case TOOL_DUNES:
+        // Just flag the tile; map_tiles_update_all_dunes() (called from
+        // editor_tool_update_use) clears the old image and assigns the proper
+        // dune sprite, clustering neighbouring dune tiles into 2x2 / 3x3
+        // sprites the same way rocks are imaged.
+        if (!(terrain & TERRAIN_DUNE)) {
+            terrain &= TERRAIN_PAINT_MASK;
+            terrain |= TERRAIN_DUNE;
+            map_vegetation_deplete(grid_offset);
+        }
+        break;
     case TOOL_RAISE_LAND:
         terrain = raise_land_tile(x, y, grid_offset, terrain);
         break;
@@ -371,6 +396,9 @@ void editor_tool_update_use(tile2i tile) {
             map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
         }
         map_tiles_update_all_rocks();
+        // re-cluster any dunes the stroke partially erased, then let the
+        // empty-land pass re-image the tiles whose TERRAIN_DUNE bit was cleared
+        map_tiles_update_all_dunes();
         map_tiles_update_region_empty_land(true, imin, imax);
         map_tiles_update_region_meadow(imin.x(), imin.y(), imax.x(), imax.y());
         map_tree_update_region_tiles(x_min, y_min, x_max, y_max);
@@ -410,9 +438,15 @@ void editor_tool_update_use(tile2i tile) {
         break;
     }
     case TOOL_ROCKS:
+    case TOOL_ORE:
     case TOOL_FLOODPLAIN:
         map_image_context_reset_water();
         map_tiles_update_all_rocks();
+        map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
+        break;
+    case TOOL_DUNES:
+        map_image_context_reset_water();
+        map_tiles_update_all_dunes();
         map_tiles_river_refresh_region(x_min, y_min, x_max, y_max);
         break;
     case TOOL_SHRUB:

--- a/src/editor/tool.h
+++ b/src/editor/tool.h
@@ -26,7 +26,9 @@ enum {
     TOOL_NATIVE_CENTER = 22,
     TOOL_NATIVE_FIELD = 23,
     TOOL_FISHING_POINT = 24,
-    TOOL_HERD_POINT = 25
+    TOOL_HERD_POINT = 25,
+    TOOL_DUNES = 26,
+    TOOL_ORE = 27
 };
 
 int editor_tool_type(void);

--- a/src/graphics/image_groups.h
+++ b/src/graphics/image_groups.h
@@ -112,6 +112,7 @@ extern const e_pack_tokens_t e_pack_type_tokens;
 #define GROUP_TERRAIN_ELEVATION PACK_TERRAIN, 9      // this isn't in Pharaoh
 #define GROUP_TERRAIN_EMPTY_LAND PACK_TERRAIN, 10
 #define GROUP_TERRAIN_REEDS PACK_TERRAIN, 11
+#define GROUP_TERRAIN_DUNE PACK_TERRAIN, 13 // 8x 1-tile, 4x 2x2, 2x 3x3 - same layout as rocks
 // #define GROUP_BUILDING_TRANSPORT_WHARF  PACK_TERRAIN,  17
 //#define GROUP_BUILDING_FISHING_WHARF PACK_TERRAIN, 18 // 79
 #define GROUP_SUNKEN_TILE PACK_TERRAIN, 20

--- a/src/grid/tiles.cpp
+++ b/src/grid/tiles.cpp
@@ -181,6 +181,45 @@ void map_tiles_update_all_rocks(void) {
     map_tiles_foreach_map_tile(set_rock_image);
 }
 
+static bool is_updatable_dune(int grid_offset) {
+    return map_terrain_is(grid_offset, TERRAIN_DUNE) && !map_property_is_plaza_or_earthquake(tile2i(grid_offset))
+           && !map_terrain_is(grid_offset, TERRAIN_ELEVATION | TERRAIN_ACCESS_RAMP);
+}
+static void clear_dune_image(int grid_offset) {
+    if (is_updatable_dune(grid_offset)) {
+        map_image_set(grid_offset, 0);
+        map_property_set_multi_tile_size(grid_offset, 1);
+        map_property_mark_draw_tile(grid_offset);
+    }
+}
+static void set_dune_image(int grid_offset) {
+    tile2i tile(grid_offset);
+    // GROUP_TERRAIN_DUNE follows the same multi-tile layout as the rock groups:
+    // 8 single-tile variants, then 4 2x2 variants (offset 8), then 2 3x3
+    // variants (offset 12). Cluster painted dune tiles into the largest sprite
+    // that fits, exactly like set_rock_image / set_ore_rock_image.
+    if (is_updatable_dune(grid_offset)) {
+        if (!map_image_at(grid_offset)) {
+            if (map_terrain_all_tiles_in_area_are(tile, 3, TERRAIN_DUNE)
+                && terrain_no_image_at(grid_offset, 3)) { // 3x3 dune
+                int image_id = 12 + (map_random_get(grid_offset) & 1) + image_id_from_group(GROUP_TERRAIN_DUNE);
+                map_building_tiles_add(0, tile, 3, image_id, TERRAIN_DUNE);
+            } else if (map_terrain_all_tiles_in_area_are(tile, 2, TERRAIN_DUNE)
+                       && terrain_no_image_at(grid_offset, 2)) { // 2x2 dune
+                int image_id = 8 + (map_random_get(grid_offset) & 3) + image_id_from_group(GROUP_TERRAIN_DUNE);
+                map_building_tiles_add(0, tile, 2, image_id, TERRAIN_DUNE);
+            } else { // single-tile dune
+                int image_id = (map_random_get(grid_offset) & 7) + image_id_from_group(GROUP_TERRAIN_DUNE);
+                map_image_set(grid_offset, image_id);
+            }
+        }
+    }
+}
+void map_tiles_update_all_dunes(void) {
+    map_tiles_foreach_map_tile(clear_dune_image);
+    map_tiles_foreach_map_tile(set_dune_image);
+}
+
 static void set_shrub_image(int grid_offset) {
     if (map_terrain_is(grid_offset, TERRAIN_SHRUB)
         && !map_terrain_is(grid_offset, TERRAIN_ELEVATION | TERRAIN_ACCESS_RAMP)) {

--- a/src/grid/tiles.h
+++ b/src/grid/tiles.h
@@ -5,6 +5,7 @@
 #include "grid/point.h"
 
 void map_tiles_update_all_rocks(void);
+void map_tiles_update_all_dunes(void);
 
 void map_tiles_update_region_shrub(int x_min, int y_min, int x_max, int y_max);
 

--- a/src/widget/debug_console.cpp
+++ b/src/widget/debug_console.cpp
@@ -328,6 +328,8 @@ void game_debug_terrain_paint_draw() {
         { TOOL_FLOODPLAIN, "Floodplain" },
         { TOOL_REEDS,      "Reeds" },
         { TOOL_ROCKS,      "Rocks" },
+        { TOOL_ORE,        "Orebearing rock" },
+        { TOOL_DUNES,      "Dunes" },
         { TOOL_MEADOW,     "Meadow" },
     };
 


### PR DESCRIPTION
Extends the debug terrain paint panel (Top Menu → Debug → "Terrain paint ON/OFF", added in #542) with two more brushes, and fixes the Land brush leaving dunes/ore behind.

## What's new

- **Orebearing rock** — paints `TERRAIN_ROCK | TERRAIN_ORE` so `set_ore_rock_image` (in `map_tiles_update_all_rocks()`) renders proper ore-rock sprites. Both bits are required because `set_ore_rock_image` only images ore tiles that also carry `TERRAIN_ROCK` (`is_updatable_rock`).
- **Dunes** — paints `TERRAIN_DUNE` and images it via a new `map_tiles_update_all_dunes()` pass.

## Finding the dune sprites

`TERRAIN_DUNE` had no main-view image group defined in the engine (dune art only ever came from loaded map files). I identified it by parsing `Pharaoh_Terrain.sg3` and cross-referencing the stock maps: dunes live in **`PACK_TERRAIN` group 13** (image ids 15061–15074), used by 13 of 15 maps. The group shares the exact rock layout — 8 single-tile, 4 2×2, 2 3×3 variants — so `set_dune_image` clusters painted dune tiles into multi-tile sprites the same way `set_rock_image` / `set_ore_rock_image` do.

## Land-brush fix

`TERRAIN_DUNE` and `TERRAIN_ORE` were missing from `TERRAIN_PAINT_MASK`, so the Land brush cleared the visuals but left the terrain flags set. They're now part of the mask (every brush clears them before painting; the dune/ore brushes re-add their own bits), and the Land refresh calls `map_tiles_update_all_dunes()` so partially-erased multi-tile dunes re-cluster and cleared tiles re-image as terrain.

## Verification

Built with `cmake --build --preset win-msvc-relwithdebinfo-vs2022` (exit 0) and tested in-game: painting/erasing dunes (single and multi-tile) and orebearing rock, plus removing them with the Land brush. Debug-only UI; no game-logic or savegame changes.