### PR TITLE
Fix scenario editor predator herd point ignoring the placed tile

### DIFF
--- a/src/scenario/editor_map.cpp
+++ b/src/scenario/editor_map.cpp
@@ -46,7 +46,7 @@ tile2i scenario_editor_predator_herd_point(int id) {
 }
 
 void scenario_editor_set_predator_herd_point(int id, int x, int y) {
-    g_scenario.herd_points_animals[id] = tile2i::invalid;
+    g_scenario.herd_points_animals[id] = tile2i{ x, y };
     g_scenario.is_saved = 0;
 }
 


### PR DESCRIPTION
@
## Bug

`scenario_editor_set_predator_herd_point(int id, int x, int y)` in `src/scenario/editor_map.cpp` took the placed `x, y` coordinates but stored `tile2i::invalid`, discarding them:

```cpp
// before
void scenario_editor_set_predator_herd_point(int id, int x, int y) {
    g_scenario.herd_points_animals[id] = tile2i::invalid;   // x, y ignored
    g_scenario.is_saved = 0;
}
```

As a result, predator herd spawn points placed in the scenario editor were **never recorded** — `scenario_map_foreach_herd_point` / spawn paths guard on `tile.valid()`, so editor-placed herd points always read back invalid and no predator herd would ever spawn from them.

## Fix

Store the passed tile, mirroring the working `scenario_editor_set_fishing_point` (and `scenario_editor_set_river_exit_point`) analogues in the same file:

```cpp
void scenario_editor_set_predator_herd_point(int id, int x, int y) {
    g_scenario.herd_points_animals[id] = tile2i{ x, y };
    g_scenario.is_saved = 0;
}
```

## Scope
- `herd_points_animals[]` is `tile2i[MAX_PREDATOR_HERD_POINTS]` (already exists, already serialized as UINT16 x/y pairs) — **no save/load format change**.
- Called identically to the fishing-point setter via `place_flag_with_id`, so no new bounds risk.
- No game-logic/pathfinding change beyond recording the editor-placed point; `clear`/init paths still set invalid correctly.

## Verification
- Built `akhenaten` with `cmake --build --preset win-msvc-relwithdebinfo-vs2022` — compiles cleanly.
- Independent review pass: verdict approve — confirmed the old line discarded x/y, the replacement matches sibling setters, no format/logic change, herd points read back via valid() guards.
@