### PR TITLE
fix(ui): don't crash __ui_draw_button on a non-bool border/body flag

### DIFF
--- a/src/graphics/elements/ui_js.cpp
+++ b/src/graphics/elements/ui_js.cpp
@@ -139,10 +139,13 @@ int ANK_FUNCTION_UNIFIED(__ui_draw_button)(const bvariant_map &args) {
     const xstring tooltip = args.s("tooltip");
 
     int flags = args.int32_or_def("flags", 0);
+    // Only disable the border/body when the flag is explicitly the bool false.
+    // Several button configs pass these keys as non-bool (e.g. body:"" or border:3),
+    // and as_bool() throws bad_variant_access on a non-bool variant -> hard crash.
     const auto border = args["border"];
-    flags |= (!border.is_empty() && !border.as_bool() ? UiFlags_NoBorder : 0);
+    flags |= (border.is_bool() && !border.as_bool() ? UiFlags_NoBorder : 0);
     const auto body = args["body"];
-    flags |= (!body.is_empty() && !body.as_bool() ? UiFlags_NoBody : 0);
+    flags |= (body.is_bool() && !body.as_bool() ? UiFlags_NoBody : 0);
 
     const bool is_underlying = g_window_manager.underlying_windows_redrawing > 0;
     flags |= is_underlying ? UiFlags_Readonly : UiFlags_None;

--- a/tests/09_ui_button_nonbool_flags.js
+++ b/tests/09_ui_button_nonbool_flags.js
@@ -1,0 +1,34 @@
+// Regression test for a hard crash in __ui_draw_button.
+//
+// The "take config as bvariant_map" refactor made __ui_draw_button read the
+// `border` and `body` keys through bvariant::as_bool(). Several button configs
+// pass these keys as non-bool values (e.g. body:"" in the chief advisor,
+// border:3 in the population/housing advisors, body:2 in the campaign selection).
+// as_bool() does std::get<bool> on a variant that does not hold a bool, which
+// throws bad_variant_access and aborts the whole process under -fno-exceptions.
+//
+// The fix only honours these keys when they are an actual bool (disable the
+// border/body when explicitly false, otherwise keep the default). This data-less
+// check draws buttons with non-bool border/body and asserts the process survives.
+
+function run_test() {
+    try {
+        // non-bool body (string) + non-bool border (number) -- used to abort here
+        __ui_draw_button({ text: "x", pos: [0, 0], size: [20, 20], body: "", border: 3 });
+        // non-bool body (number)
+        __ui_draw_button({ text: "y", pos: [0, 0], size: [20, 20], body: 2 });
+        // explicit false must still be honoured (no crash, disables border/body)
+        __ui_draw_button({ text: "z", pos: [0, 0], size: [20, 20], body: false, border: false });
+    } catch (e) {
+        // a catchable JS error is acceptable -- the regression we guard against is a
+        // non-recoverable abort that would kill the process before we get here.
+        __log_info_native("[btnflags] threw (non-fatal): " + e);
+    }
+
+    __log_info_native("[btnflags] survived");
+    __test_signal_ready();
+}
+
+function check_valid() {
+    return __test_find_inlog("[btnflags] survived");
+}


### PR DESCRIPTION
Fixes #561

### Summary
Opening a window whose button config passes `border` or `body` as a non-bool value aborts the game.

### Cause
After `__ui_draw_button` started reading config as a `bvariant_map`, it reads the `border`/`body` keys via `bvariant::as_bool()`, which does `std::get<bool>` and throws `bad_variant_access` (aborts under `-fno-exceptions`) when the value is present but not a bool. Several existing configs pass them as non-bool: `body: ""` (chief advisor), `border: 3` (population/housing advisors), `body: 2` (campaign selection).

### Changes
- `__ui_draw_button`: honour `border`/`body` only when they actually hold a bool — disable the border/body when explicitly `false`, otherwise keep the default. No behaviour change for bool/absent values.
- New integral test `tests/09_ui_button_nonbool_flags.js`: draws buttons with non-bool `border`/`body` and asserts the process survives (`[btnflags] survived`).

### Verification
- In-game (Selima): the crash that fired on a distant-battle request window is gone.
- `--integraltests`: `09_ui_button_nonbool_flags` PASS, build + clang-format clean.
- Note: `02_main_menu_buttons` fails on the integral-tests check, but it fails the same way on clean `origin/master` without this change (missing `window_show` markers in headless) — pre-existing, unrelated to this PR.