### PR TITLE
fix(figure): remove duplicate roam_length increment in scriber, embalmer, scriber figure_action

### DIFF
--- a/src/figuretype/figure_academy_scriber.cpp
+++ b/src/figuretype/figure_academy_scriber.cpp
@@ -7,22 +7,6 @@
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_academy_scriber);
 
-void figure_academy_scriber::figure_action() {
-    switch (action_state()) {
-    case ACTION_125_ROAMER_ROAMING:
-        base.roam_length++;
-        if (base.roam_length >= base.max_roam_length) {
-            advance_action(ACTION_126_ROAMER_RETURNING);
-        }
-
-        break;
-
-    case ACTION_126_ROAMER_RETURNING:
-        ; // nothing here
-        break;
-
-    }
-}
 
 sound_key figure_academy_scriber::phrase_key() const {
     svector<sound_key, 10> keys;

--- a/src/figuretype/figure_academy_scriber.h
+++ b/src/figuretype/figure_academy_scriber.h
@@ -8,7 +8,6 @@ public:
     figure_academy_scriber(figure *f) : figure_impl(f) {}
 
     virtual void on_create() override {}
-    virtual void figure_action() override;
     virtual sound_key phrase_key() const override;
     virtual int provide_service() override;
     virtual e_overlay get_overlay() const override { return OVERLAY_SCRIBAL_SCHOOL; }

--- a/src/figuretype/figure_embalmer.cpp
+++ b/src/figuretype/figure_embalmer.cpp
@@ -8,22 +8,6 @@
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_embalmer);
 
-void figure_embalmer::figure_action() {
-    switch (action_state()) {
-    case ACTION_125_ROAMER_ROAMING:
-        base.roam_length++;
-        if (base.roam_length >= base.max_roam_length) {
-            advance_action(ACTION_126_ROAMER_RETURNING);
-        }
-
-        break;
-
-    case ACTION_126_ROAMER_RETURNING:
-        ; // nothing here
-        break;
-
-    }
-}
 
 void figure_embalmer::figure_before_action() {
     auto b = home();

--- a/src/figuretype/figure_embalmer.h
+++ b/src/figuretype/figure_embalmer.h
@@ -9,7 +9,6 @@ public:
 
     virtual void on_create() override {}
     virtual void figure_before_action() override;
-    virtual void figure_action() override;
     virtual sound_key phrase_key() const override;
     virtual int provide_service() override;
     virtual e_overlay get_overlay() const override { return OVERLAY_MORTUARY; }

--- a/src/figuretype/figure_scriber.cpp
+++ b/src/figuretype/figure_scriber.cpp
@@ -7,22 +7,6 @@
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(figure_scriber);
 
-void figure_scriber::figure_action() {
-    switch (action_state()) {
-    case ACTION_125_ROAMER_ROAMING:
-        base.roam_length++;
-        if (base.roam_length >= base.max_roam_length) {
-            advance_action(ACTION_126_ROAMER_RETURNING);
-        }
-
-        break;
-
-    case ACTION_126_ROAMER_RETURNING:
-        ; // nothing here
-        break;
-
-    }
-}
 
 sound_key figure_scriber::phrase_key() const {
     svector<sound_key, 10> keys;

--- a/src/figuretype/figure_scriber.h
+++ b/src/figuretype/figure_scriber.h
@@ -8,7 +8,6 @@ public:
     figure_scriber(figure *f) : figure_impl(f) {}
 
     virtual void on_create() override {}
-    virtual void figure_action() override;
     virtual sound_key phrase_key() const override;
     virtual int provide_service() override;
     virtual e_overlay get_overlay() const override { return OVERLAY_SCRIBAL_SCHOOL; }


### PR DESCRIPTION
## Summary

`figure_academy_scriber`, `figure_embalmer`, and `figure_scriber` all had a custom `figure_action()` override that manually incremented `base.roam_length` and called `advance_action(ACTION_126_ROAMER_RETURNING)` when the limit was reached. The base class `figure_impl::figure_action()` already handles this for `ACTION_125_ROAMER_ROAMING`, so these overrides caused `roam_length` to be incremented twice per tick — walkers turned back at half their expected range.

Removing the three overrides restores correct roaming distance for academy scribers, embalmers, and mortuary scribers.

