### PR TITLE
fix: campaign mission victory advances to next mission

### DIFF
--- a/src/scripts/ui_mission_end_window.js
+++ b/src/scripts/ui_mission_end_window.js
@@ -74,29 +74,7 @@ function mission_end_replay_mission() {
     }
 }
 
-// Returns the scenario_id the player should play after completing
-// `completed_id`, or -1 if there's no next mission (true end-of-game).
-// Used by both mission_end_show (to decide between mid-campaign vs.
-// final-victory video) and mission_end_advance_to_next_mission (to
-// decide between the choice screen vs. bouncing to the main menu),
-// so the two stay in sync.
-//
-// Source of truth for `next_mission` is the mission JS config object
-// (e.g. `mission10.next_mission = 11`), NOT __win_criteria — the C++
-// scenario_data_t::win_criterias_t.next_mission field exists but is
-// never written from the mission scripts, so __win_criteria.next_mission
-// is always 0. Read from get_mission_config(completed_id) instead.
-//
-// Validity check uses __game_mission_is_valid (matches game_show_mission_choice's
-// own gate) so a script-declared next_mission that isn't a registered campaign
-// step is treated as end-of-game and we don't hand the choice window a id it'd
-// just bounce back from.
 function mission_end_compute_next_scenario_id(completed_id) {
-    // Use the direct enum check (not scenario.is_custom). The is_custom getter
-    // defined in scenario.js does `scmode != e_scenario_normal`, which is also
-    // true for e_scenario_selected — a value some campaign saves carry, causing
-    // every won campaign mission to end as if it were a custom map (wrong video
-    // + main-menu bounce). Only e_scenario_custom_map genuinely means "custom".
     if (scenario.scmode == e_scenario_custom_map) {
         log_info("mission_end_compute_next: custom map, ending campaign")
         return -1
@@ -122,17 +100,8 @@ function mission_end_advance_to_next_mission() {
     var next_rank = rank + 1
     var completed_id = scenario.campaign_scenario_id
     var savings = city.kingdome.personal_savings
-
-    // (Previously gated on `next_rank < 11`, which assumed the original
-    // Pharaoh player-rank ceiling and silently dropped the link to the
-    // next mission once a campaign's last-rank mission was won — e.g.
-    // Selima(8)→Saqqara(10) and Saqqara(10)→Serabit Khadim(11) both lost
-    // their next_mission and bounced to the main menu.)
     var next_scenario_id = mission_end_compute_next_scenario_id(completed_id)
 
-    // Direct enum check, same reason as in mission_end_compute_next_scenario_id:
-    // the is_custom getter mis-tags e_scenario_selected campaign saves as custom,
-    // which would drop the player's personal-savings carry between missions.
     if (scenario.scmode != e_scenario_custom_map) {
         city.kingdome.campaign_carry_personal_savings = savings
     }
@@ -151,8 +120,6 @@ function mission_end_advance_to_next_mission() {
 
     if (next_scenario_id == -1) {
         __game_show_main_menu()
-        // Same direct-enum guard rationale as above — don't let a misclassified
-        // selected-mode save block the campaign-end scenario reset.
         if (scenario.scmode != e_scenario_custom_map) {
             __scenario_init()
             scenario.campaign_mission_rank = 2
@@ -175,11 +142,6 @@ function mission_end_show(state) {
         return
     }
 
-    // Show the full-game-victory video only when this really IS the final
-    // mission. The hardcoded `rank >= 10` check this replaces fired on
-    // every rank-10 mission (Saqqara, Selima, ...), so mid-campaign
-    // victories incorrectly played the "you completed the entire game"
-    // video. Same end-of-game signal as the bounce-fix above.
     if (mission_end_compute_next_scenario_id(scenario.campaign_scenario_id) == -1
         && scenario.scmode != e_scenario_custom_map) {
         __game_victory_video_show("smk/win_game.smk", 400, 292, "mission_end_after_video")

--- a/src/scripts/ui_mission_end_window.js
+++ b/src/scripts/ui_mission_end_window.js
@@ -74,21 +74,66 @@ function mission_end_replay_mission() {
     }
 }
 
+// Returns the scenario_id the player should play after completing
+// `completed_id`, or -1 if there's no next mission (true end-of-game).
+// Used by both mission_end_show (to decide between mid-campaign vs.
+// final-victory video) and mission_end_advance_to_next_mission (to
+// decide between the choice screen vs. bouncing to the main menu),
+// so the two stay in sync.
+//
+// Source of truth for `next_mission` is the mission JS config object
+// (e.g. `mission10.next_mission = 11`), NOT __win_criteria — the C++
+// scenario_data_t::win_criterias_t.next_mission field exists but is
+// never written from the mission scripts, so __win_criteria.next_mission
+// is always 0. Read from get_mission_config(completed_id) instead.
+//
+// Validity check uses __game_mission_is_valid (matches game_show_mission_choice's
+// own gate) so a script-declared next_mission that isn't a registered campaign
+// step is treated as end-of-game and we don't hand the choice window a id it'd
+// just bounce back from.
+function mission_end_compute_next_scenario_id(completed_id) {
+    // Use the direct enum check (not scenario.is_custom). The is_custom getter
+    // defined in scenario.js does `scmode != e_scenario_normal`, which is also
+    // true for e_scenario_selected — a value some campaign saves carry, causing
+    // every won campaign mission to end as if it were a custom map (wrong video
+    // + main-menu bounce). Only e_scenario_custom_map genuinely means "custom".
+    if (scenario.scmode == e_scenario_custom_map) {
+        log_info("mission_end_compute_next: custom map, ending campaign")
+        return -1
+    }
+    var src = get_mission_config(completed_id)
+    var next_id = (src && src.next_mission) ? src.next_mission : 0
+    if (!next_id) {
+        next_id = completed_id + 1
+    }
+    if (next_id < 0 || !__game_mission_is_valid(next_id)) {
+        log_info("mission_end_compute_next: completed=" + completed_id
+            + " scmode=" + scenario.scmode + " next_id=" + next_id
+            + " not a valid campaign step -> end of game")
+        return -1
+    }
+    log_info("mission_end_compute_next: completed=" + completed_id
+        + " scmode=" + scenario.scmode + " -> next_scenario_id=" + next_id)
+    return next_id
+}
+
 function mission_end_advance_to_next_mission() {
     var rank = scenario.campaign_mission_rank
     var next_rank = rank + 1
     var completed_id = scenario.campaign_scenario_id
     var savings = city.kingdome.personal_savings
 
-    var next_scenario_id = -1
-    if (!scenario.is_custom && next_rank < 11) {
-        next_scenario_id = __win_criteria.next_mission
-        if (!next_scenario_id) {
-            next_scenario_id = completed_id + 1
-        }
-    }
+    // (Previously gated on `next_rank < 11`, which assumed the original
+    // Pharaoh player-rank ceiling and silently dropped the link to the
+    // next mission once a campaign's last-rank mission was won — e.g.
+    // Selima(8)→Saqqara(10) and Saqqara(10)→Serabit Khadim(11) both lost
+    // their next_mission and bounced to the main menu.)
+    var next_scenario_id = mission_end_compute_next_scenario_id(completed_id)
 
-    if (!scenario.is_custom) {
+    // Direct enum check, same reason as in mission_end_compute_next_scenario_id:
+    // the is_custom getter mis-tags e_scenario_selected campaign saves as custom,
+    // which would drop the player's personal-savings carry between missions.
+    if (scenario.scmode != e_scenario_custom_map) {
         city.kingdome.campaign_carry_personal_savings = savings
     }
 
@@ -104,9 +149,11 @@ function mission_end_advance_to_next_mission() {
     city.current_overlay = OVERLAY_NONE
     city.previous_overlay = OVERLAY_NONE
 
-    if (next_rank >= 11 || scenario.is_custom) {
+    if (next_scenario_id == -1) {
         __game_show_main_menu()
-        if (!scenario.is_custom) {
+        // Same direct-enum guard rationale as above — don't let a misclassified
+        // selected-mode save block the campaign-end scenario reset.
+        if (scenario.scmode != e_scenario_custom_map) {
             __scenario_init()
             scenario.campaign_mission_rank = 2
         }
@@ -128,7 +175,13 @@ function mission_end_show(state) {
         return
     }
 
-    if (!scenario.is_custom && scenario.campaign_mission_rank >= 10) {
+    // Show the full-game-victory video only when this really IS the final
+    // mission. The hardcoded `rank >= 10` check this replaces fired on
+    // every rank-10 mission (Saqqara, Selima, ...), so mid-campaign
+    // victories incorrectly played the "you completed the entire game"
+    // video. Same end-of-game signal as the bounce-fix above.
+    if (mission_end_compute_next_scenario_id(scenario.campaign_scenario_id) == -1
+        && scenario.scmode != e_scenario_custom_map) {
         __game_victory_video_show("smk/win_game.smk", 400, 292, "mission_end_after_video")
         return
     }


### PR DESCRIPTION
## Summary

Winning a campaign mission could silently drop the player back to the main
menu, play the full-game-victory video on the wrong mission, or skip the
personal-savings carry into the next mission. This routes the post-victory
next-mission decision through a single helper so the dialog/video path
(`mission_end_show`) and the advance path
(`mission_end_advance_to_next_mission`) stay in sync, and it fixes the
three sources of the bad behaviour.

All changes are confined to `src/scripts/ui_mission_end_window.js`.

## Bugs fixed

1. **Rank-10 missions silently bounced to the main menu.** The old
   `if (!scenario.is_custom && next_rank < 11)` gate assumed the original
   Pharaoh player-rank ceiling and dropped the link to the next mission
   whenever the completed mission's `player_rank` was 10 — e.g.
   Selima (8) → Saqqara (10) and Saqqara (10) → Serabit Khadim (11)
   both ended at the main menu instead of advancing.

2. **`scenario.is_custom` mis-tagged campaign saves as custom.** The
   getter in `scenario.js` is `scmode != e_scenario_normal`, which is
   also true for `e_scenario_selected` — a value some campaign saves
   carry. Wins in that mode took the custom-map branch: wrong end-of-game
   video, no `campaign_carry_personal_savings`, main-menu bounce.

3. **Final-victory video played on every rank-10 win.** `rank >= 10`
   triggered `smk/win_game.smk` ("you completed the entire game") on
   mid-campaign rank-10 missions (Saqqara, Selima, …) instead of only
   the true final mission.

## How

- New helper `mission_end_compute_next_scenario_id(completed_id)` reads
  `next_mission` from the mission JS config (the actual source of truth
  — `__win_criteria.next_mission` is never written from the scripts),
  defaults to `completed_id + 1`, and validates the result via
  `__game_mission_is_valid` (the same gate `game_show_mission_choice`
  uses). End-of-game is signalled uniformly by a return value of `-1`.
- Both `mission_end_show` and `mission_end_advance_to_next_mission` now
  consult that helper instead of hardcoded rank thresholds.
- All `scenario.is_custom` call sites in this file are replaced with
  `scenario.scmode == e_scenario_custom_map` so only genuine custom maps
  take the custom branch.

The `log_info` lines inside `mission_end_compute_next_scenario_id` make
each decision auditable in the game log without further instrumentation.

## Test plan

Manual end-to-end on a debug build (JS-only change — if testing
incrementally, delete `resources.lib` or run with `--mixed` so the
bundled scripts aren't stale):

1. **Mid-campaign rank-10 win** — load a Saqqara save near victory and
   win. Expect: win dialog, *not* `smk/win_game.smk`; clicking through
   advances to the mission-choice window.
2. **`e_scenario_selected` save** — load any campaign save in that mode
   and win. Expect: same behaviour as a normal-mode save, savings
   carried into the next mission.
3. **Custom-map win** — load a custom `.map` and win. Expect: straight
   to main menu, no savings carry, no scenario reset.
4. **True end-of-campaign win** — win the actual final mission. Expect:
   `smk/win_game.smk` plays, then the after-video handler shows the won
   dialog.
