### PR TITLE
fix(ui): scenario-selection thumbnails, titles, and branched-mission loading

### DIFF
--- a/src/graphics/elements/ui.cpp
+++ b/src/graphics/elements/ui.cpp
@@ -1184,15 +1184,27 @@ void ui::eimg::draw(UiFlags flags) {
         push(cmd_t::image_isometric, Pos{scr_pos}, ImageId{img_desc.tid()}, Mask{COLOR_MASK_NONE});
     } else {
         vec2i rpos = pos;
-        if (centering.x > -1000 || centering.y > -1000) {
-            const image_t* img = image_get(img_desc);
+        const image_t* img = (fit || centering.x > -1000 || centering.y > -1000) ? image_get(img_desc) : nullptr;
+
+        // Shrink-to-fit: if the image is larger than the size box, scale it down
+        // (preserving aspect ratio), anchored at the element position so previews
+        // that already fit are left exactly where they are.
+        float draw_scale = 1.f;
+        if (fit && img && img->width > 0 && img->height > 0 && size.x > 0 && size.y > 0) {
+            draw_scale = std::min({(float)size.x / img->width, (float)size.y / img->height, 1.f});
+        } else if (centering.x > -1000 || centering.y > -1000) {
             if (img) {
                 const vec2i psize = pxsize();
                 rpos.x += (centering.x > -1000) ? ((psize.x - img->width) / 2 + centering.x) : 0;
                 rpos.y += (centering.y > -1000) ? ((psize.y - img->height) / 2 + centering.y) : 0;
             }
         }
-        ui::eimage(img_desc, rpos);
+
+        if (draw_scale != 1.f) {
+            push(cmd_t::image, Pos{rpos + ui::current_offset()}, ImageId{img_desc.tid()}, Scale{draw_scale});
+        } else {
+            ui::eimage(img_desc, rpos);
+        }
     }
 }
 
@@ -1206,6 +1218,7 @@ void ui::eimg::load(archive arch, element* parent, items& elems) {
     img_desc.offset = arch.r_int("offset");
     isometric = arch.r_bool("isometric");
     centering = arch.r_vec2i("centering", {-1001, -1001});
+    fit = arch.r_bool("fit");
 }
 
 void ui::eimg::image(const image_desc& image) {

--- a/src/graphics/elements/ui.h
+++ b/src/graphics/elements/ui.h
@@ -585,6 +585,10 @@ namespace ui {
         image_desc img_desc;
         bool isometric;
         vec2i centering;
+        // When set (with a non-zero `size`), shrink the image to fit within the
+        // size box, preserving aspect ratio (never enlarges). Used for variable-
+        // sized mission preview thumbnails so large maps don't overflow the panel.
+        bool fit = false;
 
         virtual void draw(UiFlags flags) override;
         virtual void load(archive elem, element* parent, items& elems) override;

--- a/src/scripts/scenario.js
+++ b/src/scripts/scenario.js
@@ -5,6 +5,16 @@ function scenario_win_criteria_goal(c) {
 }
 
 function mission_selection_title(scenario_id) {
+    // Use the original "history" message name (id 200 + scenario_id) as the primary
+    // title. These use the Egyptian place names (e.g. "Abedju") and match the mission
+    // briefing window, keeping the Explore History list consistent. The JS config's
+    // selection_title is an Anglicized fallback (e.g. "Abydos") for any mission whose
+    // history message is missing; "No title" is the last resort for unported ids with
+    // neither.
+    var orig = __lang_message_title_text(200 + scenario_id)
+    if (orig && orig.length > 0) {
+        return orig
+    }
     var config = get_mission_config(scenario_id)
     if (config && config.selection_title && config.selection_title.length > 0) {
         return config.selection_title

--- a/src/scripts/ui_scenario_selection.js
+++ b/src/scripts/ui_scenario_selection.js
@@ -16,7 +16,7 @@ function window_scenario_selection_on_init(ev) {
             if (sid < 0) {
                 continue
             }
-            list.add_item(mission_selection_title(sid), list.items_count)
+            list.add_item(mission_selection_title(sid), sid)
         }
     }
     window_scenario_selection.scores_or_goals = 0
@@ -224,8 +224,12 @@ function window_scenario_selection_btn_start() {
 }
 
 function window_scenario_selection_on_map_list_click(entry) {
-    var base = window_scenario_selection.campaign_first_mission
-    __game_load_mission(base + entry.user_data | 0, 0)
+    // user_data carries the real scenario id of the clicked step (set in
+    // on_init). Load it directly: campaign scenario ids are not necessarily
+    // contiguous from the first mission once choice-tree branches exist, so the
+    // old "campaign_first_mission + display_index" math could load a different
+    // mission than the one the player selected.
+    __game_load_mission(entry.user_data | 0, 0)
 
     emit window_scenario_selection.mission_changed { id: scenario.campaign_scenario_id }
 }
@@ -244,7 +248,7 @@ window_scenario_selection {
         img_background         : image({ pos[0, 0], pack:PACK_UNLOADED, id:33, offset:0 })
 
         debug_file_schema      : text({ pos[265, 170], size[160, 20], text:"", font:FONT_NORMAL_BLACK_ON_DARK })
-        img_scenario_thumb     : image({ pos[270, 200], pack:PACK_UNLOADED, id:28, offset:0 })
+        img_scenario_thumb     : image({ pos[270, 200], size[256, 152], fit:true, pack:PACK_UNLOADED, id:28, offset:0 })
 
         scenario_map_list      : scrollable_list({
             pos[210, 360]

--- a/src/scripts/ui_scenario_selection_campaign.js
+++ b/src/scripts/ui_scenario_selection_campaign.js
@@ -54,7 +54,7 @@ window_scenario_selection_campaign {
         hdr_pharaoh : text_center({ pos[220, 361], size[144, 20], align:"center", text[294, 41], font:FONT_NORMAL_BLACK_ON_LIGHT })
         hdr_cleopatra : text_center({ pos[352, 361], size[144, 20], align:"center", text[294, 42], font:FONT_NORMAL_BLACK_ON_LIGHT })
 
-        campaign_hover_thumb : image({ pos[270, 200], pack:PACK_UNLOADED, id:28, offset:0 })
+        campaign_hover_thumb : image({ pos[270, 200], size[256, 152], fit:true, pack:PACK_UNLOADED, id:28, offset:0 })
         campaign_hover_subtitle : text_center({ pos[545, 208], size[265, 22], align:"center", font:FONT_LARGE_BLACK_ON_DARK })
         campaign_hover_body : text({ pos[545, 250], size[265, 200], wrap:px(16), font:FONT_NORMAL_BLACK_ON_DARK, multiline:true, clip_area:true })
 

--- a/src/scripts/ui_scenario_selection_custom.js
+++ b/src/scripts/ui_scenario_selection_custom.js
@@ -75,7 +75,7 @@ window_scenario_selection_custom {
         debug_file_schema     : text({ pos[265, 170], size[160, 20], text:"", font:FONT_NORMAL_BLACK_ON_DARK })
 
         img_custom            : image({ pos[0, 0], pack:PACK_UNLOADED, id:32, offset:0, enabled:true })
-        img_scenario_thumb    : image({ pos[270, 200], pack:PACK_UNLOADED, id:28, offset:0 })
+        img_scenario_thumb    : image({ pos[270, 200], size[256, 152], fit:true, pack:PACK_UNLOADED, id:28, offset:0 })
 
         scenario_map_list     : scrollable_list({
             pos[210, 360]


### PR DESCRIPTION
## Problem

Three issues on the scenario-selection screens (Explore History / custom / campaign):

1. Large mission preview images overflowed the preview panel.
2. Clicking a step in a branched campaign could load the wrong mission — the loader used `campaign_first_mission + display_index`, which breaks once choice-tree branches make scenario ids non-contiguous.
3. Selection titles came only from the JS config (Anglicized names), diverging from the mission briefing window.

## Changes

- **`ui::eimg` shrink-to-fit (`fit` flag):** when set with a non-zero `size`, the image is scaled down aspect-preserving (never enlarged) so previews fit the panel. The three selection screens opt in with `size[256,152], fit:true` on their thumbnail elements.
- **Branched-mission loading:** `ui_scenario_selection.js` stores the real scenario id per list row and loads it directly, instead of the index-offset math.
- **Selection title:** prefer the original "history" message name (Egyptian place names, matching the briefing window), falling back to the config `selection_title`, then `"No title"`. Consolidated into the single `mission_selection_title()` in `scenario.js` rather than duplicating it in the window script.

## Testing

Open Explore History, custom, and campaign screens: thumbnails fit the panel, Egyptian titles show where available, and clicking a branched campaign step loads the selected mission.