### PR TITLE
Declare labor_category for marble quarry config block

### DIFF
--- a/src/scripts/building/config.js
+++ b/src/scripts/building/config.js
@@ -991,6 +991,7 @@ building_marble_quarry {
     work { pos : [54, 15], pack:PACK_SPR_AMBIENT, id:49, max_frames: 16 }
   }
   meta { help_id:95, text_id:118 }
+  labor_category : LABOR_CATEGORY_INDUSTRY_COMMERCE,
   cost[ 15, 30, 50, 80, 150 ]
   desirability { value[-6], step[1], step_size[1], range[6] }
   laborers[12]


### PR DESCRIPTION
@
## Change

`building_marble_quarry` was the only quarry config block in `src/scripts/building/config.js` without a `labor_category` line. Every sibling quarry — sandstone, stone, granite, limestone — declares `LABOR_CATEGORY_INDUSTRY_COMMERCE`. This adds the missing line for config consistency.

```diff
   meta { help_id:95, text_id:118 }
+  labor_category : LABOR_CATEGORY_INDUSTRY_COMMERCE,
   cost[ 15, 30, 50, 80, 150 ]
```

## Scope / honesty note

An independent review pass flagged that `marble_quarry` currently has **no `BUILDING_MARBLE_QUARRY` engine type, C++ class, or `REPLICATE_STATIC_PARAMS_FROM_CONFIG` registration** — so this `labor_category` value is **not yet consumed at runtime**. This is therefore **declarative config consistency, not a behavioural fix**: it makes the block correct for when/if marble quarry is wired into the engine, and removes the lone inconsistency among quarry configs.

- No game-logic, pathfinding, or simulation-formula change.
- No save/load buffer or serialized-format change.
- Value matches every other extractor (clay pit, mines, quarries).

## Verification

Built `akhenaten` with `cmake --build --preset win-msvc-relwithdebinfo-vs2022` — `config.js.cpp` regenerates and compiles cleanly.

## Follow-up (separate)

Whether `marble_quarry` should be promoted to a real engine-side building (Cleopatra marble economy) is a larger question tracked separately, out of scope here.
@