### PR TITLE
fix(figure): recruit soldiers by marking the legion standard as at-rest

### DIFF
--- a/src/figuretype/figure_standart_bearer.cpp
+++ b/src/figuretype/figure_standart_bearer.cpp
@@ -11,6 +11,12 @@ void figure_standard_bearer::on_create() {
 void figure_standard_bearer::figure_action() {
     const formation *m = formation_get(base.formation_id);
 
+    // The standard is the legion's anchor, not a deployable soldier. Keep it marked
+    // at-rest so calculate_figures() doesn't treat a flag-only legion as "deployed"
+    // (is_at_fort would stay 0, which blocks recruit_type and the very first recruit).
+    // Deployed soldiers still drive is_at_fort=0 on their own when the legion marches out.
+    base.formation_at_rest = 1;
+
     base.wait_ticks = 0;
     base.map_figure_remove();
     if (m->is_at_fort) {


### PR DESCRIPTION
Fixes #555

### Summary
A freshly built fort never recruits a soldier: weapons pile up at the recruiter but the legion stays empty forever.

### Cause
`calculate_figures()` derives `formation::is_at_fort` from each figure's `formation_at_rest` flag. A new legion holds only the standard bearer, which never set the flag, so the formation was permanently "deployed" → `is_at_fort` 0 → recruit type stayed NONE → `create_soldier()` never ran.

### Changes
- `figure_standart_bearer::figure_action()`: set `base.formation_at_rest = 1`.

### Verification
In-game (Selima, mission 8): the fort begins recruiting and fills to capacity normally. Build clean, clang-format clean.