### PR TITLE
Fix inverted flax-source check in weaver placement warning

### DIFF
--- a/src/building/building_weaver.cpp
+++ b/src/building/building_weaver.cpp
@@ -12,7 +12,7 @@
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(building_weaver);
 
 void building_weaver::on_place_checks() {
-    if (g_city.buildings.count_industry_active(RESOURCE_FLAX) <= 0) {
+    if (g_city.buildings.count_industry_active(RESOURCE_FLAX) > 0) {
         return;
     }
 


### PR DESCRIPTION
@
## Problem

`building_weaver::on_place_checks()` uses an inverted early-return condition compared to its sibling workshops:

```cpp
if (g_city.buildings.count_industry_active(RESOURCE_FLAX) <= 0) {  // wrong
    return;
}
```

`building_jewels_workshop` and `building_brewery` both skip the "needs raw material" warning when an active source industry **exists** (`> 0`). Weaver had the inverse, so the *"needs flax / build a flax farm / set up a trade route"* placement warning was:

- **suppressed** exactly when the player has **no** active flax source at all, and
- **shown** when an active flax industry already exists (and storage is momentarily empty).

i.e. the warning fired in the opposite situation from the one it is meant for.

## Fix

Change the active-industry early-return to `> 0`, matching `building_jewels_workshop::on_place_checks()` and `building_brewery::on_place_checks()`.

```diff
-    if (g_city.buildings.count_industry_active(RESOURCE_FLAX) <= 0) {
+    if (g_city.buildings.count_industry_active(RESOURCE_FLAX) > 0) {
```

One-line change, no logic added/removed beyond correcting the comparison; behaviour now consistent with the other two workshops.
@