### PR TITLE
fix(scripts): correct fire_risk and damage_risk for firehouse and architect post

### DIFF
--- a/src/scripts/building/architect_post.js
+++ b/src/scripts/building/architect_post.js
@@ -16,7 +16,7 @@ building_architect_post {
     meta { help_id: 81, text_id: 104 }
     info_sound : "Wavs/eng.wav"
     cost [ 6, 12, 25, 40, 60 ]
-    laborers[5], fire_risk[2], damage_risk[0]
+    laborers[5], fire_risk[0], damage_risk[0]
     flags {
         is_infrastructure: true
     }

--- a/src/scripts/building/firehouse.js
+++ b/src/scripts/building/firehouse.js
@@ -17,7 +17,7 @@ building_firehouse {
     desirability { value[-2], step[1], step_size[1], range[2] }
     laborers [6]
     fire_risk [0]
-    damage_risk [2]
+    damage_risk [0]
     flags {
         is_infrastructure: true
     }


### PR DESCRIPTION
## Summary

- `building_firehouse`: `damage_risk` was `[2]`, should be `[0]` — firehouses don't take structural damage
- `building_architect_post`: `fire_risk` was `[2]`, should be `[0]` — architect posts are fire-proof in the original game
