### PR TITLE
Store editor entry/exit/river-entry/earthquake points instead of discarding them

### DIFF
--- a/src/scenario/editor_map.cpp
+++ b/src/scenario/editor_map.cpp
@@ -6,14 +6,12 @@
 // TODO !!!!!!
 
 void scenario_editor_set_entry_point(int x, int y) {
-    //    g_scenario.entry_point.x() = x;
-    //    g_scenario.entry_point.y() = y;
+    g_scenario.entry_point = tile2i{ x, y };
     g_scenario.is_saved = 0;
 }
 
 void scenario_editor_set_exit_point(int x, int y) {
-    //    g_scenario.exit_point.x() = x;
-    //    g_scenario.exit_point.y() = y;
+    g_scenario.exit_point = tile2i{ x, y };
     g_scenario.is_saved = 0;
 }
 
@@ -22,8 +20,7 @@ static void update_river() {
 }
 
 void scenario_editor_set_river_entry_point(int x, int y) {
-    //    g_scenario.river_entry_point.x() = x;
-    //    g_scenario.river_entry_point.y() = y;
+    g_scenario.river_entry_point = tile2i{ x, y };
     g_scenario.is_saved = 0;
     update_river();
 }
@@ -106,8 +103,7 @@ tile2i scenario_editor_earthquake_point(void) {
 }
 
 void scenario_editor_set_earthquake_point(int x, int y) {
-    //    g_scenario.earthquake_point.x = x;
-    //    g_scenario.earthquake_point.y = y;
+    g_scenario.earthquake_point = tile2i{ x, y };
     g_scenario.is_saved = 0;
 }
 


### PR DESCRIPTION
@
## Summary

Four scenario-editor point setters in `src/scenario/editor_map.cpp` had their bodies commented out, so placing those points in the editor silently discarded the coordinates (only `is_saved` was cleared):

- `scenario_editor_set_entry_point`
- `scenario_editor_set_exit_point`
- `scenario_editor_set_river_entry_point`
- `scenario_editor_set_earthquake_point`

Each now stores the passed coordinates into `g_scenario` via `tile2i{ x, y }`, mirroring the already-working `scenario_editor_set_river_exit_point`. `update_river()` is still called for the river-entry case as before.

## Verification

- `1 file changed, +4 / -8` — restores the assignments; no save-format change (these `g_scenario` fields already exist).
- Build OK with `win-msvc-relwithdebinfo-vs2022`.

## Follow-up

Sibling invasion-point setters (`scenario_editor_set_land_invasion_point` / `_count_invasion_points` / `_clear_invasion_points`) are still commented out and remain TODO.

_Automated change by auto_review.py (run #27)._
@