### PR TITLE
docs: explain why irrigation ditch on_place_checks is intentionally empty

### DIFF
--- a/src/building/building_irrigation_ditch.cpp
+++ b/src/building/building_irrigation_ditch.cpp
@@ -213,5 +213,9 @@ const building_irrigation_ditch::image_set &building_irrigation_ditch::images() 
 }
 
 void building_irrigation_ditch::on_place_checks() {
-    // nothing
+    // Intentionally empty: an irrigation ditch is a drag-placed canal segment, not a
+    // worker building. Do NOT chain to building_impl::on_place_checks() here -- the base
+    // emits #needs_road_access (canals never need road access) and #city_needs_more_workers
+    // (canals have no labor), both of which are spurious for a canal. building_road does
+    // the same (deliberately empty on_place_checks).
 }

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
Documents why `building_irrigation_ditch::on_place_checks()` is intentionally empty rather than chaining to `building_impl::on_place_checks()`.

An irrigation ditch is a drag-placed canal segment, not a worker building. The base implementation emits `#needs_road_access` (canals never need road access) and `#city_needs_more_workers` (canals have no labor) — both spurious for a canal. `building_road` is deliberately empty for the same reason.

Comment-only change; serves as a guard against future base-call-chaining sweeps incorrectly adding a base call here. No behaviour change.
@