### PR TITLE
fix(figure): guard null soldier when a low-morale batalion flees to fort

### DIFF
--- a/src/figure/formation_batalion.cpp
+++ b/src/figure/formation_batalion.cpp
@@ -206,8 +206,13 @@ void formations_t::batalions_update() {
         if (m->has_low_morale()) {
             // flee back to fort
             for (int n = 0; n < formation::max_figures_count; n++) {
+                if (m->figures[n] == 0) {
+                    continue;
+                }
                 figure_soldier* soldier = figure_get(m->figures[n])->dcast_soldier();
-                soldier->goback_to_fort();
+                if (soldier) {
+                    soldier->goback_to_fort();
+                }
             }
 
         } else if (m->layout == FORMATION_MOP_UP) {


### PR DESCRIPTION
Fixes #553.

`formations_t::batalions_update()` iterated every formation slot and called
`figure_get(m->figures[n])->dcast_soldier()->goback_to_fort()` without checking for an empty slot (`m->figures[n] == 0`) or a null dcast, crashing with SIGSEGV when a low-morale batalion (e.g. after a distant battle) had empty/non-soldier slots.

Mirrors the guard already used by the `FORMATION_MOP_UP` branch a few lines below.

Verified in-game: replayed the Selima (mission 8) distant battle that reproduced the crash — troops now enter and the battle resolves without a crash.