### PR TITLE
Add BIK video playback support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -965,12 +965,25 @@ cmrc_add_resource_library(
     ${PROJECT_SOURCE_DIR}/res/patreon_48.png
 )
 
+if (MSVC)
+    # Generated localization translation units are very large and can exhaust
+    # cl.exe's default heap on some VS setups. Keep this target single-process
+    # because a handful of giant generated translation units are the main issue.
+    target_compile_options(resources PRIVATE /bigobj /Zm1000 /MP1)
+endif()
+
 if (!APPLE)
     set_source_files_properties(${SOURCE_FILES} PROPERTIES LANGUAGE CXX)
 endif()
 
 
 add_executable(${GAME} ${SOURCE_FILES})
+
+if (MSVC)
+    # Some translation units in the main game target also hit cl.exe heap limits
+    # on VS2022 without larger compiler heaps/object section support.
+    target_compile_options(${GAME} PRIVATE /bigobj /Zm200)
+endif()
 
 if(LAME_FILES)
     set_source_files_properties(${LAME_FILES} PROPERTIES

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -31,6 +31,7 @@
 #include "scenario/scenario.h"
 #include "sound/sound_city.h"
 #include "sound/sound.h"
+#include "window/intro_video.h"
 #include "window/window_city.h"
 #include "window/editor/window_editor.h"
 #include "window/main_menu.h"
@@ -396,8 +397,12 @@ bool game_init(game_opts opts) {
         main_menu_screen::show(/*restart_music*/ false);
     } else {
         game.logo_show_patch_message = 0;
-        g_sound.play_intro();
-        autoconfig_window::show("window_logo");
+        if (!!game_features::gameui_show_intro_video) {
+            window_intro_video_show();
+        } else {
+            g_sound.play_intro();
+            autoconfig_window::show("window_logo");
+        }
     }
 
     return true;

--- a/src/graphics/video.cpp
+++ b/src/graphics/video.cpp
@@ -1,9 +1,11 @@
 #include "video.h"
 
+#include "core/log.h"
 #include "core/system_time.h"
 #include "graphics/graphics.h"
 #include "content/dir.h"
 #include "content/vfs.h"
+#include "io/gamefiles/bink.h"
 #include "io/gamefiles/smacker.h"
 #include "platform/renderer.h"
 #include "game/game_config.h"
@@ -11,11 +13,17 @@
 #include "sound/sound.h"
 #include "sound/music.h"
 
+#include <SDL.h>
+#include <cstring>
+#include <algorithm>
+
 static struct {
     bool is_playing;
     bool is_ended;
+    int backend;
 
     smacker s;
+    bink b;
     struct {
         int width;
         int height;
@@ -23,6 +31,7 @@ static struct {
         int micros_per_frame;
         time_millis start_render_millis;
         int current_frame;
+        bool frame_dirty;
     } video;
     struct {
         int has_audio;
@@ -36,10 +45,27 @@ static struct {
     } buffer;
 } data;
 
+static int s_video_profile_logs = 0;
+static constexpr int BIK_STARTUP_PREBUFFER_FRAMES = 4;
+static constexpr int BIK_STEADY_PREBUFFER_FRAMES = 3;
+
+enum {
+    VIDEO_BACKEND_NONE = 0,
+    VIDEO_BACKEND_SMK = 1,
+    VIDEO_BACKEND_BIK = 2
+};
+
 static void close_smk(void) {
     if (data.s) {
         smacker_close(data.s);
         data.s = 0;
+    }
+}
+
+static void close_bik(void) {
+    if (data.b) {
+        bink_close(data.b);
+        data.b = 0;
     }
 }
 
@@ -64,6 +90,7 @@ static int load_smk(const char* filename) {
     data.video.height = y_scale == SMACKER_Y_SCALE_NONE ? height : height * 2;
     data.video.y_scale = y_scale;
     data.video.current_frame = 0;
+    data.video.frame_dirty = true;
     data.video.micros_per_frame = micros_per_frame;
 
     data.audio.has_audio = 0;
@@ -82,6 +109,36 @@ static int load_smk(const char* filename) {
         close_smk();
         return 0;
     }
+    data.backend = VIDEO_BACKEND_SMK;
+    return 1;
+}
+
+static int load_bik(const char* filename) {
+    data.b = bink_open(filename);
+    if (!data.b) {
+        return 0;
+    }
+
+    data.video.width = bink_get_width(data.b);
+    data.video.height = bink_get_height(data.b);
+    data.video.y_scale = SMACKER_Y_SCALE_NONE;
+    data.video.current_frame = 0;
+    data.video.frame_dirty = true;
+    data.video.micros_per_frame = bink_get_micros_per_frame(data.b);
+
+    data.audio.has_audio = 0;
+    if (!!game_features::gameopt_sound_effects_enabled && bink_has_audio(data.b)) {
+        data.audio.has_audio = 1;
+        data.audio.bitdepth = bink_get_audio_bitdepth(data.b);
+        data.audio.channels = bink_get_audio_channels(data.b);
+        data.audio.rate = bink_get_audio_sample_rate(data.b);
+    }
+
+    if (!bink_first_frame(data.b)) {
+        close_bik();
+        return 0;
+    }
+    data.backend = VIDEO_BACKEND_BIK;
     return 1;
 }
 
@@ -91,11 +148,18 @@ static void end_video(void) {
     g_render.release_custom_texture_buffer(CUSTOM_IMAGE_VIDEO);
 }
 
+static void queue_bik_audio_chunk(void*, const void* audio_data, int len) {
+    if (audio_data && len > 0) {
+        g_sound.write_custom_music_data(const_cast<void*>(audio_data), len);
+    }
+}
+
 bool video_start(const char* filename) {
     data.is_playing = false;
     data.is_ended = false;
+    data.backend = VIDEO_BACKEND_NONE;
 
-    if (load_smk(filename)) {
+    if (load_smk(filename) || load_bik(filename)) {
         g_sound.music_stop();
         g_sound.speech_stop();
         g_render.create_custom_texture(CUSTOM_IMAGE_VIDEO, data.video.width, data.video.height);
@@ -113,12 +177,26 @@ void video_size(int* width, int* height) {
 
 void video_init(void) {
     data.video.start_render_millis = time_get_millis();
+    s_video_profile_logs = 0;
 
     if (data.audio.has_audio) {
-        int audio_len = smacker_get_frame_audio_size(data.s, 0);
+        int audio_len = data.backend == VIDEO_BACKEND_SMK
+            ? smacker_get_frame_audio_size(data.s, 0)
+            : bink_get_frame_audio_size(data.b);
         if (audio_len > 0) {
-            g_sound.use_custom_music_player(data.audio.bitdepth, data.audio.channels, data.audio.rate, (void*)smacker_get_frame_audio(data.s, 0), audio_len);
+            void* audio_data = data.backend == VIDEO_BACKEND_SMK
+                ? (void*)smacker_get_frame_audio(data.s, 0)
+                : (void*)bink_get_frame_audio(data.b);
+            g_sound.use_custom_music_player(data.audio.bitdepth, data.audio.channels, data.audio.rate, audio_data, audio_len);
         }
+    }
+
+    if (data.backend == VIDEO_BACKEND_BIK) {
+        bink_prebuffer_frames(
+            data.b,
+            data.audio.has_audio ? BIK_STARTUP_PREBUFFER_FRAMES : 1,
+            data.audio.has_audio ? queue_bik_audio_chunk : nullptr,
+            nullptr);
     }
 }
 
@@ -132,28 +210,45 @@ void video_stop(void) {
             end_video();
 
         close_smk();
+        close_bik();
         data.is_playing = 0;
+        data.backend = VIDEO_BACKEND_NONE;
     }
 }
 
 void video_shutdown(void) {
     if (data.is_playing) {
         close_smk();
+        close_bik();
         data.is_playing = 0;
+        data.backend = VIDEO_BACKEND_NONE;
     }
 }
 
 static int get_next_frame(void) {
-    if (!data.s) {
+    if (data.backend == VIDEO_BACKEND_NONE) {
         return 0;
     }
     time_millis now_millis = time_get_millis();
-
     int frame_no = (now_millis - data.video.start_render_millis) * 1000 / data.video.micros_per_frame;
-    int draw_frame = data.video.current_frame == 0;
+    if (data.audio.has_audio) {
+        uint64_t played_micros = g_sound.custom_music_playback_micros();
+        if (played_micros > 0) {
+            frame_no = (int)(played_micros / data.video.micros_per_frame);
+        }
+    }
+    int draw_frame = data.video.frame_dirty ? 1 : 0;
+    data.video.frame_dirty = false;
+    frame_no = std::min(frame_no, data.video.current_frame + 1);
+
     while (frame_no > data.video.current_frame) {
-        if (smacker_next_frame(data.s) != SMACKER_FRAME_OK) {
+        Uint32 decode_begin = SDL_GetTicks();
+        int ok = data.backend == VIDEO_BACKEND_SMK
+            ? (smacker_next_frame(data.s) == SMACKER_FRAME_OK)
+            : bink_next_frame(data.b);
+        if (!ok) {
             close_smk();
+            close_bik();
             data.is_ended = 1;
             data.is_playing = 0;
             end_video();
@@ -162,26 +257,62 @@ static int get_next_frame(void) {
         data.video.current_frame++;
         draw_frame = 1;
 
-        if (data.audio.has_audio) {
-            int audio_len = smacker_get_frame_audio_size(data.s, 0);
+        if (data.audio.has_audio && !(data.backend == VIDEO_BACKEND_BIK && bink_current_audio_is_prebuffered(data.b))) {
+            int audio_len = data.backend == VIDEO_BACKEND_SMK
+                ? smacker_get_frame_audio_size(data.s, 0)
+                : bink_get_frame_audio_size(data.b);
             if (audio_len > 0) {
-                g_sound.write_custom_music_data((void*)smacker_get_frame_audio(data.s, 0), audio_len);
+                void* audio_data = data.backend == VIDEO_BACKEND_SMK
+                    ? (void*)smacker_get_frame_audio(data.s, 0)
+                    : (void*)bink_get_frame_audio(data.b);
+                g_sound.write_custom_music_data(audio_data, audio_len);
             }
+        }
+
+        if (data.backend == VIDEO_BACKEND_BIK) {
+            bink_prebuffer_frames(
+                data.b,
+                data.audio.has_audio ? BIK_STEADY_PREBUFFER_FRAMES : 1,
+                data.audio.has_audio ? queue_bik_audio_chunk : nullptr,
+                nullptr);
+        }
+
+        if (s_video_profile_logs < 20) {
+            Uint32 decode_end = SDL_GetTicks();
+            logs::info(
+                "BIK profile: frame=%d decode_ms=%u target_frame=%d played_us=%llu buffered_us=%llu",
+                data.video.current_frame,
+                (unsigned)(decode_end - decode_begin),
+                frame_no,
+                (unsigned long long)g_sound.custom_music_playback_micros(),
+                (unsigned long long)g_sound.custom_music_buffered_micros());
+            ++s_video_profile_logs;
         }
     }
     return draw_frame;
 }
 static void update_video_frame(void) {
-    const unsigned char* frame = smacker_get_frame_video(data.s);
-    const uint32_t* pal = smacker_get_frame_palette(data.s);
-    if (frame && pal) {
-        for (int y = 0; y < data.video.height; y++) {
-            color* pixel = &data.buffer.pixels[y * data.buffer.width];
-            int video_y = data.video.y_scale == SMACKER_Y_SCALE_NONE ? y : y / 2;
-            const unsigned char* line = frame + (video_y * data.video.width);
-            for (int x = 0; x < data.video.width; x++) {
-                *pixel = ALPHA_OPAQUE | pal[line[x]];
-                ++pixel;
+    if (data.backend == VIDEO_BACKEND_BIK) {
+        const uint32_t* frame = bink_get_frame_rgba(data.b);
+        if (frame) {
+            for (int y = 0; y < data.video.height; y++) {
+                color* pixel = &data.buffer.pixels[y * data.buffer.width];
+                const uint32_t* line = frame + (y * data.video.width);
+                std::memcpy(pixel, line, (size_t)data.video.width * sizeof(color));
+            }
+        }
+    } else {
+        const unsigned char* frame = smacker_get_frame_video(data.s);
+        const uint32_t* pal = smacker_get_frame_palette(data.s);
+        if (frame && pal) {
+            for (int y = 0; y < data.video.height; y++) {
+                color* pixel = &data.buffer.pixels[y * data.buffer.width];
+                int video_y = data.video.y_scale == SMACKER_Y_SCALE_NONE ? y : y / 2;
+                const unsigned char* line = frame + (video_y * data.video.width);
+                for (int x = 0; x < data.video.width; x++) {
+                    *pixel = ALPHA_OPAQUE | pal[line[x]];
+                    ++pixel;
+                }
             }
         }
     }
@@ -199,18 +330,27 @@ void video_draw_fullscreen(void) {
     if (get_next_frame())
         update_video_frame();
 
-    int s_width = screen_width();
-    int s_height = screen_height();
-    float scale_w = data.video.width / (float)screen_width();
-    float scale_h = data.video.height / (float)screen_height();
-    float scale = scale_w > scale_h ? scale_w : scale_h;
+    int width = screen_width();
+    int height = screen_height();
+    if (width <= 0 || height <= 0 || data.video.width <= 0 || data.video.height <= 0) {
+        return;
+    }
+
+    float scale_w = data.video.width / (float) width;
+    float scale_h = data.video.height / (float) height;
+    float scale = std::max(scale_w, scale_h);
+    if (scale <= 0.0f) {
+        return;
+    }
 
     int x = 0;
     int y = 0;
-    if (scale == scale_h)
-        x = (int)((s_width - data.video.width / scale) / 2 * scale);
-    if (scale == scale_w)
-        y = (int)((s_height - data.video.height / scale) / 2 * scale);
+    if (scale == scale_h) {
+        x = (int)(((width - data.video.width / scale) / 2.0f) * scale);
+    }
+    if (scale == scale_w) {
+        y = (int)(((height - data.video.height / scale) / 2.0f) * scale);
+    }
 
     g_render.draw_custom_texture(CUSTOM_IMAGE_VIDEO, x, y, scale);
 }

--- a/src/graphics/video.h
+++ b/src/graphics/video.h
@@ -43,4 +43,10 @@ void video_shutdown(void);
  */
 void video_draw(int x_offset, int y_offset);
 
+/**
+ * Draws the current video scaled to fit inside the window while preserving
+ * aspect ratio.
+ */
+void video_draw_fullscreen(void);
+
 #endif // GRAPHICS_VIDEO_H

--- a/src/io/gamefiles/bink.cpp
+++ b/src/io/gamefiles/bink.cpp
@@ -1,0 +1,1843 @@
+#include "bink.h"
+
+#include "core/log.h"
+#include "content/vfs.h"
+
+#include <SDL.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t kBikTagMask = 0x00FFFFFFu;
+constexpr uint32_t kBikTag = 0x004B4942u;
+constexpr char kSupportedRevision = 'f';
+constexpr uint16_t kAudioFlagStereo = 0x2000;
+constexpr uint16_t kAudioFlagUseDct = 0x1000;
+constexpr double kPi = 3.14159265358979323846;
+
+constexpr int kParamBlockTypes = 0;
+constexpr int kParamSubBlockTypes = 1;
+constexpr int kParamColors = 2;
+constexpr int kParamPattern = 3;
+constexpr int kParamXOff = 4;
+constexpr int kParamYOff = 5;
+constexpr int kParamIntraDc = 6;
+constexpr int kParamInterDc = 7;
+constexpr int kParamRun = 8;
+constexpr int kParamCount = 9;
+
+constexpr int kSkipBlock = 0;
+constexpr int kScaledBlock = 1;
+constexpr int kMotionBlock = 2;
+constexpr int kRunBlock = 3;
+constexpr int kResidueBlock = 4;
+constexpr int kIntraBlock = 5;
+constexpr int kFillBlock = 6;
+constexpr int kInterBlock = 7;
+constexpr int kPatternBlock = 8;
+constexpr int kRawBlock = 9;
+
+constexpr int kHuffmanTreeCount = 16;
+constexpr int kHuffmanSymbolCount = 16;
+constexpr int kHuffmanMaxCodeLength = 7;
+
+constexpr std::array<int, 4> kBlockTypeRleLengths = {4, 8, 12, 32};
+constexpr std::array<int, 25> kCriticalFrequencies = {
+    100, 200, 300, 400, 510, 630, 770, 920,
+    1080, 1270, 1480, 1720, 2000, 2320, 2700, 3150,
+    3700, 4400, 5300, 6400, 7700, 9500, 12000, 15500, 24500
+};
+constexpr std::array<int, 16> kRleLengthTable = {
+    2, 3, 4, 5, 6, 8, 9, 10,
+    11, 12, 13, 14, 15, 16, 32, 64
+};
+
+constexpr uint8_t kHuffmanCodeBits[kHuffmanTreeCount][kHuffmanSymbolCount] = {
+    { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F },
+    { 0x00, 0x01, 0x03, 0x05, 0x07, 0x09, 0x0B, 0x0D, 0x0F, 0x13, 0x15, 0x17, 0x19, 0x1B, 0x1D, 0x1F },
+    { 0x00, 0x02, 0x01, 0x09, 0x05, 0x15, 0x0D, 0x1D, 0x03, 0x13, 0x0B, 0x1B, 0x07, 0x17, 0x0F, 0x1F },
+    { 0x00, 0x02, 0x06, 0x01, 0x09, 0x05, 0x0D, 0x1D, 0x03, 0x13, 0x0B, 0x1B, 0x07, 0x17, 0x0F, 0x1F },
+    { 0x00, 0x04, 0x02, 0x06, 0x01, 0x09, 0x05, 0x0D, 0x03, 0x13, 0x0B, 0x1B, 0x07, 0x17, 0x0F, 0x1F },
+    { 0x00, 0x04, 0x02, 0x0A, 0x06, 0x0E, 0x01, 0x09, 0x05, 0x0D, 0x03, 0x0B, 0x07, 0x17, 0x0F, 0x1F },
+    { 0x00, 0x02, 0x0A, 0x06, 0x0E, 0x01, 0x09, 0x05, 0x0D, 0x03, 0x0B, 0x1B, 0x07, 0x17, 0x0F, 0x1F },
+    { 0x00, 0x01, 0x05, 0x03, 0x13, 0x0B, 0x1B, 0x3B, 0x07, 0x27, 0x17, 0x37, 0x0F, 0x2F, 0x1F, 0x3F },
+    { 0x00, 0x01, 0x03, 0x13, 0x0B, 0x2B, 0x1B, 0x3B, 0x07, 0x27, 0x17, 0x37, 0x0F, 0x2F, 0x1F, 0x3F },
+    { 0x00, 0x01, 0x05, 0x0D, 0x03, 0x13, 0x0B, 0x1B, 0x07, 0x27, 0x17, 0x37, 0x0F, 0x2F, 0x1F, 0x3F },
+    { 0x00, 0x02, 0x01, 0x05, 0x0D, 0x03, 0x13, 0x0B, 0x1B, 0x07, 0x17, 0x37, 0x0F, 0x2F, 0x1F, 0x3F },
+    { 0x00, 0x01, 0x09, 0x05, 0x0D, 0x03, 0x13, 0x0B, 0x1B, 0x07, 0x17, 0x37, 0x0F, 0x2F, 0x1F, 0x3F },
+    { 0x00, 0x02, 0x01, 0x03, 0x13, 0x0B, 0x1B, 0x3B, 0x07, 0x27, 0x17, 0x37, 0x0F, 0x2F, 0x1F, 0x3F },
+    { 0x00, 0x01, 0x05, 0x03, 0x07, 0x27, 0x17, 0x37, 0x0F, 0x4F, 0x2F, 0x6F, 0x1F, 0x5F, 0x3F, 0x7F },
+    { 0x00, 0x01, 0x05, 0x03, 0x07, 0x17, 0x37, 0x77, 0x0F, 0x4F, 0x2F, 0x6F, 0x1F, 0x5F, 0x3F, 0x7F },
+    { 0x00, 0x02, 0x01, 0x05, 0x03, 0x07, 0x27, 0x17, 0x37, 0x0F, 0x2F, 0x6F, 0x1F, 0x5F, 0x3F, 0x7F }
+};
+
+constexpr uint8_t kHuffmanCodeLengths[kHuffmanTreeCount][kHuffmanSymbolCount] = {
+    { 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 },
+    { 1, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 },
+    { 2, 2, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 },
+    { 2, 3, 3, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5 },
+    { 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5 },
+    { 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5 },
+    { 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5 },
+    { 1, 3, 3, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
+    { 1, 2, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
+    { 1, 3, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6 },
+    { 2, 2, 3, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6 },
+    { 1, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6 },
+    { 2, 2, 2, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 },
+    { 1, 3, 3, 3, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7 },
+    { 1, 3, 3, 3, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7 },
+    { 2, 2, 3, 3, 3, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7 }
+};
+
+struct audio_track_info {
+    uint16_t sample_rate = 0;
+    uint32_t max_decoded_size = 0;
+    bool is_stereo = false;
+};
+
+struct frame_index_entry {
+    uint32_t offset = 0;
+    uint32_t size = 0;
+    bool is_keyframe = false;
+};
+
+struct audio_packet {
+    std::vector<uint8_t> payload;
+};
+
+struct frame_packet {
+    std::vector<audio_packet> audio_packets;
+    std::vector<uint8_t> video_payload;
+};
+
+static uint32_t read_u32_le(FILE* fp) {
+    uint8_t bytes[4];
+    if (std::fread(bytes, 1, 4, fp) != 4) {
+        throw std::runtime_error("Unexpected end of file.");
+    }
+    return (uint32_t)bytes[0]
+        | ((uint32_t)bytes[1] << 8)
+        | ((uint32_t)bytes[2] << 16)
+        | ((uint32_t)bytes[3] << 24);
+}
+
+static uint16_t read_u16_le(FILE* fp) {
+    uint8_t bytes[2];
+    if (std::fread(bytes, 1, 2, fp) != 2) {
+        throw std::runtime_error("Unexpected end of file.");
+    }
+    return (uint16_t)(bytes[0] | (bytes[1] << 8));
+}
+
+static int clamp_int(int value, int min_value, int max_value) {
+    return value < min_value ? min_value : (value > max_value ? max_value : value);
+}
+
+static int int_log2(int value) {
+    int result = 0;
+    while ((1 << (result + 1)) <= value) {
+        ++result;
+    }
+    return result;
+}
+
+static int align8(int value) {
+    return (value + 7) & ~7;
+}
+
+class bit_reader_le {
+public:
+    explicit bit_reader_le(const std::vector<uint8_t>& data) : data_(data) {}
+
+    int bits_remaining() const { return (int)data_.size() * 8 - bit_position_; }
+
+    bool read_bit() { return read_bits(1) != 0; }
+
+    uint32_t read_bits(int count) {
+        if (count < 0 || count > 32 || bits_remaining() < count) {
+            throw std::runtime_error("Invalid bit read.");
+        }
+        uint32_t value = 0;
+        for (int i = 0; i < count; ++i) {
+            int absolute_bit = bit_position_ + i;
+            int byte_index = absolute_bit >> 3;
+            int bit_index = absolute_bit & 7;
+            uint32_t bit = (data_[byte_index] >> bit_index) & 1u;
+            value |= bit << i;
+        }
+        bit_position_ += count;
+        return value;
+    }
+
+    void skip_bits(int count) {
+        if (count < 0 || bits_remaining() < count) {
+            throw std::runtime_error("Invalid bit skip.");
+        }
+        bit_position_ += count;
+    }
+
+    void align32() {
+        int padding = (-bit_position_) & 31;
+        if (padding) {
+            skip_bits(padding);
+        }
+    }
+
+private:
+    const std::vector<uint8_t>& data_;
+    int bit_position_ = 0;
+};
+
+class bink_file {
+public:
+    static bink_file load(const std::string& path) {
+        FILE* fp = std::fopen(path.c_str(), "rb");
+        if (!fp) {
+            throw std::runtime_error("Unable to open BIK file.");
+        }
+
+        try {
+            uint32_t codec_tag = read_u32_le(fp);
+            if ((codec_tag & kBikTagMask) != kBikTag) {
+                throw std::runtime_error("Unsupported BIK signature.");
+            }
+
+            char revision = (char)((codec_tag >> 24) & 0xff);
+            if (revision != kSupportedRevision) {
+                throw std::runtime_error("Only BIKf video is supported.");
+            }
+
+            uint32_t declared_file_size = read_u32_le(fp) + 8u;
+            uint32_t frame_count = read_u32_le(fp);
+            (void)read_u32_le(fp);
+            (void)read_u32_le(fp);
+            uint32_t width = read_u32_le(fp);
+            uint32_t height = read_u32_le(fp);
+            uint32_t fps_numerator = read_u32_le(fp);
+            uint32_t fps_denominator = read_u32_le(fp);
+            uint32_t video_flags_raw = read_u32_le(fp);
+            uint32_t audio_track_count = read_u32_le(fp);
+
+            if (video_flags_raw != 0) {
+                throw std::runtime_error("Only plain YUV BIKf videos are supported.");
+            }
+            if (audio_track_count != 1) {
+                throw std::runtime_error("Only single-track BIKf files are supported.");
+            }
+
+            uint32_t max_decoded_size = read_u32_le(fp);
+            uint16_t sample_rate = read_u16_le(fp);
+            uint16_t flags = read_u16_le(fp);
+            if ((flags & kAudioFlagUseDct) != 0) {
+                throw std::runtime_error("Only RDFT Bink audio is supported.");
+            }
+
+            audio_track_info audio_track;
+            audio_track.sample_rate = sample_rate;
+            audio_track.max_decoded_size = max_decoded_size;
+            audio_track.is_stereo = (flags & kAudioFlagStereo) != 0;
+
+            (void)read_u32_le(fp);
+            uint32_t next_pos = read_u32_le(fp);
+            bool next_keyframe = true;
+            std::vector<frame_index_entry> index;
+            index.reserve(frame_count);
+
+            for (uint32_t i = 0; i < frame_count; ++i) {
+                bool is_keyframe = next_keyframe;
+                uint32_t pos = next_pos & ~1u;
+                if (i == frame_count - 1) {
+                    next_pos = declared_file_size;
+                    next_keyframe = false;
+                } else {
+                    uint32_t raw_next_pos = read_u32_le(fp);
+                    next_keyframe = (raw_next_pos & 1u) != 0;
+                    next_pos = raw_next_pos & ~1u;
+                }
+
+                if (next_pos <= pos) {
+                    throw std::runtime_error("Invalid BIK frame index.");
+                }
+
+                index.push_back({pos, next_pos - pos, is_keyframe});
+            }
+
+            std::fclose(fp);
+            return bink_file(path, width, height, fps_numerator, fps_denominator, audio_track, std::move(index));
+        } catch (...) {
+            std::fclose(fp);
+            throw;
+        }
+    }
+
+    bink_file() = default;
+
+    const std::string& path() const { return file_path_; }
+    int width() const { return (int)width_; }
+    int height() const { return (int)height_; }
+    int micros_per_frame() const {
+        if (fps_numerator_ == 0) {
+            return 0;
+        }
+        double fps = (double)fps_numerator_ / std::max<uint32_t>(fps_denominator_, 1u);
+        return (int)std::llround(1000000.0 / std::max(fps, 1.0));
+    }
+    const audio_track_info& audio_track() const { return audio_track_; }
+    const std::vector<frame_index_entry>& frame_index() const { return frame_index_; }
+
+private:
+    bink_file(
+        std::string file_path,
+        uint32_t width,
+        uint32_t height,
+        uint32_t fps_numerator,
+        uint32_t fps_denominator,
+        audio_track_info audio_track,
+        std::vector<frame_index_entry> frame_index)
+        : file_path_(std::move(file_path))
+        , width_(width)
+        , height_(height)
+        , fps_numerator_(fps_numerator)
+        , fps_denominator_(fps_denominator)
+        , audio_track_(audio_track)
+        , frame_index_(std::move(frame_index)) {}
+
+    std::string file_path_;
+    uint32_t width_ = 0;
+    uint32_t height_ = 0;
+    uint32_t fps_numerator_ = 0;
+    uint32_t fps_denominator_ = 0;
+    audio_track_info audio_track_;
+    std::vector<frame_index_entry> frame_index_;
+};
+
+class bink_sequential_packet_reader {
+public:
+    explicit bink_sequential_packet_reader(const bink_file& file) : file_(file) {
+        fp_ = std::fopen(file.path().c_str(), "rb");
+        if (!fp_) {
+            throw std::runtime_error("Unable to open BIK stream.");
+        }
+    }
+
+    ~bink_sequential_packet_reader() {
+        if (fp_) {
+            std::fclose(fp_);
+        }
+    }
+
+    frame_packet read_frame_packet(int frame_number) {
+        const auto& index = file_.frame_index();
+        if (frame_number < 0 || frame_number >= (int)index.size()) {
+            throw std::runtime_error("Frame index out of range.");
+        }
+
+        const frame_index_entry& entry = index[frame_number];
+        std::fseek(fp_, (long)entry.offset, SEEK_SET);
+
+        uint32_t audio_size = read_u32_le(fp_);
+        int bytes_consumed = 4;
+        if (audio_size > entry.size - (uint32_t)bytes_consumed) {
+            throw std::runtime_error("Invalid BIK audio packet boundary.");
+        }
+
+        int encoded_size = 0;
+        if (audio_size > 3) {
+            (void)read_u32_le(fp_);
+            bytes_consumed += 4;
+            encoded_size = (int)audio_size - 4;
+        }
+
+        std::vector<uint8_t> audio_payload = read_exact(encoded_size);
+        bytes_consumed += (int)audio_payload.size();
+
+        int video_size = (int)entry.size - bytes_consumed;
+        std::vector<uint8_t> video_payload = read_exact(video_size);
+
+        frame_packet packet;
+        packet.audio_packets.push_back({std::move(audio_payload)});
+        packet.video_payload = std::move(video_payload);
+        return packet;
+    }
+
+private:
+    std::vector<uint8_t> read_exact(int count) {
+        if (count < 0) {
+            throw std::runtime_error("Negative packet size.");
+        }
+        std::vector<uint8_t> result((size_t)count);
+        if (count > 0 && std::fread(result.data(), 1, (size_t)count, fp_) != (size_t)count) {
+            throw std::runtime_error("Unexpected end of BIK file.");
+        }
+        return result;
+    }
+
+    const bink_file& file_;
+    FILE* fp_ = nullptr;
+};
+
+struct bink_reference_data {
+    static bink_reference_data& instance() {
+        static bink_reference_data data = create();
+        return data;
+    }
+
+    std::array<int, 64> scan{};
+    std::array<std::array<int, 64>, 17> patterns{};
+    std::array<std::array<int, 64>, 16> intra_quant{};
+    std::array<std::array<int, 64>, 16> inter_quant{};
+
+private:
+    static bink_reference_data create() {
+        static constexpr const char* packed_base_quant =
+            "11231143113210102232101034232322322312112211333332211010111110001223113211210010212110102323221222221100110032222111100011000000eyopuy4feb531jgwzmirsxwt3asvjj7r3sm2nm4jh8ulwin58cjwmrbnsfcb8mwje2b7yu6vk8fwwgbpezdvdpanec950snamd506soxoiyu5tyo3nse5lyha0qlpde7k5fr2lxpk6zrm67nd3c9t1dqhnc6n4gvhc3yvw4meg2fa83mxfva5w1az2t9fnkykiaj7wj3wpovhkgepdh5529kpareotlnzhvzr2evca6rayt5ulkq1sxt6a58x7mxg1xpjz2ogi6vom0m47tz5ftgr9aekmnura7g6c0w48u30wpasfmbljblwgxtlh8vguh077we04awyg6dtl5pzcczt3djwqhv557xe1y58ygdvvo0oh96usw9k9rl3pot";
+        static constexpr int embedded_scan[64] = {
+            0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15,
+            20, 21, 28, 29, 22, 23, 30, 31, 16, 17, 24, 25, 32, 33, 40, 41,
+            34, 35, 42, 43, 48, 49, 56, 57, 50, 51, 58, 59, 18, 19, 26, 27,
+            36, 37, 44, 45, 38, 39, 46, 47, 52, 53, 60, 61, 54, 55, 62, 63
+        };
+        static constexpr int embedded_patterns[17][64] = {
+            {0, 8, 16, 24, 32, 40, 48, 56, 57, 49, 41, 33, 25, 17, 9, 1, 2, 10, 18, 26, 34, 42, 50, 58, 59, 51, 43, 35, 27, 19, 11, 3, 4, 12, 20, 28, 36, 44, 52, 60, 61, 53, 45, 37, 29, 21, 13, 5, 6, 14, 22, 30, 38, 46, 54, 62, 63, 55, 47, 39, 31, 23, 15, 7},
+            {59, 58, 57, 56, 48, 49, 50, 51, 43, 42, 41, 40, 32, 33, 34, 35, 27, 26, 25, 24, 16, 17, 18, 19, 11, 10, 9, 8, 0, 1, 2, 3, 4, 5, 6, 7, 15, 14, 13, 12, 20, 21, 22, 23, 31, 30, 29, 28, 36, 37, 38, 39, 47, 46, 45, 44, 52, 53, 54, 55, 63, 62, 61, 60},
+            {25, 17, 18, 26, 27, 19, 11, 3, 2, 10, 9, 1, 0, 8, 16, 24, 32, 40, 48, 56, 57, 49, 41, 42, 50, 58, 59, 51, 43, 35, 34, 33, 29, 21, 22, 30, 31, 23, 15, 7, 6, 14, 13, 5, 4, 12, 20, 28, 36, 44, 52, 60, 61, 53, 45, 46, 54, 62, 63, 55, 47, 39, 38, 37},
+            {3, 11, 2, 10, 1, 9, 0, 8, 16, 24, 17, 25, 18, 26, 19, 27, 35, 43, 34, 42, 33, 41, 32, 40, 48, 56, 49, 57, 50, 58, 51, 59, 60, 52, 61, 53, 62, 54, 63, 55, 47, 39, 46, 38, 45, 37, 44, 36, 28, 20, 29, 21, 30, 22, 31, 23, 15, 7, 14, 6, 13, 5, 12, 4},
+            {24, 25, 16, 17, 8, 9, 0, 1, 2, 3, 10, 11, 18, 19, 26, 27, 28, 29, 20, 21, 12, 13, 4, 5, 6, 7, 14, 15, 22, 23, 30, 31, 39, 38, 47, 46, 55, 54, 63, 62, 61, 60, 53, 52, 45, 44, 37, 36, 35, 34, 43, 42, 51, 50, 59, 58, 57, 56, 49, 48, 41, 40, 33, 32},
+            {0, 1, 2, 3, 8, 9, 10, 11, 16, 17, 18, 19, 24, 25, 26, 27, 32, 33, 34, 35, 40, 41, 42, 43, 48, 49, 50, 51, 56, 57, 58, 59, 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31, 36, 37, 38, 39, 44, 45, 46, 47, 52, 53, 54, 55, 60, 61, 62, 63},
+            {6, 7, 15, 14, 13, 5, 12, 4, 3, 11, 2, 10, 9, 1, 0, 8, 16, 24, 17, 25, 18, 26, 19, 27, 20, 28, 21, 29, 22, 30, 23, 31, 39, 47, 38, 46, 37, 45, 36, 44, 35, 43, 34, 42, 33, 41, 32, 40, 49, 48, 56, 57, 58, 50, 59, 51, 60, 52, 61, 53, 54, 55, 63, 62},
+            {0, 1, 2, 3, 4, 5, 6, 7, 15, 14, 13, 12, 11, 10, 9, 8, 16, 17, 18, 19, 20, 21, 22, 23, 31, 30, 29, 28, 27, 26, 25, 24, 32, 33, 34, 35, 36, 37, 38, 39, 47, 46, 45, 44, 43, 42, 41, 40, 48, 49, 50, 51, 52, 53, 54, 55, 63, 62, 61, 60, 59, 58, 57, 56},
+            {0, 8, 9, 1, 2, 3, 11, 10, 18, 19, 27, 26, 25, 17, 16, 24, 32, 40, 41, 33, 34, 35, 43, 42, 50, 49, 48, 56, 57, 58, 59, 51, 52, 60, 61, 62, 63, 55, 54, 53, 45, 44, 36, 37, 38, 46, 47, 39, 31, 23, 22, 30, 29, 28, 20, 21, 13, 12, 4, 5, 6, 14, 15, 7},
+            {24, 25, 16, 17, 8, 9, 0, 1, 2, 3, 10, 11, 18, 19, 26, 27, 28, 29, 20, 21, 12, 13, 4, 5, 6, 7, 14, 15, 22, 23, 30, 31, 38, 39, 46, 47, 54, 55, 62, 63, 60, 61, 52, 53, 44, 45, 36, 37, 34, 35, 42, 43, 50, 51, 58, 59, 56, 57, 48, 49, 40, 41, 32, 33},
+            {0, 8, 1, 9, 2, 10, 3, 11, 19, 27, 18, 26, 17, 25, 16, 24, 32, 40, 33, 41, 34, 42, 35, 43, 51, 59, 50, 58, 49, 57, 48, 56, 60, 52, 61, 53, 62, 54, 63, 55, 47, 39, 46, 38, 45, 37, 44, 36, 31, 23, 30, 22, 29, 21, 28, 20, 12, 4, 13, 5, 14, 6, 15, 7},
+            {0, 8, 16, 24, 25, 26, 27, 19, 11, 3, 2, 1, 9, 17, 18, 10, 4, 12, 20, 28, 29, 30, 31, 23, 15, 7, 6, 5, 13, 21, 22, 14, 36, 44, 52, 60, 61, 62, 63, 55, 47, 39, 38, 37, 45, 53, 54, 46, 32, 40, 48, 56, 57, 58, 59, 51, 43, 35, 34, 33, 41, 49, 50, 42},
+            {0, 8, 9, 1, 2, 3, 11, 10, 19, 27, 26, 18, 17, 16, 24, 25, 33, 32, 40, 41, 42, 34, 35, 43, 51, 59, 58, 50, 49, 57, 56, 48, 52, 60, 61, 53, 54, 62, 63, 55, 47, 39, 38, 46, 45, 44, 36, 37, 29, 28, 20, 21, 22, 30, 31, 23, 14, 15, 7, 6, 5, 13, 12, 4},
+            {24, 16, 8, 0, 1, 2, 3, 11, 19, 27, 26, 25, 17, 10, 9, 18, 28, 20, 12, 4, 5, 6, 7, 15, 23, 31, 30, 29, 21, 14, 13, 22, 60, 52, 44, 36, 37, 38, 39, 47, 55, 63, 62, 61, 53, 46, 45, 54, 56, 48, 40, 32, 33, 34, 35, 43, 51, 59, 58, 57, 49, 42, 41, 50},
+            {0, 8, 9, 1, 2, 10, 18, 17, 16, 24, 25, 26, 27, 19, 11, 3, 7, 6, 14, 15, 23, 22, 21, 13, 5, 4, 12, 20, 28, 29, 30, 31, 63, 62, 54, 55, 47, 46, 45, 53, 61, 60, 52, 44, 36, 37, 38, 39, 56, 48, 49, 57, 58, 50, 42, 41, 40, 32, 33, 34, 35, 43, 51, 59},
+            {0, 1, 8, 9, 16, 17, 24, 25, 32, 33, 40, 41, 48, 49, 56, 57, 58, 59, 50, 51, 42, 43, 34, 35, 26, 27, 18, 19, 10, 11, 2, 3, 4, 5, 12, 13, 20, 21, 28, 29, 36, 37, 44, 45, 52, 53, 60, 61, 62, 63, 54, 55, 46, 47, 38, 39, 30, 31, 22, 23, 14, 15, 6, 7}
+        };
+
+        bink_reference_data data;
+        for (int i = 0; i < 64; ++i) {
+            data.scan[i] = embedded_scan[i];
+        }
+        for (int p = 0; p < 17; ++p) {
+            for (int i = 0; i < 64; ++i) {
+                data.patterns[p][i] = embedded_patterns[p][i];
+            }
+        }
+
+        std::vector<int> base_quant = unpack_values(4, packed_base_quant);
+        constexpr double factors[16] = {
+            1.0, 4.0 / 3.0, 5.0 / 3.0, 2.0,
+            8.0 / 3.0, 7.0 / 2.0, 4.0, 5.0,
+            6.0, 8.0, 12.0, 17.0,
+            22.0, 28.0, 34.0, 44.0
+        };
+
+        for (int level = 0; level < 32; ++level) {
+            auto& target = level < 16 ? data.intra_quant[level & 15] : data.inter_quant[level & 15];
+            int source_offset = level < 16 ? 0 : 64;
+            double factor = factors[level & 15];
+            for (int i = 0; i < 64; ++i) {
+                target[i] = (int)std::llround(base_quant[source_offset + i] * factor);
+            }
+        }
+        return data;
+    }
+
+    static std::vector<int> unpack_values(int width, const char* packed) {
+        int packed_len = (int)std::strlen(packed);
+        int len = packed_len / width;
+        std::vector<int> values((size_t)len);
+        std::vector<char> token((size_t)width);
+        for (int index = 0; index < len; ++index) {
+            for (int i = 0; i < width; ++i) {
+                token[(size_t)i] = packed[(i * len) + index];
+            }
+            values[(size_t)index] = parse_base36(token);
+        }
+        return values;
+    }
+
+    static int parse_base36(const std::vector<char>& token) {
+        int value = 0;
+        for (char c0 : token) {
+            char c = (char)std::tolower((unsigned char)c0);
+            int digit = 0;
+            if (c >= '0' && c <= '9') {
+                digit = c - '0';
+            } else if (c >= 'a' && c <= 'z') {
+                digit = 10 + (c - 'a');
+            } else {
+                throw std::runtime_error("Invalid base36 character.");
+            }
+            value = value * 36 + digit;
+        }
+        return value;
+    }
+};
+
+struct tree_t {
+    int tree_index = 0;
+    std::array<uint8_t, 16> symbols{};
+};
+
+struct bundle_t {
+    int length_bits = 0;
+    tree_t tree;
+    std::vector<int> data;
+    int read_index = 0;
+    bool active = false;
+
+    void reset() {
+        data.clear();
+        read_index = 0;
+        active = true;
+    }
+};
+
+struct bink_video_transforms {
+    static constexpr int kDctC0 = 2896;
+    static constexpr int kDctC1 = 2217;
+    static constexpr int kDctC2 = 3784;
+    static constexpr int kDctC3 = -5352;
+
+    static void idct_put(int* block, uint8_t* destination, size_t destination_len, int destination_offset, int stride) {
+        for (int i = 0; i < 8; ++i) {
+            idct(block, i, nullptr, 0, i, true);
+        }
+        for (int i = 0; i < 64; i += 8) {
+            if (destination_offset >= (int)destination_len) {
+                break;
+            }
+            idct(block, i, destination, destination_len, destination_offset, false);
+            destination_offset += stride;
+        }
+    }
+
+    static void idct_add(int* block, uint8_t* destination, size_t destination_len, int destination_offset, int stride) {
+        for (int i = 0; i < 8; ++i) {
+            idct(block, i, nullptr, 0, i, true);
+        }
+        for (int i = 0; i < 64; i += 8) {
+            idct(block, i, nullptr, 0, i, false);
+        }
+        add_block_8x8(block, destination, destination_len, destination_offset, stride);
+    }
+
+    static void add_block_8x8(int* block, uint8_t* destination, size_t destination_len, int destination_offset, int stride) {
+        for (int y = 0; y < 8; ++y) {
+            int row_offset = destination_offset + y * stride;
+            for (int x = 0; x < 8; ++x) {
+                int destination_index = row_offset + x;
+                if (destination_index < 0 || destination_index >= (int)destination_len) {
+                    continue;
+                }
+                destination[(size_t)destination_index] = (uint8_t)(destination[(size_t)destination_index] + block[y * 8 + x]);
+            }
+        }
+    }
+
+private:
+    static void idct(int* source, int source_offset, uint8_t* destination, size_t destination_len, int destination_offset, bool column) {
+        int index_shift = column ? 3 : 0;
+        int constant_to_add = column ? 0 : 0x7f;
+        int destination_shift = column ? 0 : 8;
+
+        int a0 = source[source_offset] + constant_to_add;
+        int b0 = source[source_offset + (1 << index_shift)];
+        int a2 = source[source_offset + (2 << index_shift)];
+        int x3 = source[source_offset + (3 << index_shift)];
+        int x4 = source[source_offset + (4 << index_shift)];
+        int a4 = source[source_offset + (5 << index_shift)];
+        int x6 = source[source_offset + (6 << index_shift)];
+        int x7 = source[source_offset + (7 << index_shift)];
+
+        int a1 = a0 - x4;
+        int a3 = (kDctC0 * (a2 - x6)) >> 11;
+        int a5 = a4 - x3;
+        int a7 = b0 - x7;
+        a0 += x4;
+        a2 += x6;
+        a4 += x3;
+        b0 += x7;
+
+        int a0_plus_a2 = a0 + a2;
+        int a0_minus_a2 = a0 - a2;
+        int a1_plus_a3_minus_a2 = a1 + a3 - a2;
+        int a1_minus_a3_plus_a2 = a1 - a3 + a2;
+
+        int b1 = (kDctC2 * (a5 + a7)) >> 11;
+        int b3 = (kDctC0 * (b0 - a4)) >> 11;
+        b0 += a4;
+        int b2 = ((kDctC3 * a5) >> 11) - b0 + b1;
+        b3 -= b2;
+        int b4 = ((kDctC1 * a7) >> 11) + b3 - b1;
+
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 0, a0_plus_a2 + b0);
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 1, a1_plus_a3_minus_a2 + b2);
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 2, a1_minus_a3_plus_a2 + b3);
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 3, a0_minus_a2 - b4);
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 4, a0_minus_a2 + b4);
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 5, a1_minus_a3_plus_a2 - b3);
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 6, a1_plus_a3_minus_a2 - b2);
+        write(destination, destination_len, source, destination_offset, source_offset, index_shift, destination_shift, 7, a0_plus_a2 - b0);
+    }
+
+    static void write(uint8_t* destination, size_t destination_len, int* source, int destination_offset, int source_offset, int index_shift, int destination_shift, int element, int value) {
+        int shifted = value >> destination_shift;
+        int index = destination_offset + (element << index_shift);
+        if (!destination) {
+            source[index] = shifted;
+            return;
+        }
+        if (index < 0 || index >= (int)destination_len) {
+            return;
+        }
+        destination[(size_t)index] = (uint8_t)shifted;
+    }
+};
+
+class bink_rdft_audio_decoder {
+public:
+    explicit bink_rdft_audio_decoder(const audio_track_info& track) {
+        original_channels_ = track.is_stereo ? 2 : 1;
+
+        int frame_length_bits = 0;
+        if (track.sample_rate < 22050) {
+            frame_length_bits = 9;
+        } else if (track.sample_rate < 44100) {
+            frame_length_bits = 10;
+        } else {
+            frame_length_bits = 11;
+        }
+        frame_length_bits += int_log2(original_channels_);
+
+        frame_length_ = 1 << frame_length_bits;
+        overlap_length_ = frame_length_ / 16;
+        root_ = (float)(2.0 / (std::sqrt((double)frame_length_) * 32768.0));
+
+        quant_table_.resize(96);
+        for (int i = 0; i < 96; ++i) {
+            quant_table_[(size_t)i] = (float)(std::exp(i * 0.15289164787221954) * root_);
+        }
+
+        int sample_rate_for_bands = track.sample_rate * original_channels_;
+        int sample_rate_half = (sample_rate_for_bands + 1) / 2;
+        int num_bands = 1;
+        while (num_bands < 25 && sample_rate_half > kCriticalFrequencies[(size_t)(num_bands - 1)]) {
+            ++num_bands;
+        }
+
+        bands_.resize((size_t)num_bands + 1);
+        bands_[0] = 2;
+        for (int i = 1; i < num_bands; ++i) {
+            bands_[(size_t)i] = (uint32_t)((kCriticalFrequencies[(size_t)(i - 1)] * frame_length_ / sample_rate_half) & ~1);
+        }
+        bands_[(size_t)num_bands] = (uint32_t)frame_length_;
+
+        previous_overlap_.assign((size_t)overlap_length_, 0.0f);
+
+        int quarter_length = frame_length_ >> 2;
+        rdft_cos_table_.resize((size_t)quarter_length);
+        rdft_sin_table_.resize((size_t)quarter_length);
+        double theta = (2.0 * kPi) / frame_length_;
+        for (int i = 0; i < quarter_length; ++i) {
+            rdft_cos_table_[(size_t)i] = (float)std::cos(i * theta);
+            rdft_sin_table_[(size_t)i] = (float)std::sin(i * theta);
+        }
+
+        int fft_size = frame_length_ >> 1;
+        int fft_bits = int_log2(fft_size);
+        fft_bit_reverse_.resize((size_t)fft_size);
+        for (int i = 0; i < fft_size; ++i) {
+            fft_bit_reverse_[(size_t)i] = reverse_bits(i, fft_bits);
+        }
+
+        fft_twiddles_.resize((size_t)fft_size);
+        for (int i = 0; i < (fft_size >> 1); ++i) {
+            int twiddle_index = i << 1;
+            double angle = (-2.0 * kPi * i) / fft_size;
+            fft_twiddles_[(size_t)twiddle_index] = (float)std::cos(angle);
+            fft_twiddles_[(size_t)(twiddle_index + 1)] = (float)std::sin(angle);
+        }
+    }
+
+    std::vector<float> decode_packet(const std::vector<uint8_t>& audio_payload) {
+        bit_reader_le reader(audio_payload);
+        std::vector<float> output;
+        output.reserve((size_t)frame_length_);
+
+        while (reader.bits_remaining() > 0) {
+            std::vector<float> coeffs = decode_coefficients(reader);
+            std::vector<float> transformed = inverse_packed_rdft(coeffs);
+            apply_overlap(transformed);
+            std::vector<float> block = slice_playable_samples(transformed);
+            output.insert(output.end(), block.begin(), block.end());
+            reader.align32();
+        }
+        return output;
+    }
+
+private:
+    std::vector<float> decode_coefficients(bit_reader_le& reader) {
+        std::vector<float> coeffs((size_t)frame_length_, 0.0f);
+        coeffs[0] = read_packed_float(reader) * root_;
+        coeffs[1] = read_packed_float(reader) * root_;
+
+        std::vector<float> quantizers(bands_.size() - 1);
+        for (size_t i = 0; i < quantizers.size(); ++i) {
+            int index = (int)reader.read_bits(8);
+            quantizers[i] = quant_table_[(size_t)std::min(index, 95)];
+        }
+
+        size_t band_index = 0;
+        float current_quantizer = quantizers[0];
+        int coefficient_index = 2;
+        while (coefficient_index < frame_length_) {
+            bool has_run = reader.read_bit();
+            int group_end = 0;
+            if (has_run) {
+                int run_length = kRleLengthTable[(size_t)reader.read_bits(4)];
+                group_end = coefficient_index + run_length * 8;
+            } else {
+                group_end = coefficient_index + 8;
+            }
+            group_end = std::min(group_end, frame_length_);
+
+            int width = (int)reader.read_bits(4);
+            if (width == 0) {
+                while (coefficient_index < group_end) {
+                    coeffs[(size_t)coefficient_index++] = 0.0f;
+                    while (band_index + 1 < bands_.size() && bands_[band_index] < (uint32_t)coefficient_index) {
+                        current_quantizer = quantizers[std::min(band_index, quantizers.size() - 1)];
+                        ++band_index;
+                    }
+                }
+                continue;
+            }
+
+            while (coefficient_index < group_end) {
+                if (band_index < bands_.size() - 1 && bands_[band_index] == (uint32_t)coefficient_index) {
+                    current_quantizer = quantizers[band_index];
+                    ++band_index;
+                }
+                uint32_t coefficient = reader.read_bits(width);
+                if (coefficient == 0) {
+                    coeffs[(size_t)coefficient_index] = 0.0f;
+                } else {
+                    bool negative = reader.read_bit();
+                    float value = current_quantizer * (float)coefficient;
+                    coeffs[(size_t)coefficient_index] = negative ? -value : value;
+                }
+                ++coefficient_index;
+            }
+        }
+
+        return coeffs;
+    }
+
+    std::vector<float> inverse_packed_rdft(const std::vector<float>& packed_coefficients) {
+        int n = frame_length_;
+        std::vector<float> data = packed_coefficients;
+        float dc = data[0];
+        float nyquist = data[1];
+        data[0] = 0.5f * (dc + nyquist);
+        data[1] = 0.5f * (dc - nyquist);
+
+        int quarter_length = n >> 2;
+        for (int i = 1; i < quarter_length; ++i) {
+            int i1 = 2 * i;
+            int i2 = n - i1;
+
+            float d01 = data[(size_t)i1];
+            float d02 = data[(size_t)i2];
+            float d11 = data[(size_t)(i1 + 1)];
+            float d12 = data[(size_t)(i2 + 1)];
+
+            float even_re = 0.5f * (d01 + d02);
+            float odd_im = 0.5f * (d01 - d02);
+            float even_im = 0.5f * (d11 - d12);
+            float odd_re = -0.5f * (d11 + d12);
+
+            float cos_value = rdft_cos_table_[(size_t)i];
+            float sin_value = rdft_sin_table_[(size_t)i];
+
+            data[(size_t)i1] = even_re + odd_re * cos_value - odd_im * sin_value;
+            data[(size_t)(i1 + 1)] = even_im + odd_im * cos_value + odd_re * sin_value;
+            data[(size_t)i2] = even_re - odd_re * cos_value + odd_im * sin_value;
+            data[(size_t)(i2 + 1)] = -even_im + odd_im * cos_value + odd_re * sin_value;
+        }
+
+        forward_fft_in_place(data);
+        return data;
+    }
+
+    void apply_overlap(std::vector<float>& samples) {
+        if (!first_frame_) {
+            for (int i = 0; i < overlap_length_; ++i) {
+                samples[(size_t)i] = ((previous_overlap_[(size_t)i] * (overlap_length_ - i)) + (samples[(size_t)i] * i)) / overlap_length_;
+            }
+        }
+        std::copy(samples.end() - overlap_length_, samples.end(), previous_overlap_.begin());
+        first_frame_ = false;
+    }
+
+    std::vector<float> slice_playable_samples(const std::vector<float>& samples) const {
+        int count = frame_length_ - overlap_length_;
+        return std::vector<float>(samples.begin(), samples.begin() + count);
+    }
+
+    static float read_packed_float(bit_reader_le& reader) {
+        int exponent = (int)reader.read_bits(5);
+        uint32_t mantissa = reader.read_bits(23);
+        bool negative = reader.read_bit();
+        double value = mantissa * std::pow(2.0, exponent - 23);
+        return negative ? (float)-value : (float)value;
+    }
+
+    void forward_fft_in_place(std::vector<float>& data) {
+        int n = (int)data.size() >> 1;
+        for (int i = 0; i < n; ++i) {
+            int j = fft_bit_reverse_[(size_t)i];
+            if (j > i) {
+                int i2 = i << 1;
+                int j2 = j << 1;
+                std::swap(data[(size_t)i2], data[(size_t)j2]);
+                std::swap(data[(size_t)(i2 + 1)], data[(size_t)(j2 + 1)]);
+            }
+        }
+
+        for (int length = 2; length <= n; length <<= 1) {
+            int half_size = length >> 1;
+            int step = n / length;
+            for (int i = 0; i < n; i += length) {
+                int twiddle_index = 0;
+                for (int j = 0; j < half_size; ++j) {
+                    float wr = fft_twiddles_[(size_t)(twiddle_index << 1)];
+                    float wi = fft_twiddles_[(size_t)((twiddle_index << 1) + 1)];
+                    int even_index = (i + j) << 1;
+                    int odd_index = (i + j + half_size) << 1;
+                    float er = data[(size_t)even_index];
+                    float ei = data[(size_t)(even_index + 1)];
+                    float orr = data[(size_t)odd_index];
+                    float oi = data[(size_t)(odd_index + 1)];
+
+                    float tr = wr * orr - wi * oi;
+                    float ti = wr * oi + wi * orr;
+
+                    data[(size_t)odd_index] = er - tr;
+                    data[(size_t)(odd_index + 1)] = ei - ti;
+                    data[(size_t)even_index] = er + tr;
+                    data[(size_t)(even_index + 1)] = ei + ti;
+                    twiddle_index += step;
+                }
+            }
+        }
+    }
+
+    static int reverse_bits(int value, int bit_count) {
+        int result = 0;
+        for (int i = 0; i < bit_count; ++i) {
+            result = (result << 1) | ((value >> i) & 1);
+        }
+        return result;
+    }
+
+    int original_channels_ = 0;
+    int frame_length_ = 0;
+    int overlap_length_ = 0;
+    float root_ = 0.0f;
+    std::vector<float> quant_table_;
+    std::vector<uint32_t> bands_;
+    std::vector<float> previous_overlap_;
+    std::vector<float> rdft_cos_table_;
+    std::vector<float> rdft_sin_table_;
+    std::vector<int> fft_bit_reverse_;
+    std::vector<float> fft_twiddles_;
+    bool first_frame_ = true;
+};
+
+class bink_video_decoder {
+public:
+    explicit bink_video_decoder(const bink_file& file)
+        : width_(file.width())
+        , height_(file.height())
+        , num_pixels_(width_ * height_)
+        , uv_size_(((width_ + 1) >> 1) * ((height_ + 1) >> 1))
+        , previous_frame_data_((size_t)(num_pixels_ + uv_size_ * 2), 0)
+        , reference_data_(bink_reference_data::instance()) {
+        for (auto& tree : color_high_trees_) {
+            tree.tree_index = 0;
+            for (int i = 0; i < 16; ++i) {
+                tree.symbols[(size_t)i] = (uint8_t)i;
+            }
+        }
+    }
+
+    std::vector<uint8_t> decode(const frame_packet& packet) {
+        int chroma_width = (width_ + 1) >> 1;
+        int chroma_height = (height_ + 1) >> 1;
+        std::vector<uint8_t> yuv = previous_frame_data_;
+        bit_reader_le reader(packet.video_payload);
+
+        decode_plane(reader, yuv, width_, height_, 0);
+        if (reader.bits_remaining() >= 1) {
+            decode_plane(reader, yuv, chroma_width, chroma_height, num_pixels_);
+        }
+        if (reader.bits_remaining() >= 1) {
+            decode_plane(reader, yuv, chroma_width, chroma_height, num_pixels_ + uv_size_);
+        }
+
+        previous_frame_data_ = yuv;
+        return yuv;
+    }
+
+private:
+    void decode_plane(bit_reader_le& reader, std::vector<uint8_t>& frame_data, int current_width, int current_height, int plane_offset) {
+        int block_width = (current_width + 7) >> 3;
+        int block_height = (current_height + 7) >> 3;
+        int plane_size = current_width * current_height;
+
+        plane_data_.assign(frame_data.begin() + plane_offset, frame_data.begin() + plane_offset + plane_size);
+        previous_plane_data_.assign(previous_frame_data_.begin() + plane_offset, previous_frame_data_.begin() + plane_offset + plane_size);
+        plane_data_offset_ = 0;
+        plane_end_offset_ = plane_size;
+        stride_ = current_width;
+        current_plane_width_ = current_width;
+        current_plane_height_ = current_height;
+
+        init_lengths(std::max(current_width, 8), block_width);
+        read_plane_trees(reader);
+
+        int block_line_increment = stride_ * 7;
+        int current_block_y = 0;
+        int current_plane_ptr = 0;
+
+        while (current_block_y++ < block_height) {
+            read_block_types(reader, bundles_[kParamBlockTypes]);
+            read_block_types(reader, bundles_[kParamSubBlockTypes]);
+            read_colors(reader, bundles_[kParamColors]);
+            read_patterns(reader, bundles_[kParamPattern]);
+            read_motion_values(reader, bundles_[kParamXOff]);
+            read_motion_values(reader, bundles_[kParamYOff]);
+            read_dcs(reader, bundles_[kParamIntraDc], false);
+            read_dcs(reader, bundles_[kParamInterDc], true);
+            read_runs(reader, bundles_[kParamRun]);
+
+            int current_block_x = 0;
+            while (current_block_x++ < block_width) {
+                int block_type = get_value(kParamBlockTypes);
+                switch (block_type) {
+                case kSkipBlock:
+                    break;
+                case kScaledBlock:
+                    if ((current_block_y & 1) != 0) {
+                        decode_scaled_block(reader, current_plane_ptr);
+                    }
+                    ++current_block_x;
+                    current_plane_ptr += 16;
+                    continue;
+                case kMotionBlock:
+                    decode_motion_block(current_plane_ptr);
+                    break;
+                case kRunBlock:
+                    decode_run_block(reader, plane_data_.data(), plane_data_.size(), current_plane_ptr, stride_, true);
+                    break;
+                case kResidueBlock:
+                    decode_residue_block(reader, current_plane_ptr);
+                    break;
+                case kIntraBlock:
+                    decode_intra_block(reader, plane_data_.data(), plane_data_.size(), current_plane_ptr, stride_, true);
+                    break;
+                case kFillBlock:
+                    decode_fill_block(current_plane_ptr, 8);
+                    break;
+                case kInterBlock:
+                    decode_inter_block(reader, current_plane_ptr);
+                    break;
+                case kPatternBlock:
+                    decode_pattern_block(plane_data_.data(), plane_data_.size(), current_plane_ptr, stride_, true);
+                    break;
+                case kRawBlock:
+                    decode_raw_block(current_plane_ptr);
+                    break;
+                default:
+                    throw std::runtime_error("Invalid BIK block type.");
+                }
+                current_plane_ptr += 8;
+            }
+            current_plane_ptr += block_line_increment;
+        }
+
+        reader.align32();
+        std::copy(plane_data_.begin(), plane_data_.end(), frame_data.begin() + plane_offset);
+    }
+
+    void decode_motion_block(int destination_offset) {
+        int x_off = get_value(kParamXOff);
+        int y_off = get_value(kParamYOff);
+        int source_offset = destination_offset + x_off + y_off * stride_;
+        copy_block(source_offset, destination_offset);
+    }
+
+    void decode_run_block(bit_reader_le& reader, uint8_t* block, size_t block_len, int offset, int block_stride, bool plane_target) {
+        int i = 0;
+        int scan_index = (int)reader.read_bits(4) << 6;
+        do {
+            int run = get_value(kParamRun) + 1;
+            i += run;
+
+            if (reader.read_bit()) {
+                int value = get_value(kParamColors);
+                for (int j = 0; j < run; ++j) {
+                    int pos = scan_index < 1024 ? reference_data_.patterns[(size_t)(scan_index >> 6)][(size_t)(scan_index & 63)] : 0;
+                    ++scan_index;
+                    write_block_byte(block, block_len, offset + ((pos >> 3) * block_stride) + (pos & 7), (uint8_t)value, plane_target);
+                }
+            } else {
+                for (int j = 0; j < run; ++j) {
+                    int pos = scan_index < 1024 ? reference_data_.patterns[(size_t)(scan_index >> 6)][(size_t)(scan_index & 63)] : 0;
+                    ++scan_index;
+                    write_block_byte(block, block_len, offset + ((pos >> 3) * block_stride) + (pos & 7), (uint8_t)get_value(kParamColors), plane_target);
+                }
+            }
+        } while (i < 63);
+
+        if (i == 63) {
+            int pos = scan_index < 1024 ? reference_data_.patterns[(size_t)(scan_index >> 6)][(size_t)(scan_index & 63)] : 0;
+            write_block_byte(block, block_len, offset + ((pos >> 3) * block_stride) + (pos & 7), (uint8_t)get_value(kParamColors), plane_target);
+        }
+    }
+
+    void decode_residue_block(bit_reader_le& reader, int destination_offset) {
+        int x_off = get_value(kParamXOff);
+        int y_off = get_value(kParamYOff);
+        int source_offset = destination_offset + x_off + y_off * stride_;
+        std::fill(temp_dct_buffer_.begin(), temp_dct_buffer_.end(), 0);
+        read_coefficients_or_residue(reader, temp_dct_buffer_.data(), -1, false);
+        copy_block(source_offset, destination_offset);
+        bink_video_transforms::add_block_8x8(temp_dct_buffer_.data(), plane_data_.data(), plane_data_.size(), destination_offset, stride_);
+    }
+
+    void decode_intra_block(bit_reader_le& reader, uint8_t* block, size_t block_len, int offset, int block_stride, bool) {
+        temp_dct_buffer_[0] = get_value(kParamIntraDc);
+        std::fill(temp_dct_buffer_.begin() + 1, temp_dct_buffer_.end(), 0);
+        read_coefficients_or_residue(reader, temp_dct_buffer_.data(), 0, false);
+        bink_video_transforms::idct_put(temp_dct_buffer_.data(), block, block_len, offset, block_stride);
+    }
+
+    void decode_fill_block(int destination_offset, int size) {
+        int value = get_value(kParamColors);
+        for (int y = 0; y < size; ++y) {
+            int row_offset = destination_offset + y * stride_;
+            for (int x = 0; x < size; ++x) {
+                write_plane_byte(row_offset + x, (uint8_t)value);
+            }
+        }
+    }
+
+    void decode_inter_block(bit_reader_le& reader, int destination_offset) {
+        int x_off = get_value(kParamXOff);
+        int y_off = get_value(kParamYOff);
+        int source_offset = destination_offset + x_off + y_off * stride_;
+        copy_block(source_offset, destination_offset);
+        temp_dct_buffer_[0] = get_value(kParamInterDc);
+        std::fill(temp_dct_buffer_.begin() + 1, temp_dct_buffer_.end(), 0);
+        read_coefficients_or_residue(reader, temp_dct_buffer_.data(), 0, true);
+        bink_video_transforms::idct_add(temp_dct_buffer_.data(), plane_data_.data(), plane_data_.size(), destination_offset, stride_);
+    }
+
+    void decode_pattern_block(uint8_t* block, size_t block_len, int offset, int block_stride, bool plane_target) {
+        int color0 = get_value(kParamColors);
+        int color1 = get_value(kParamColors);
+        for (int i = 0; i < 8; ++i) {
+            int value = get_value(kParamPattern);
+            for (int j = 0; j < 8; ++j) {
+                write_block_byte(block, block_len, offset + i * block_stride + j, (uint8_t)(((value & 1) == 0) ? color0 : color1), plane_target);
+                value >>= 1;
+            }
+        }
+    }
+
+    void decode_raw_block(int destination_offset) {
+        for (int y = 0; y < 8; ++y) {
+            int row_offset = destination_offset + y * stride_;
+            for (int x = 0; x < 8; ++x) {
+                write_plane_byte(row_offset + x, (uint8_t)get_value(kParamColors));
+            }
+        }
+    }
+
+    void decode_scaled_block(bit_reader_le& reader, int destination_offset) {
+        int sub_block = get_value(kParamSubBlockTypes);
+        switch (sub_block) {
+        case kRawBlock:
+            for (int i = 0; i < 64; ++i) {
+                temp_scaling_buffer_[(size_t)i] = (uint8_t)get_value(kParamColors);
+            }
+            break;
+        case kIntraBlock:
+            decode_intra_block(reader, temp_scaling_buffer_.data(), temp_scaling_buffer_.size(), 0, 8, false);
+            break;
+        case kFillBlock:
+            decode_fill_block(destination_offset, 16);
+            return;
+        case kRunBlock:
+            decode_run_block(reader, temp_scaling_buffer_.data(), temp_scaling_buffer_.size(), 0, 8, false);
+            break;
+        case kPatternBlock:
+            decode_pattern_block(temp_scaling_buffer_.data(), temp_scaling_buffer_.size(), 0, 8, false);
+            break;
+        default:
+            throw std::runtime_error("Invalid BIK scaled block type.");
+        }
+
+        int source_index = 0;
+        int destination_line = destination_offset;
+        int max_destination_line = destination_line + (stride_ << 4);
+        int line_increment = (stride_ << 1) - 15;
+        while (destination_line < max_destination_line) {
+            uint8_t value = temp_scaling_buffer_[(size_t)source_index++];
+            write_plane_byte(destination_line, value);
+            write_plane_byte(destination_line + stride_, value);
+            ++destination_line;
+            write_plane_byte(destination_line, value);
+            write_plane_byte(destination_line + stride_, value);
+            destination_line += (source_index & 0x7) != 0 ? 1 : line_increment;
+        }
+    }
+
+    void copy_block(int source_offset, int destination_offset) {
+        if (source_offset == destination_offset) {
+            return;
+        }
+
+        int source_base_y = floor_div(source_offset, stride_);
+        int source_base_x = source_offset - source_base_y * stride_;
+        int destination_row = destination_offset;
+        for (int y = 0; y < 8; ++y) {
+            for (int x = 0; x < 8; ++x) {
+                int dst_index = destination_row + x;
+                if (dst_index < plane_data_offset_ || dst_index >= plane_end_offset_) {
+                    continue;
+                }
+
+                int src_x = clamp_int(source_base_x + x, 0, current_plane_width_ - 1);
+                int src_y = clamp_int(source_base_y + y, 0, current_plane_height_ - 1);
+                int src_index = src_y * stride_ + src_x;
+                plane_data_[(size_t)dst_index] = previous_plane_data_[(size_t)src_index];
+            }
+            destination_row += stride_;
+        }
+    }
+
+    static int floor_div(int value, int divisor) {
+        int quotient = value / divisor;
+        int remainder = value % divisor;
+        if (remainder != 0 && ((remainder < 0) != (divisor < 0))) {
+            --quotient;
+        }
+        return quotient;
+    }
+
+    void write_plane_byte(int index, uint8_t value) {
+        if (index >= plane_data_offset_ && index < plane_end_offset_) {
+            plane_data_[(size_t)index] = value;
+        }
+    }
+
+    void write_block_byte(uint8_t* block, size_t block_len, int index, uint8_t value, bool plane_target) {
+        if (plane_target) {
+            write_plane_byte(index, value);
+        } else if (index >= 0 && index < (int)block_len) {
+            block[(size_t)index] = value;
+        }
+    }
+
+    void init_lengths(int current_width, int block_width) {
+        int aligned_width = align8(current_width);
+        bundles_[kParamBlockTypes].length_bits = int_log2((aligned_width >> 3) + 511) + 1;
+        bundles_[kParamSubBlockTypes].length_bits = int_log2((aligned_width >> 4) + 511) + 1;
+        bundles_[kParamColors].length_bits = int_log2(block_width * 64 + 511) + 1;
+        bundles_[kParamPattern].length_bits = int_log2((block_width << 3) + 511) + 1;
+        bundles_[kParamXOff].length_bits = int_log2((aligned_width >> 3) + 511) + 1;
+        bundles_[kParamYOff].length_bits = int_log2((aligned_width >> 3) + 511) + 1;
+        bundles_[kParamIntraDc].length_bits = int_log2((aligned_width >> 3) + 511) + 1;
+        bundles_[kParamInterDc].length_bits = int_log2((aligned_width >> 3) + 511) + 1;
+        bundles_[kParamRun].length_bits = int_log2(block_width * 48 + 511) + 1;
+    }
+
+    void read_plane_trees(bit_reader_le& reader) {
+        for (int i = 0; i < kParamCount; ++i) {
+            if (i == kParamColors) {
+                for (auto& tree : color_high_trees_) {
+                    read_tree(reader, tree);
+                }
+                color_last_value_ = 0;
+            }
+            if (i != kParamIntraDc && i != kParamInterDc) {
+                read_tree(reader, bundles_[(size_t)i].tree);
+            }
+            bundles_[(size_t)i].reset();
+        }
+    }
+
+    void read_tree(bit_reader_le& reader, tree_t& tree) {
+        int tree_index = (int)reader.read_bits(4);
+        tree.tree_index = tree_index;
+        if (tree_index == 0) {
+            for (int i = 0; i < 16; ++i) {
+                tree.symbols[(size_t)i] = (uint8_t)i;
+            }
+            return;
+        }
+
+        if (reader.read_bit()) {
+            int len = (int)reader.read_bits(3);
+            std::array<bool, 16> used{};
+            for (int i = 0; i <= len; ++i) {
+                uint8_t symbol = (uint8_t)reader.read_bits(4);
+                tree.symbols[(size_t)i] = symbol;
+                used[(size_t)symbol] = true;
+            }
+            for (int i = 0; i < 16 && len < 15; ++i) {
+                if (!used[(size_t)i]) {
+                    tree.symbols[(size_t)++len] = (uint8_t)i;
+                }
+            }
+        } else {
+            std::array<uint8_t, 16> current{};
+            std::array<uint8_t, 16> next{};
+            for (int i = 0; i < 16; ++i) {
+                current[(size_t)i] = (uint8_t)i;
+            }
+            int depth = (int)reader.read_bits(2);
+            for (int i = 0; i <= depth; ++i) {
+                int size = 1 << i;
+                for (int t = 0; t < 16; t += size << 1) {
+                    merge(reader, next, t, current, t, size);
+                }
+                current.swap(next);
+            }
+            tree.symbols = current;
+        }
+    }
+
+    static void merge(bit_reader_le& reader, std::array<uint8_t, 16>& destination, int destination_offset, const std::array<uint8_t, 16>& source, int source_offset, int size) {
+        int left_offset = source_offset;
+        int right_offset = source_offset + size;
+        int left = size;
+        int right = size;
+        int write_offset = destination_offset;
+
+        while (left > 0 && right > 0) {
+            if (!reader.read_bit()) {
+                destination[(size_t)write_offset++] = source[(size_t)left_offset++];
+                --left;
+            } else {
+                destination[(size_t)write_offset++] = source[(size_t)right_offset++];
+                --right;
+            }
+        }
+        while (left-- > 0) {
+            destination[(size_t)write_offset++] = source[(size_t)left_offset++];
+        }
+        while (right-- > 0) {
+            destination[(size_t)write_offset++] = source[(size_t)right_offset++];
+        }
+    }
+
+    void read_block_types(bit_reader_le& reader, bundle_t& bundle) {
+        int count = begin_bundle_read(reader, bundle);
+        if (count <= 0) {
+            return;
+        }
+
+        if (reader.read_bit()) {
+            int value = (int)reader.read_bits(4);
+            bundle.data.insert(bundle.data.end(), (size_t)count, value);
+        } else {
+            int last = 0;
+            for (int i = 0; i < count;) {
+                int value = decode_huff(reader, bundle.tree);
+                if (value < 12) {
+                    last = value;
+                    bundle.data.push_back(value);
+                    ++i;
+                } else {
+                    int run = kBlockTypeRleLengths[(size_t)(value - 12)];
+                    bundle.data.insert(bundle.data.end(), (size_t)run, last);
+                    i += run;
+                }
+            }
+        }
+    }
+
+    void read_colors(bit_reader_le& reader, bundle_t& bundle) {
+        int count = begin_bundle_read(reader, bundle);
+        if (count <= 0) {
+            return;
+        }
+        bool is_run = reader.read_bit();
+        int iterations = is_run ? 1 : count;
+        do {
+            int high_value = decode_huff(reader, color_high_trees_[(size_t)color_last_value_]);
+            int value = decode_huff(reader, bundle.tree) | (high_value << 4);
+            color_last_value_ = high_value;
+            value = value > 127 ? 256 - value : value + 128;
+            if (is_run) {
+                bundle.data.insert(bundle.data.end(), (size_t)count, value);
+            } else {
+                bundle.data.push_back(value);
+            }
+        } while (--iterations > 0);
+    }
+
+    void read_patterns(bit_reader_le& reader, bundle_t& bundle) {
+        int count = begin_bundle_read(reader, bundle);
+        for (int i = 0; i < count; ++i) {
+            bundle.data.push_back(decode_huff(reader, bundle.tree) | (decode_huff(reader, bundle.tree) << 4));
+        }
+    }
+
+    void read_motion_values(bit_reader_le& reader, bundle_t& bundle) {
+        int count = begin_bundle_read(reader, bundle);
+        if (count <= 0) {
+            return;
+        }
+        if (reader.read_bit()) {
+            int value = (int)reader.read_bits(4);
+            if (value != 0) {
+                int sign = reader.read_bit() ? -1 : 0;
+                value = (value ^ sign) - sign;
+            }
+            for (int i = 0; i < count; ++i) {
+                bundle.data.push_back((int8_t)value);
+            }
+        } else {
+            for (int i = 0; i < count; ++i) {
+                int value = decode_huff(reader, bundle.tree);
+                if (value != 0) {
+                    int sign = reader.read_bit() ? -1 : 0;
+                    value = (value ^ sign) - sign;
+                }
+                bundle.data.push_back((int8_t)value);
+            }
+        }
+    }
+
+    void read_dcs(bit_reader_le& reader, bundle_t& bundle, bool has_sign) {
+        int count = begin_bundle_read(reader, bundle);
+        if (count <= 0) {
+            return;
+        }
+        int value = (int)reader.read_bits(has_sign ? 10 : 11);
+        if (value != 0 && has_sign) {
+            int sign = reader.read_bit() ? -1 : 0;
+            value = (value ^ sign) - sign;
+        }
+        bundle.data.push_back(value);
+        int index = 1;
+        while (index < count) {
+            int len = std::min(count - index, 8);
+            int size = (int)reader.read_bits(4);
+            if (size != 0) {
+                for (int j = 0; j < len; ++j) {
+                    int delta = (int)reader.read_bits(size);
+                    if (delta != 0) {
+                        int sign = reader.read_bit() ? -1 : 0;
+                        delta = (delta ^ sign) - sign;
+                    }
+                    value += delta;
+                    bundle.data.push_back(value);
+                }
+            } else {
+                for (int j = 0; j < len; ++j) {
+                    bundle.data.push_back(value);
+                }
+            }
+            index += len;
+        }
+    }
+
+    void read_runs(bit_reader_le& reader, bundle_t& bundle) {
+        int count = begin_bundle_read(reader, bundle);
+        if (count <= 0) {
+            return;
+        }
+        if (reader.read_bit()) {
+            int value = (int)reader.read_bits(4);
+            bundle.data.insert(bundle.data.end(), (size_t)count, value);
+        } else {
+            for (int i = 0; i < count; ++i) {
+                bundle.data.push_back(decode_huff(reader, bundle.tree));
+            }
+        }
+    }
+
+    static int begin_bundle_read(bit_reader_le& reader, bundle_t& bundle) {
+        if (!bundle.active || (int)bundle.data.size() > bundle.read_index) {
+            return 0;
+        }
+        int count = (int)reader.read_bits(bundle.length_bits);
+        if (count == 0) {
+            bundle.active = false;
+            return 0;
+        }
+        return count;
+    }
+
+    int get_value(int source) {
+        bundle_t& bundle = bundles_[(size_t)source];
+        if (bundle.read_index >= (int)bundle.data.size()) {
+            throw std::runtime_error("BIK bundle underflow.");
+        }
+        return bundle.data[(size_t)bundle.read_index++];
+    }
+
+    static int decode_huff(bit_reader_le& reader, const tree_t& tree) {
+        int code = 0;
+        for (int len = 1; len <= kHuffmanMaxCodeLength; ++len) {
+            code |= (reader.read_bit() ? 1 : 0) << (len - 1);
+            for (int symbol_index = 0; symbol_index < kHuffmanSymbolCount; ++symbol_index) {
+                if (kHuffmanCodeLengths[tree.tree_index][symbol_index] == len && kHuffmanCodeBits[tree.tree_index][symbol_index] == code) {
+                    return tree.symbols[(size_t)symbol_index];
+                }
+            }
+        }
+        throw std::runtime_error("Invalid BIK Huffman code.");
+    }
+
+    void read_coefficients_or_residue(bit_reader_le& reader, int* block, int quant_start_index, bool inter) {
+        bool residue = quant_start_index < 0;
+        int list_start = 64;
+        int list_end = residue ? 68 : 70;
+        int masks_count = 0;
+        int coeff_count = 0;
+
+        coeff_list_[64] = 4;
+        coeff_list_[65] = 24;
+        coeff_list_[66] = 44;
+        mode_list_[64] = 0;
+        mode_list_[65] = 0;
+        mode_list_[66] = 0;
+        if (residue) {
+            masks_count = (int)reader.read_bits(7);
+            coeff_list_[67] = 0;
+            mode_list_[67] = 2;
+        } else {
+            coeff_list_[67] = 1;
+            coeff_list_[68] = 2;
+            coeff_list_[69] = 3;
+            mode_list_[67] = 3;
+            mode_list_[68] = 3;
+            mode_list_[69] = 3;
+        }
+
+        int bits = residue ? 1 << (int)reader.read_bits(3) : (int)reader.read_bits(4) - 1;
+        while (residue ? bits != 0 : bits >= 0) {
+            if (residue) {
+                for (int i = 0; i < coeff_count; ++i) {
+                    if (reader.read_bit()) {
+                        int current_index = coeff_index_[(size_t)i];
+                        int value = block[current_index];
+                        block[current_index] = value < 0 ? value - bits : value + bits;
+                        if (masks_count-- == 0) {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            int list_pos = list_start;
+            while (list_pos < list_end) {
+                int coefficient = coeff_list_[(size_t)list_pos];
+                int mode = mode_list_[(size_t)list_pos];
+                if ((mode | coefficient) == 0 || !reader.read_bit()) {
+                    ++list_pos;
+                    continue;
+                }
+
+                switch (mode) {
+                case 0:
+                case 2:
+                    if (mode == 0) {
+                        coeff_list_[(size_t)list_pos] = coefficient + 4;
+                        mode_list_[(size_t)list_pos] = 1;
+                    } else {
+                        coeff_list_[(size_t)list_pos] = 0;
+                        mode_list_[(size_t)list_pos++] = 0;
+                    }
+
+                    for (int i = coefficient; i < coefficient + 4; ++i) {
+                        if (reader.read_bit()) {
+                            coeff_list_[(size_t)--list_start] = i;
+                            mode_list_[(size_t)list_start] = 3;
+                        } else if (residue) {
+                            int offset = reference_data_.scan[(size_t)i];
+                            coeff_index_[(size_t)coeff_count++] = offset;
+                            block[offset] = reader.read_bit() ? -bits : bits;
+                            if (masks_count-- == 0) {
+                                return;
+                            }
+                        } else {
+                            int value = bits != 0
+                                ? apply_signed_magnitude(reader, (int)reader.read_bits(bits) | (1 << bits))
+                                : 1 - ((reader.read_bit() ? 1 : 0) << 1);
+                            int block_index = reference_data_.scan[(size_t)i];
+                            block[block_index] = value;
+                            coeff_index_[(size_t)coeff_count++] = i;
+                        }
+                    }
+                    break;
+                case 1:
+                    mode_list_[(size_t)list_pos] = 2;
+                    for (int i = coefficient + 4; i < coefficient + 16; i += 4) {
+                        coeff_list_[(size_t)list_end] = i;
+                        mode_list_[(size_t)list_end++] = 2;
+                    }
+                    break;
+                case 3:
+                    coeff_list_[(size_t)list_pos] = 0;
+                    mode_list_[(size_t)list_pos++] = 0;
+                    if (residue) {
+                        int offset = reference_data_.scan[(size_t)coefficient];
+                        coeff_index_[(size_t)coeff_count++] = offset;
+                        block[offset] = reader.read_bit() ? -bits : bits;
+                        if (masks_count-- == 0) {
+                            return;
+                        }
+                    } else {
+                        int value = bits != 0
+                            ? apply_signed_magnitude(reader, (int)reader.read_bits(bits) | (1 << bits))
+                            : 1 - ((reader.read_bit() ? 1 : 0) << 1);
+                        int block_index = reference_data_.scan[(size_t)coefficient];
+                        block[block_index] = value;
+                        coeff_index_[(size_t)coeff_count++] = coefficient;
+                    }
+                    break;
+                }
+            }
+
+            bits = residue ? bits >> 1 : bits - 1;
+        }
+
+        if (!residue) {
+            int quant_index = (int)reader.read_bits(4);
+            const auto& quant_table = inter ? reference_data_.inter_quant[(size_t)quant_index] : reference_data_.intra_quant[(size_t)quant_index];
+            block[0] = (block[0] * quant_table[0]) >> 11;
+            while (coeff_count-- > 0) {
+                int zig_zag_index = coeff_index_[(size_t)coeff_count];
+                int block_index = reference_data_.scan[(size_t)zig_zag_index];
+                block[block_index] = (block[block_index] * quant_table[(size_t)zig_zag_index]) >> 11;
+            }
+        }
+    }
+
+    static int apply_signed_magnitude(bit_reader_le& reader, int value) {
+        int sign = reader.read_bit() ? -1 : 0;
+        return (value ^ sign) - sign;
+    }
+
+    int width_ = 0;
+    int height_ = 0;
+    int num_pixels_ = 0;
+    int uv_size_ = 0;
+    std::vector<uint8_t> previous_frame_data_;
+    std::array<bundle_t, kParamCount> bundles_{};
+    std::array<tree_t, 16> color_high_trees_{};
+    std::array<int, 64> coeff_index_{};
+    std::array<int, 128> coeff_list_{};
+    std::array<uint8_t, 128> mode_list_{};
+    std::array<uint8_t, 64> temp_scaling_buffer_{};
+    std::array<int, 64> temp_dct_buffer_{};
+    bink_reference_data& reference_data_;
+
+    std::vector<uint8_t> plane_data_;
+    std::vector<uint8_t> previous_plane_data_;
+    int plane_data_offset_ = 0;
+    int plane_end_offset_ = 0;
+    int stride_ = 0;
+    int color_last_value_ = 0;
+    int current_plane_width_ = 0;
+    int current_plane_height_ = 0;
+};
+
+static uint8_t clamp_to_byte(int value) {
+    return (uint8_t)clamp_int(value, 0, 255);
+}
+
+static void convert_bik_yuv_to_rgba(const std::vector<uint8_t>& yuv, int width, int height, std::vector<uint32_t>& pixels) {
+    int chroma_width = (width + 1) >> 1;
+    int y_plane_size = width * height;
+    int uv_plane_size = chroma_width * ((height + 1) >> 1);
+    int u_offset = y_plane_size;
+    int v_offset = y_plane_size + uv_plane_size;
+    pixels.resize((size_t)width * (size_t)height);
+
+    for (int y = 0; y < height; ++y) {
+        int y_row = y * width;
+        int uv_row = (y >> 1) * chroma_width;
+        for (int x = 0; x < width; ++x) {
+            int y_sample = yuv[(size_t)(y_row + x)];
+            int uv_index = uv_row + (x >> 1);
+            int u_sample = yuv[(size_t)(u_offset + uv_index)];
+            int v_sample = yuv[(size_t)(v_offset + uv_index)];
+
+            int c = y_sample - 16;
+            if (c < 0) {
+                c = 0;
+            }
+            int d = u_sample - 128;
+            int e = v_sample - 128;
+            uint8_t red = clamp_to_byte((298 * c + 409 * e + 128) >> 8);
+            uint8_t green = clamp_to_byte((298 * c - 100 * d - 208 * e + 128) >> 8);
+            uint8_t blue = clamp_to_byte((298 * c + 516 * d + 128) >> 8);
+
+            pixels[(size_t)(y * width + x)] = 0xff000000u | ((uint32_t)red << 16) | ((uint32_t)green << 8) | blue;
+        }
+    }
+}
+
+static void floats_to_pcm_s16(const std::vector<float>& samples, std::vector<uint8_t>& pcm) {
+    pcm.resize(samples.size() * sizeof(int16_t));
+    auto* out = reinterpret_cast<int16_t*>(pcm.data());
+    for (size_t i = 0; i < samples.size(); ++i) {
+        float sample = std::max(-1.0f, std::min(1.0f, samples[i]));
+        out[i] = (int16_t)std::lrint(sample * 32767.0f);
+    }
+}
+
+} // namespace
+
+struct bink_movie {
+    struct decoded_frame {
+        std::vector<uint32_t> rgba;
+        std::vector<uint8_t> audio_pcm;
+        int frame_index = -1;
+        bool audio_prebuffered = false;
+    };
+
+    bink_file file;
+    bink_sequential_packet_reader reader;
+    bink_video_decoder video_decoder;
+    bink_rdft_audio_decoder audio_decoder;
+    std::vector<uint32_t> current_rgba;
+    std::vector<uint8_t> current_audio_pcm;
+    std::deque<decoded_frame> queued_frames;
+    int current_frame = -1;
+    int next_decode_frame = 0;
+    int profile_logs = 0;
+    bool current_audio_prebuffered = false;
+
+    explicit bink_movie(const std::string& path)
+        : file(bink_file::load(path))
+        , reader(file)
+        , video_decoder(file)
+        , audio_decoder(file.audio_track()) {
+        current_rgba.reserve((size_t)file.width() * (size_t)file.height());
+        current_audio_pcm.reserve(file.audio_track().max_decoded_size);
+    }
+
+    bool decode_frame_data(int frame_index, decoded_frame& decoded) {
+        Uint32 packet_begin = SDL_GetTicks();
+        frame_packet packet = reader.read_frame_packet(frame_index);
+        Uint32 packet_end = SDL_GetTicks();
+        std::vector<uint8_t> yuv = video_decoder.decode(packet);
+        Uint32 video_end = SDL_GetTicks();
+        convert_bik_yuv_to_rgba(yuv, file.width(), file.height(), decoded.rgba);
+        Uint32 rgba_end = SDL_GetTicks();
+        decoded.audio_pcm.clear();
+        if (!packet.audio_packets.empty() && !packet.audio_packets[0].payload.empty()) {
+            std::vector<float> decoded_samples = audio_decoder.decode_packet(packet.audio_packets[0].payload);
+            floats_to_pcm_s16(decoded_samples, decoded.audio_pcm);
+        }
+        Uint32 audio_end = SDL_GetTicks();
+
+        if (profile_logs < 20) {
+            logs::info(
+                "BIK frame timings: frame=%d read_ms=%u video_ms=%u rgba_ms=%u audio_ms=%u audio_bytes=%d",
+                frame_index,
+                (unsigned)(packet_end - packet_begin),
+                (unsigned)(video_end - packet_end),
+                (unsigned)(rgba_end - video_end),
+                (unsigned)(audio_end - rgba_end),
+                (int)decoded.audio_pcm.size());
+            ++profile_logs;
+        }
+        decoded.frame_index = frame_index;
+        return true;
+    }
+
+    bool decode_frame(int frame_index) {
+        decoded_frame decoded;
+        if (!decode_frame_data(frame_index, decoded)) {
+            return false;
+        }
+
+        current_rgba = std::move(decoded.rgba);
+        current_audio_pcm = std::move(decoded.audio_pcm);
+        current_frame = frame_index;
+        current_audio_prebuffered = decoded.audio_prebuffered;
+        return true;
+    }
+
+    bool prebuffer_frames(int frame_count, bink_audio_sink sink, void* userdata) {
+        frame_count = std::max(frame_count, 0);
+        while ((int)queued_frames.size() < frame_count && next_decode_frame < (int)file.frame_index().size()) {
+            decoded_frame decoded;
+            if (!decode_frame_data(next_decode_frame, decoded)) {
+                return false;
+            }
+
+            if (sink && !decoded.audio_pcm.empty()) {
+                sink(userdata, decoded.audio_pcm.data(), (int)decoded.audio_pcm.size());
+                decoded.audio_prebuffered = true;
+            }
+
+            queued_frames.push_back(std::move(decoded));
+            ++next_decode_frame;
+        }
+
+        return true;
+    }
+
+    bool advance_frame() {
+        if (!queued_frames.empty()) {
+            decoded_frame decoded = std::move(queued_frames.front());
+            queued_frames.pop_front();
+            current_rgba = std::move(decoded.rgba);
+            current_audio_pcm = std::move(decoded.audio_pcm);
+            current_frame = decoded.frame_index;
+            current_audio_prebuffered = decoded.audio_prebuffered;
+            return true;
+        }
+
+        if (next_decode_frame >= (int)file.frame_index().size()) {
+            return false;
+        }
+
+        bool ok = decode_frame(next_decode_frame);
+        if (ok) {
+            ++next_decode_frame;
+        }
+        return ok;
+    }
+};
+
+bink bink_open(const char* filename) {
+    if (!filename || !*filename) {
+        return nullptr;
+    }
+
+    try {
+        vfs::path fs_file = vfs::path(filename).resolve();
+        if (fs_file.empty()) {
+            return nullptr;
+        }
+        return new bink_movie(fs_file.c_str());
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void bink_close(bink movie) {
+    delete movie;
+}
+
+int bink_get_width(bink movie) {
+    return movie ? movie->file.width() : 0;
+}
+
+int bink_get_height(bink movie) {
+    return movie ? movie->file.height() : 0;
+}
+
+int bink_get_micros_per_frame(bink movie) {
+    return movie ? movie->file.micros_per_frame() : 0;
+}
+
+int bink_has_audio(bink movie) {
+    return movie ? 1 : 0;
+}
+
+int bink_get_audio_channels(bink movie) {
+    return movie ? (movie->file.audio_track().is_stereo ? 2 : 1) : 0;
+}
+
+int bink_get_audio_sample_rate(bink movie) {
+    return movie ? movie->file.audio_track().sample_rate : 0;
+}
+
+int bink_get_audio_bitdepth(bink movie) {
+    return movie ? 16 : 0;
+}
+
+int bink_first_frame(bink movie) {
+    if (!movie) {
+        return 0;
+    }
+    try {
+        movie->queued_frames.clear();
+        movie->next_decode_frame = 1;
+        movie->current_audio_prebuffered = false;
+        return movie->decode_frame(0) ? 1 : 0;
+    } catch (...) {
+        return 0;
+    }
+}
+
+int bink_next_frame(bink movie) {
+    if (!movie) {
+        return 0;
+    }
+    if (movie->current_frame + 1 >= (int)movie->file.frame_index().size()) {
+        return 0;
+    }
+    try {
+        return movie->advance_frame() ? 1 : 0;
+    } catch (...) {
+        return 0;
+    }
+}
+
+int bink_prebuffer_frames(bink movie, int frame_count, bink_audio_sink sink, void* userdata) {
+    if (!movie) {
+        return 0;
+    }
+    try {
+        return movie->prebuffer_frames(frame_count, sink, userdata) ? 1 : 0;
+    } catch (...) {
+        return 0;
+    }
+}
+
+int bink_current_audio_is_prebuffered(bink movie) {
+    return movie && movie->current_audio_prebuffered ? 1 : 0;
+}
+
+const uint32_t* bink_get_frame_rgba(bink movie) {
+    return movie && !movie->current_rgba.empty() ? movie->current_rgba.data() : nullptr;
+}
+
+const void* bink_get_frame_audio(bink movie) {
+    return movie && !movie->current_audio_pcm.empty() ? movie->current_audio_pcm.data() : nullptr;
+}
+
+int bink_get_frame_audio_size(bink movie) {
+    return movie ? (int)movie->current_audio_pcm.size() : 0;
+}

--- a/src/io/gamefiles/bink.h
+++ b/src/io/gamefiles/bink.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdint.h>
+
+struct bink_movie;
+using bink = bink_movie*;
+using bink_audio_sink = void (*)(void* userdata, const void* data, int len);
+
+bink bink_open(const char* filename);
+void bink_close(bink movie);
+
+int bink_get_width(bink movie);
+int bink_get_height(bink movie);
+int bink_get_micros_per_frame(bink movie);
+
+int bink_has_audio(bink movie);
+int bink_get_audio_channels(bink movie);
+int bink_get_audio_sample_rate(bink movie);
+int bink_get_audio_bitdepth(bink movie);
+
+int bink_first_frame(bink movie);
+int bink_next_frame(bink movie);
+int bink_prebuffer_frames(bink movie, int frame_count, bink_audio_sink sink, void* userdata);
+int bink_current_audio_is_prebuffered(bink movie);
+
+const uint32_t* bink_get_frame_rgba(bink movie);
+const void* bink_get_frame_audio(bink movie);
+int bink_get_frame_audio_size(bink movie);

--- a/src/js/js_game.cpp
+++ b/src/js/js_game.cpp
@@ -33,6 +33,7 @@
 #include "io/gamestate/boilerplate.h"
 #include "io/manager.h"
 #include "window/main_menu.h"
+#include "window/intro_video.h"
 #include "window/plain_message_dialog.h"
 #include "core/profiler.h"
 #include "core/system_time.h"

--- a/src/platform/renderer.cpp
+++ b/src/platform/renderer.cpp
@@ -96,6 +96,7 @@ struct renderer_data_t {
     struct {
         SDL_Texture* texture;
         color* buffer;
+        atlas_data_t atlas;
         image_t img;
     } custom_textures[CUSTOM_IMAGE_MAX];
 
@@ -297,8 +298,13 @@ void graphics_renderer_interface::create_custom_texture(int type, int width, int
 #endif
 
     data.custom_textures[type].texture = SDL_CreateTexture(data.renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, width, height);
+    data.custom_textures[type].atlas.texture = data.custom_textures[type].texture;
+    data.custom_textures[type].atlas.width = width;
+    data.custom_textures[type].atlas.height = height;
     data.custom_textures[type].img.width = width;
     data.custom_textures[type].img.height = height;
+    data.custom_textures[type].img.atlas.offset = {0, 0};
+    data.custom_textures[type].img.atlas.p_atlas = &data.custom_textures[type].atlas;
     //    data.custom_textures[type].img.atlas.id = (ATLAS_CUSTOM << IMAGE_ATLAS_BIT_OFFSET) | type;
     SDL_SetTextureBlendMode(data.custom_textures[type].texture, SDL_BLENDMODE_BLEND);
 }
@@ -553,10 +559,15 @@ static void create_blend_texture(int type) {
     SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_MOD);
 
     data.custom_textures[type].texture = texture;
+    data.custom_textures[type].atlas.texture = data.custom_textures[type].texture;
+    data.custom_textures[type].atlas.width = 58;
+    data.custom_textures[type].atlas.height = 30;
     memset(&data.custom_textures[type].img, 0, sizeof(data.custom_textures[type].img));
     data.custom_textures[type].img.type = IMAGE_TYPE_ISOMETRIC;
     data.custom_textures[type].img.width = 58;
     data.custom_textures[type].img.height = 30;
+    data.custom_textures[type].img.atlas.offset = {0, 0};
+    data.custom_textures[type].img.atlas.p_atlas = &data.custom_textures[type].atlas;
     //    data.custom_textures[type].img.atlas.bitflags = (ATLAS_CUSTOM << IMAGE_ATLAS_BIT_OFFSET) | type;
 }
 

--- a/src/sound/sound.cpp
+++ b/src/sound/sound.cpp
@@ -18,6 +18,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include <vector>
 #include <map>
 
@@ -65,6 +66,9 @@ struct music_player_t {
     int buffer_size;
     int cur_read;
     int cur_write;
+    uint64_t custom_stream_bytes_written = 0;
+    uint64_t custom_stream_bytes_read = 0;
+    uint32_t custom_stream_bytes_per_second = 0;
     Mix_Music* music;
     vfs::reader current_music_data;
 
@@ -77,6 +81,7 @@ struct music_format {
 };
 
 sound_manager_t g_sound;
+static int s_custom_music_underrun_logs = 0;
 
 static int percentage_to_volume(int percentage) {
     return percentage * SDL_MIX_MAXVOLUME / 100;
@@ -572,6 +577,10 @@ void sound_manager_t::free_custom_audio_stream() {
 
 bool sound_manager_t::create_custom_audio_stream(uint16_t src_format, uint8_t src_channels, int src_rate, uint16_t dst_format, uint8_t dst_channels, int dst_rate) {
     free_custom_audio_stream();
+    _music_player->custom_stream_bytes_written = 0;
+    _music_player->custom_stream_bytes_read = 0;
+    _music_player->custom_stream_bytes_per_second = dst_rate * dst_channels * (SDL_AUDIO_BITSIZE(dst_format) / 8);
+    s_custom_music_underrun_logs = 0;
 
 #ifdef USE_SDL_AUDIOSTREAM
     if (_music_player->use_audiostream) {
@@ -613,7 +622,15 @@ bool sound_manager_t::put_custom_audio_stream(uint8_t* audio_data, int len) {
 
 #ifdef USE_SDL_AUDIOSTREAM
     if (_music_player->use_audiostream) {
-        return SDL_AudioStreamPut(_music_player->stream, audio_data, len) == 0;
+        int available_before = SDL_AudioStreamAvailable(_music_player->stream);
+        if (SDL_AudioStreamPut(_music_player->stream, audio_data, len) == 0) {
+            int available_after = SDL_AudioStreamAvailable(_music_player->stream);
+            if (available_after > available_before) {
+                _music_player->custom_stream_bytes_written += (uint64_t)(available_after - available_before);
+            }
+            return true;
+        }
+        return false;
     }
 #endif
 
@@ -642,6 +659,7 @@ bool sound_manager_t::put_custom_audio_stream(uint8_t* audio_data, int len) {
     free(_music_player->cvt.buf);
     _music_player->cvt.buf = 0;
     _music_player->cvt.len = 0;
+    _music_player->custom_stream_bytes_written += converted_len;
 
     return true;
 }
@@ -653,7 +671,11 @@ int sound_manager_t::get_custom_audio_stream(Uint8* dst, int len) {
 
 #ifdef USE_SDL_AUDIOSTREAM
     if (_music_player->use_audiostream) {
-        return SDL_AudioStreamGet(_music_player->stream, dst, len);
+        int bytes_copied = SDL_AudioStreamGet(_music_player->stream, dst, len);
+        if (bytes_copied > 0) {
+            _music_player->custom_stream_bytes_read += bytes_copied;
+        }
+        return bytes_copied;
     }
 #endif
 
@@ -677,14 +699,42 @@ int sound_manager_t::get_custom_audio_stream(Uint8* dst, int len) {
         }
     }
     _music_player->cur_read = (_music_player->cur_read + bytes_copied) % _music_player->buffer_size;
+    _music_player->custom_stream_bytes_read += bytes_copied;
 
     return bytes_copied;
+}
+
+uint64_t sound_manager_t::custom_music_playback_micros() const {
+    if (!_music_player || !_music_player->custom_stream_bytes_per_second) {
+        return 0;
+    }
+    return (_music_player->custom_stream_bytes_read * 1000000ull) / _music_player->custom_stream_bytes_per_second;
+}
+
+uint64_t sound_manager_t::custom_music_buffered_micros() const {
+    if (!_music_player || !_music_player->custom_stream_bytes_per_second) {
+        return 0;
+    }
+
+    uint64_t buffered = 0;
+    if (_music_player->custom_stream_bytes_written >= _music_player->custom_stream_bytes_read) {
+        buffered = _music_player->custom_stream_bytes_written - _music_player->custom_stream_bytes_read;
+    }
+    return (buffered * 1000000ull) / _music_player->custom_stream_bytes_per_second;
 }
 
 void sound_manager_t::custom_music_callback(void* dummy, Uint8* stream, int len) {
     int bytes_copied = g_sound.get_custom_audio_stream(stream, len);
 
     if (bytes_copied < len) {
+        if (s_custom_music_underrun_logs < 20) {
+            logs::warn("BIK audio underrun: requested=%d copied=%d buffered_us=%llu played_us=%llu",
+                len,
+                bytes_copied,
+                (unsigned long long)g_sound.custom_music_buffered_micros(),
+                (unsigned long long)g_sound.custom_music_playback_micros());
+            ++s_custom_music_underrun_logs;
+        }
         // end of stream, write silence
         memset(&stream[bytes_copied], 0, len - bytes_copied);
     }

--- a/src/sound/sound.h
+++ b/src/sound/sound.h
@@ -7,6 +7,7 @@
 #include "sound/channel.h"
 #include "sound/effect.h"
 #include <array>
+#include <stdint.h>
 
 struct music_player_t;
 
@@ -40,6 +41,8 @@ public:
     void use_default_music_player();
     void use_custom_music_player(int bitdepth, int num_channels, int rate, void *audio_data, int len);
     void write_custom_music_data(void *audio_data, int len);
+    uint64_t custom_music_playback_micros() const;
+    uint64_t custom_music_buffered_micros() const;
     bool play_music(pcstr filename, int volume_pct);
     void stop_music();
     bool is_audio_stream_active();

--- a/src/window/intro_video.cpp
+++ b/src/window/intro_video.cpp
@@ -6,32 +6,50 @@
 #include "graphics/window.h"
 #include "platform/renderer.h"
 #include "sound/sound.h"
+#include "window/autoconfig_window.h"
 
 static struct {
     int width;
     int height;
     int current_video;
+    int video_started;
 } data;
 
 static const char* PH_INTRO_VIDEOS[] = {"BINKS/high/Intro_big.bik"};
 
 static int start_next_video(void) {
-    int videos_num = 0;
-    const char** videos;
-    videos_num = 1;
-    videos = PH_INTRO_VIDEOS;
-    while (data.current_video < 3) {
-        if (videos && video_start(PH_INTRO_VIDEOS[data.current_video++])) {
+    const int videos_num = (int)(sizeof(PH_INTRO_VIDEOS) / sizeof(PH_INTRO_VIDEOS[0]));
+    while (data.current_video < videos_num) {
+        if (video_start(PH_INTRO_VIDEOS[data.current_video++])) {
             video_size(&data.width, &data.height);
             video_init();
+            data.video_started = 1;
             return 1;
         }
     }
     return 0;
 }
+
 static int init(void) {
+    data.width = 0;
+    data.height = 0;
     data.current_video = 0;
-    return start_next_video();
+    data.video_started = 0;
+    return 1;
+}
+
+static int ensure_video_started(void) {
+    if (data.video_started) {
+        return 1;
+    }
+
+    if (start_next_video()) {
+        return 1;
+    }
+
+    g_sound.play_intro();
+    autoconfig_window::show("window_logo");
+    return 0;
 }
 
 static void draw_background(int) {
@@ -39,16 +57,23 @@ static void draw_background(int) {
 }
 
 static void draw_foreground(int) {
-    video_draw((screen_width() - data.width) / 2, (screen_height() - data.height) / 2);
+    if (ensure_video_started()) {
+        video_draw_fullscreen();
+    }
 }
 
 static void handle_input(const mouse* m, const hotkeys* h) {
+    if (!data.video_started && !ensure_video_started()) {
+        return;
+    }
+
     if (m->left.went_up || m->right.went_up || video_is_finished() || h->enter_pressed) {
         g_sound.music_stop();
         video_stop();
+        data.video_started = 0;
         if (!start_next_video()) {
             g_sound.play_intro();
-            window_go_back();
+            autoconfig_window::show("window_logo");
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds BIK video playback support to Akhenaten, including intro playback, SDL-based audio streaming, and renderer integration for custom video textures.

## Included
- add a new bink.cpp / bink.h decoder backend
- integrate BIK alongside the existing video playback path
- stream decoded audio through the existing SDL custom music path
- initialize renderer custom textures correctly for video playback
- wire intro video playback into the startup flow

## Notes
- need to be enabled in the settings as "Play intro videos"
- tested in a local Windows Debug build
- branch source: mandel99/feature/bik-player
- commit: 92518f1b7

## Follow-up
There may still be room to further trim the patchset or polish resize/intro behavior, but this PR contains the working BIK player integration.