### PR TITLE
fix: misaligned printf args produced garbage phrase voice filenames

### DIFF
--- a/src/figure/figure_phrase.cpp
+++ b/src/figure/figure_phrase.cpp
@@ -94,12 +94,12 @@ int figure::figure_play_phrase_file() {
     if (phrase_key.empty() || phrase_key == "empty") {
         bstring32 prefix = params().name;
         prefix.replace_str("figure_", "");
-        path.printf("Voice/Walker/%s_random_%02u.wav", prefix.c_str(), phrase_key.c_str(), rand() % 10);
+        path.printf("Voice/Walker/%s_random_%02u.wav", prefix.c_str(), rand() % 10);
 
         vfs::path tmp;
         if (!g_sound.speech_file_exist(path, tmp)) {
             // fallback to standart phrase
-            path.printf("Voice/Walker/%s_random_01.wav", prefix.c_str(), phrase_key.c_str());
+            path.printf("Voice/Walker/%s_random_01.wav", prefix.c_str());
         }
     } else {
         auto reaction = dcast()->get_sound_reaction(phrase_key);

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
`figure::figure_play_phrase_file()` built the random walker voice path with a format string that had two conversion specifiers (`%s`, `%02u`) but passed three arguments:

```cpp
path.printf("Voice/Walker/%s_random_%02u.wav", prefix.c_str(), phrase_key.c_str(), rand() % 10);
```

`%02u` consumed `phrase_key.c_str()` — a `const char*` reinterpreted as an unsigned int (undefined behaviour) — while the intended `rand() % 10` frame number was dropped entirely, producing garbage filenames.

Fix: drop the stray `phrase_key.c_str()` so `%02u` receives `rand() % 10`. The same stray argument is removed from the `_random_01.wav` fallback (single `%s`, two args).

No logic change beyond correct argument alignment; builds cleanly (`win-msvc-relwithdebinfo-vs2022`).
@