### PR TITLE
feat(library): migrate spawn_figure and update_graphic to JS handlers

### DIFF
--- a/src/building/building_library.cpp
+++ b/src/building/building_library.cpp
@@ -4,18 +4,6 @@
 
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(building_library)
 
-void building_library::spawn_figure() {
-    common_spawn_roamer(FIGURE_LIBRARIAN, current_params().min_houses_coverage, (e_figure_action)ACTION_125_ROAMER_ROAMING);
-    check_labor_problem();
-}
-
-void building_library::update_graphic() {
-    const xstring &animkey = can_play_animation() ? animkeys().work : animkeys().base;
-    set_animation(animkey);
-
-    building_impl::update_graphic();
-}
-
 bool building_library::draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color mask) {
     draw_normal_anim(ctx, point, tile, mask);
     return true;

--- a/src/building/building_library.h
+++ b/src/building/building_library.h
@@ -6,8 +6,6 @@ class building_library : public building_impl {
 public:
     BUILDING_METAINFO(BUILDING_LIBRARY, building_library, building_impl);
 
-    virtual void spawn_figure() override;
     virtual e_overlay get_overlay() const override { return OVERLAY_LIBRARY; }
-    virtual void update_graphic() override;
     virtual bool draw_ornaments_and_animations_height(painter &ctx, vec2i point, tile2i tile, color mask) override;
 };

--- a/src/scripts/building/education.js
+++ b/src/scripts/building/education.js
@@ -40,6 +40,19 @@ building_library {
   max_service: 800
 }
 
+[es=(building_library, spawn_figure)]
+function building_library_spawn_figure(ev) {
+    var building = city.get_building(ev.bid)
+    building.common_spawn_roamer(FIGURE_LIBRARIAN, building_library.min_houses_coverage, ACTION_125_ROAMER_ROAMING)
+}
+
+[es=(building_library, update_graphic)]
+function building_library_update_graphic(ev) {
+    var building = city.get_building(ev.bid)
+    var animkey = building.can_play_animation ? "work" : "base"
+    building.set_animation(animkey)
+}
+
 
 building_academy {
   animations {


### PR DESCRIPTION
## Summary

- Added `[es=(building_library, spawn_figure)]` and `[es=(building_library, update_graphic)]` handlers to `src/scripts/building/education.js`
- Removed the now-redundant C++ overrides from `building_library.cpp` and `building_library.h`

The JS handlers follow the same pattern as `building_architect_post` and `building_physician`: `common_spawn_roamer(FIGURE_LIBRARIAN, min_houses_coverage, ACTION_125_ROAMER_ROAMING)` for spawn, and a `"work"` / `"base"` animation toggle for update_graphic (library uses `"base"` for idle, not `"none"`, matching the original C++ logic).
