### PR TITLE
fix: chain building_impl base call in mortuary on_place_checks

### DIFF
--- a/src/building/building_mortuary.cpp
+++ b/src/building/building_mortuary.cpp
@@ -24,6 +24,8 @@
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(building_mortuary);
 
 void building_mortuary::on_place_checks() {
+    building_impl::on_place_checks();
+
     if (g_city.buildings.count_industry_active(RESOURCE_LINEN) > 0) {
         return;
     }

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
`building_mortuary::on_place_checks()` returned early on its linen-industry check without ever calling the base `building_impl::on_place_checks()`. As a result it silently skipped the standard `#needs_road_access` / `#city_needs_more_workers` placement warnings and the JS `on_place_checks` event dispatch that every other building gets through the base implementation.

Fix: call `building_impl::on_place_checks()` as the first statement, matching the established pattern used by the other building types.

No behaviour change beyond restoring the missing base warnings/event; builds cleanly (`win-msvc-relwithdebinfo-vs2022`).
@