### PR TITLE
Chain workshop on_place_checks to building_impl base

### DIFF
--- a/src/building/building_brewery.cpp
+++ b/src/building/building_brewery.cpp
@@ -50,6 +50,8 @@ void building_brewery::update_preproduction() {
 }
 
 void building_brewery::on_place_checks() {
+    building_impl::on_place_checks();
+
     construction_warnings warnings("#needs_barley");
 
     // Check for barley

--- a/src/building/building_jewels_workshop.cpp
+++ b/src/building/building_jewels_workshop.cpp
@@ -26,6 +26,8 @@ bool building_jewels_workshop::can_play_animation() const {
 }
 
 void building_jewels_workshop::on_place_checks() {
+    building_impl::on_place_checks();
+
     if (g_city.buildings.count_industry_active(RESOURCE_GEMS) > 0) {
         return;
     }

--- a/src/building/building_weaponsmith.cpp
+++ b/src/building/building_weaponsmith.cpp
@@ -22,6 +22,8 @@ declare_console_command(addweapons, game_cheat_add_resource<RESOURCE_WEAPONS>);
 declare_console_command(addcopper, game_cheat_add_resource<RESOURCE_COPPER>);
 
 void building_weaponsmith::on_place_checks() {
+    building_impl::on_place_checks();
+
     if (g_city.buildings.count_industry_active(RESOURCE_COPPER) > 0) {
         return;
     }

--- a/src/building/building_workshop_papyrus.cpp
+++ b/src/building/building_workshop_papyrus.cpp
@@ -43,6 +43,8 @@ bool building_papyrus_maker::draw_ornaments_and_animations_height(painter &ctx, 
 }
 
 void building_papyrus_maker::on_place_checks() {
+    building_impl::on_place_checks();
+
     if (g_city.buildings.count_industry_active(RESOURCE_REEDS) > 0) {
         return;
     }


### PR DESCRIPTION
@
## Problem

`building_brewery`, `building_jewels_workshop`, `building_weaponsmith` and `building_papyrus_maker` return early from `on_place_checks()` without ever calling `building_impl::on_place_checks()`. The canonical analogues — `fishing_wharf`, `gatehouse`, `tower` — all call the base first.

Skipping the base means these workshops, when placed:
- never show the standard `#needs_road_access` / `#city_needs_more_workers` placement warnings;
- never dispatch the `es()` JS `on_place_checks` event.

## Fix

Add `building_impl::on_place_checks();` as the first statement of each workshop override, matching the `building_fishing_wharf` pattern. The existing resource-specific warning logic is unchanged.

## Notes

- `building_weaver` has the same defect but is intentionally **not** touched here: its `on_place_checks()` is being edited on the open branch `fix/weaver-place-check-inverted`. It should get the same base chain once that branch merges, to avoid a conflict.
- No game-logic, save-format, or simulation changes — purely additive placement warnings + JS event dispatch.

## Verification

Built `akhenaten` with `cmake --build --preset win-msvc-relwithdebinfo-vs2022` — compiles cleanly.
@