### PR TITLE
fix(empire): always allow closing the empire window

### DIFF
--- a/src/scripts/ui_empire_window.js
+++ b/src/scripts/ui_empire_window.js
@@ -137,7 +137,7 @@ function empire_window_layout_ui(window) {
     window.city_name.pos = { x: sb.min_pos.x, y: infoTop - 1 }
     window.city_name.size = { x: width, y: 20 }
 
-    window.button_help.pos = { x: sb.max_pos.x - 40, y: infoTop }
+    window.button_help.pos = { x: sb.min_pos.x + 16, y: openTradeTop }
     window.button_close.pos = { x: sb.max_pos.x - 40, y: openTradeTop }
     window.button_advisor.pos = { x: sb.min_pos.x + 16, y: infoTop }
     window.button_pause.pos = { x: sb.max_pos.x - 48, y: infoTop - 2 }

--- a/src/window/window_empire.cpp
+++ b/src/window/window_empire.cpp
@@ -557,7 +557,7 @@ void empire_window::ui_draw_foreground(UiFlags flags) {
 
     ui["city_name"] = "";
     ui["button_help"].enabled = !!city;
-    ui["button_close"].enabled = !!city;
+    ui["button_close"].enabled = true;
     ui["button_advisor"].enabled = !!city;
     ui["city_name"] = city ? city->name_str : "";
     ui["button_pause"].tooltip(lang_xtext_from_key(game.paused ? "#TR_BUTTON_RESUME" : "#TR_BUTTON_PAUSE"));


### PR DESCRIPTION
## Problem

The empire window's close button was gated on having a city selected (`button_close.enabled = !!city`). With no city selected there was no way to close the empire window.

## Changes

- `window_empire.cpp`: enable `button_close` unconditionally.
- `ui_empire_window.js`: reposition `button_help` to the lower-left (`sb.min_pos.x + 16, openTradeTop`) so it no longer sits on top of the top-right controls.

## Testing

Open the empire window with no city selected — the close button now works. Help button sits in the lower-left and no longer overlaps other controls.