### PR TITLE
Fix unconditional assert(false) crash in figure_slave animation

### DIFF
--- a/src/figuretype/figure_slave.cpp
+++ b/src/figuretype/figure_slave.cpp
@@ -39,24 +39,7 @@ void figure_slave::figure_action() {
 }
 
 void figure_slave::update_animation() {
-    int dir;
-    if (base.action_state == ACTION_150_SLAVE_ATTACK || base.direction == DIR_FIGURE_ATTACK)
-        dir = base.attack_direction;
-    else if (base.direction < 8)
-        dir = base.direction;
-    else {
-        dir = base.previous_tile_direction;
-    }
-    dir = base.figure_image_normalize_direction(dir);
-
-    assert(false);
-    if (base.action_state == ACTION_150_SLAVE_ATTACK || base.direction == DIR_FIGURE_ATTACK) {
-        //sprite_image_id = image_id_from_group(GROUP_FIGURE_MUSICIAN) + dir + 104 + 8 * (anim.frame / 2);
-    } else if (base.action_state == FIGURE_ACTION_149_CORPSE) {
-        //sprite_image_id = image_id_from_group(GROUP_FIGURE_MUSICIAN) + 96 + figure_image_corpse_offset();
-    } else {
-        //sprite_image_id = image_id_from_group(GROUP_FIGURE_MUSICIAN) + dir + 8 * anim.frame;
-    }
+    image_set_animation(animkeys().walk);
 }
 
 void figure_slave::before_poof() {


### PR DESCRIPTION
@
## Bug

`figure_slave::update_animation()` ran an **unconditional `assert(false)`** with all sprite-setting code commented out. Every time a slave figure's animation updated, the game aborted in debug builds and set no animation in release — the function did manual direction math and then asserted before doing anything useful.

```cpp
// before
void figure_slave::update_animation() {
    int dir; ... // direction math
    assert(false);
    if (...) { /* sprite_image_id = ... (commented out) */ }
    else if (...) { /* commented out */ }
    else { /* commented out */ }
}
```

## Fix

Replace the dead body with the established idiom used by `figure_noble` / `figure_protestor`:

```cpp
void figure_slave::update_animation() {
    image_set_animation(animkeys().walk);
}
```

- The slave config (`src/scripts/figures.js`, `figure_slave`) defines only a `walk` animation (plus `cart`) — no `death` or `attack` key — so `walk` is the only valid choice.
- Slaves call `poof()` and never enter `FIGURE_ACTION_149_CORPSE`, so omitting the death branch is correct.
- `image_set_animation` → `main_image_update()` applies the figure direction internally, so the removed manual `dir` math was redundant.

## Scope
- No save/load buffer or serialized-format change.
- No game-logic, formula, or pathfinding change. One function, +1 / −18.

## Verification
- Built `akhenaten` with `cmake --build --preset win-msvc-relwithdebinfo-vs2022` — compiles cleanly.
- Independent review pass: verdict approve (confirmed old body aborted, replacement matches sibling figures, config has only a walk key, no out-of-scope changes).
@