### PR TITLE
feat: visualize editor scenario points with flag figures

### DIFF
--- a/src/figuretype/editor.cpp
+++ b/src/figuretype/editor.cpp
@@ -1,6 +1,7 @@
 #include "editor.h"
 
 #include "graphics/image.h"
+#include "graphics/image_groups.h"
 #include "grid/figure.h"
 #include "grid/grid.h"
 #include "scenario/editor_map.h"
@@ -14,43 +15,55 @@ void figure_create_editor_flags() {
 }
 
 void figure::editor_flag_action() {
-    //    figure_image_increase_offset(16);
-    //    f->sprite_image_id = image_id_from_group(GROUP_FIGURE_MAP_FLAG_FLAGS) + f->anim_frame / 2;
-    //    map_f->map_figure_remove();
-    //
-    //    map_point point = {0, 0};
-    //    int id = f->resource_id;
-    //    int image_base = image_id_from_group(GROUP_FIGURE_MAP_FLAG_ICONS);
-    //    if (id == MAP_FLAG_EARTHQUAKE) {
-    //        point = scenario_editor_earthquake_point();
-    //        f->cart_image_id = image_base;
-    //    } else if (id == MAP_FLAG_ENTRY) {
-    //        point = scenario_map_entry();
-    //        f->cart_image_id = image_base + 2;
-    //    } else if (id == MAP_FLAG_EXIT) {
-    //        point = scenario_map_exit();
-    //        f->cart_image_id = image_base + 3;
-    //    } else if (id == MAP_FLAG_RIVER_ENTRY) {
-    //        point = scenario_map_river_entry();
-    //        f->cart_image_id = image_base + 4;
-    //    } else if (id == MAP_FLAG_RIVER_EXIT) {
-    //        point = scenario_map_river_exit();
-    //        f->cart_image_id = image_base + 5;
-    //    } else if (id >= MAP_FLAG_INVASION_MIN && id < MAP_FLAG_INVASION_MAX) {
-    //        point = scenario_editor_invasion_point(id - MAP_FLAG_INVASION_MIN);
-    //        f->cart_image_id = image_base + 1;
-    //    } else if (id >= MAP_FLAG_FISHING_MIN && id < MAP_FLAG_FISHING_MAX) {
-    //        point = scenario_editor_fishing_point(id - MAP_FLAG_FISHING_MIN);
-    //        f->cart_image_id = image_id_from_group(GROUP_FIGURE_FORT_STANDARD_ICONS) + 3;
-    //    } else if (id >= MAP_FLAG_HERD_MIN && id < MAP_FLAG_HERD_MAX) {
-    //        point = scenario_editor_herd_point(id - MAP_FLAG_HERD_MIN);
-    //        f->cart_image_id = image_id_from_group(GROUP_FIGURE_FORT_STANDARD_ICONS) + 4;
-    //    }
-    //    f->x = point.x;
-    //    f->y = point.y;
-    //
-    //    f->grid_offset_figure = map_grid_offset(f->x, f->y);
-    //    f->cross_country_x = 15 * f->x + 7;
-    //    f->cross_country_y = 15 * f->y + 7;
-    //    map_figure_add();
+    // each flag figure tracks one stored scenario point (selected by resource_id);
+    // reposition it onto that point every tick so placed points are visualized.
+    map_figure_remove();
+
+    const int id = resource_id;
+    const int icon_base = image_id_from_group(GROUP_FIGURE_MAP_FLAG_ICONS);
+
+    tile2i point = tile2i::invalid;
+    int icon_offset = 0;
+    if (id == MAP_FLAG_EARTHQUAKE) {
+        point = scenario_editor_earthquake_point();
+        icon_offset = 0;
+    } else if (id == MAP_FLAG_ENTRY) {
+        point = scenario_map_entry();
+        icon_offset = 2;
+    } else if (id == MAP_FLAG_EXIT) {
+        point = scenario_map_exit();
+        icon_offset = 3;
+    } else if (id == MAP_FLAG_RIVER_ENTRY) {
+        point = scenario_map_river_entry();
+        icon_offset = 4;
+    } else if (id == MAP_FLAG_RIVER_EXIT) {
+        point = scenario_map_river_exit();
+        icon_offset = 5;
+    } else if (id >= MAP_FLAG_INVASION_MIN && id < MAP_FLAG_INVASION_MAX) {
+        point = scenario_editor_land_invasion_point(id - MAP_FLAG_INVASION_MIN);
+        icon_offset = 1;
+    } else if (id >= MAP_FLAG_FISHING_MIN && id < MAP_FLAG_FISHING_MAX) {
+        point = scenario_editor_fishing_point(id - MAP_FLAG_FISHING_MIN);
+        // original used GROUP_FIGURE_FORT_STANDARD_ICONS (unavailable here); the
+        // flag number drawn by draw_map_flag disambiguates fishing/herd points
+        icon_offset = 1;
+    } else if (id >= MAP_FLAG_HERD_MIN && id < MAP_FLAG_HERD_MAX) {
+        point = scenario_editor_predator_herd_point(id - MAP_FLAG_HERD_MIN);
+        icon_offset = 1;
+    }
+
+    if (!point.valid()) {
+        // not placed yet: hide (draw_map_flag is skipped when cart_image_id == 0)
+        cart_image_id = 0;
+        tile = tile2i::invalid;
+        return;
+    }
+
+    tile = point;
+    use_cross_country = false;
+    direction = 0;
+    progress_on_tile = 0;
+    main_image_id = image_id_from_group(GROUP_FIGURE_MAP_FLAG_FLAGS);
+    cart_image_id = icon_base + icon_offset;
+    map_figure_add();
 }

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
Reimplements the previously fully-commented `figure::editor_flag_action()` so that scenario points placed in the editor (entry / exit / river entry+exit / earthquake / land invasion / fishing / herd) are visualized as positioned flag figures via the existing `draw_map_flag` path.

Each flag figure tracks one stored scenario point (selected by `resource_id`) and repositions itself onto that point every tick. If the point is not placed yet, the flag is hidden (`cart_image_id = 0`).

Old commented API calls were replaced with the current ones (`scenario_editor_land_invasion_point`, `scenario_editor_predator_herd_point`) and fields migrated to `tile2i` / `tile` / `main_image_id`.

**Notes / known limitations:**
- **Needs runtime verification** — builds cleanly (`win-msvc-relwithdebinfo-vs2022`), but the flags have not yet been visually confirmed to render on the correct tiles in editor mode.
- Fishing/herd points reuse `icon_offset = 1` because the original `GROUP_FIGURE_FORT_STANDARD_ICONS` group is unavailable here; the flag number drawn by `draw_map_flag` disambiguates them. Restoring distinct icons is left as a follow-up.
- The original flag animation (`figure_image_increase_offset`) is not restored; flags are static.
@