### PR TITLE
fix: skip phrase playback for figures with no sound reactions

### DIFF
--- a/src/figure/figure_phrase.cpp
+++ b/src/figure/figure_phrase.cpp
@@ -85,8 +85,10 @@ void figure::figure_phrase_determine() {
 }
 
 int figure::figure_play_phrase_file() {
-    // TODO: Exclude all non-speaking figures
-    if (type == 0 || category() == figure_category_animal) {
+    // Exclude non-speaking figures: unused slots, animals, and any type with no
+    // configured sound reactions (cart/service figures lack a `sounds {}` block,
+    // so attempting speech_file_exist + TTS synthesis is pointless for them).
+    if (type == 0 || category() == figure_category_animal || params().sounds.data.empty()) {
         return -1;
     }
 

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
Resolves the `// TODO: Exclude all non-speaking figures` in `figure::figure_play_phrase_file()` by adding `params().sounds.data.empty()` to the early-return guard alongside the existing `type == 0` / `figure_category_animal` checks.

⚠️ **NEEDS REVIEW — possible regression.** The function has two playback paths:
1. `phrase_key` empty → name-based random voice `Voice/Walker/<name>_random_NN.wav` (with TTS synthesis fallback) — this path does **not** read `sounds.data`.
2. otherwise → `get_sound_reaction(phrase_key)` from `sounds.data`.

The new guard short-circuits **before** path 1, so any figure type with an empty `sounds {}` block can no longer reach the name-based random-voice path — effectively making path 1 dead code for those figures. If there are figures that rely solely on `*_random_NN.wav` voice files (no `sounds` block), this silences them.

Whether this is correct depends on the Pharaoh voice data: do any speaking figures have `_random_NN.wav` files but no `sounds {}` reactions? If yes, this guard is too aggressive and should instead key off something path-1-aware. Flagging for maintainer judgement / runtime check before merge.

Builds cleanly (`win-msvc-relwithdebinfo-vs2022`).
@