### PR TITLE
test: regression test for scenario-selection crash guard

### DIFF
--- a/tests/03_scenario_selection_guard.js
+++ b/tests/03_scenario_selection_guard.js
@@ -1,0 +1,27 @@
+// Regression test for the campaign scenario-selection crash (#545 / PR #547).
+//
+// Campaign steps can reference scenario ids that have no JS mission config yet
+// (only a subset of missions are ported). get_mission_config() returns undefined
+// for those; the selection list used to dereference config.selection_title and
+// crash with a TypeError. mission_selection_title() now guards that and returns
+// "No title" instead.
+//
+// This is a data-less unit check (the full window path needs mission1.pak, which
+// is absent under --no-resource), so it exercises the guard function directly:
+// an unported id must yield "No title" and must not throw.
+
+function run_test() {
+    try {
+        var title = mission_selection_title(999); // 999 has no mission config
+        __log_info_native(title === "No title"
+            ? "[selguard] ok"
+            : "[selguard] bad: got '" + title + "'");
+    } catch (e) {
+        __log_info_native("[selguard] threw: " + e);
+    }
+    __test_signal_ready();
+}
+
+function check_valid() {
+    return __test_read_log_file().indexOf("[selguard] ok") >= 0;
+}


### PR DESCRIPTION
Uses the new integral-tests framework to lock in the fix from #547 (#545).

`tests/03_scenario_selection_guard.js` asserts `mission_selection_title()` returns `"No title"` for an unported scenario id instead of throwing. It exercises the guard function directly (data-less), so it runs in CI under `--integraltests --no-resource` — the full window path would need `mission1.pak`.

Verified locally:
```
[test:03_scenario_selection_guard] PASS
[integraltests] 3 passed, 0 failed
```