### PR TITLE
fix(ui): localize 'in' and 'Companies' in the military advisor army status

### DIFF
--- a/src/scripts/ui_advisor_military.js
+++ b/src/scripts/ui_advisor_military.js
@@ -67,8 +67,8 @@ function advisor_military_window_init(window) {
     window.distant_text.text = __loc(51, distant_battle_text_id)
 
     var total_soldiers_str = __loc(8, 46) + " " + city.military.total_soldiers
-    var total_batalions_str =  city.military.total_batalions + " Companies"
-    window.forts_text.text = total_soldiers_str + " in " + total_batalions_str
+    var total_batalions_str = city.military.total_batalions + " " + __loc(8, 49)
+    window.forts_text.text = total_soldiers_str + " " + __loc(51, 7) + " " + total_batalions_str
 
     if (city.num_forts > 0) {
         window.nothing_text.enabled = false


### PR DESCRIPTION
Fixes #557

### Summary
The army status line in the military advisor rendered hardcoded English text, so non-English players saw e.g. "Солдат 1 in 0 Companies".

### Changes
- `ui_advisor_military.js`: replace the literals with `__loc(51, 7)` ("in") and `__loc(8, 49)` ("Companies"). No new localization keys — uses the original text files.

### Verification
In-game (ru): the army status line is fully localized.