### PR TITLE
Fix sea invasion points never reset on scenario load

### DIFF
--- a/src/scenario/scenario.cpp
+++ b/src/scenario/scenario.cpp
@@ -232,7 +232,7 @@ io_buffer *iob_scenario_info = new io_buffer([] (io_buffer *iob, size_t version)
 
     if (iob->is_read_access()) {
         auto& lands = g_scenario.invasion_points_land;
-        auto& sea = g_scenario.invasion_points_land;
+        auto& sea = g_scenario.invasion_points_sea;
         std::fill(lands.begin(), lands.end(), tile2i::invalid);
         std::fill(sea.begin(), sea.end(), tile2i::invalid);
     }


### PR DESCRIPTION
@
## Summary

`iob_scenario_info` read path in `src/scenario/scenario.cpp` had a copy-paste bug: the `sea` reference aliased `invasion_points_land` instead of `invasion_points_sea`:

```cpp
auto& lands = g_scenario.invasion_points_land;
auto& sea   = g_scenario.invasion_points_land;   // <-- was land, should be sea
std::fill(lands.begin(), lands.end(), tile2i::invalid);
std::fill(sea.begin(),   sea.end(),   tile2i::invalid);
```

As a result, on scenario load the `invasion_points_land` array was filled with `tile2i::invalid` twice and `invasion_points_sea` was never reset — stale sea invasion points could carry over from a previously loaded scenario. The fix points `sea` at `invasion_points_sea`.

## Verification

- `1 file changed, 1 insertion(+), 1 deletion(-)` — single-character type fix; no save-format change.
- Note: the automated build for this branch timed out (>15 min, scenario.cpp triggers a wide rebuild), so CI/local build still needs to confirm. The change itself is a trivial reference correction.

_Found by auto_review.py (run #29)._
@