### PR TITLE
docs: explain why well on_place_checks omits the base call

### DIFF
--- a/src/building/building_well.cpp
+++ b/src/building/building_well.cpp
@@ -39,6 +39,11 @@ void building_well::update_month() {
 }
 
 void building_well::on_place_checks() {
+    // Do NOT chain to building_impl::on_place_checks() here. A well needs groundwater,
+    // not road access, and has no labor -- the base would emit spurious #needs_road_access
+    // and #city_needs_more_workers warnings. Same rationale as building_irrigation_ditch
+    // and building_road (both deliberately skip the base). The only relevant check is
+    // groundwater presence below.
     construction_warnings warnings;
 
     int has_water = map_terrain_is(tile(), TERRAIN_GROUNDWATER);

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
Documents why `building_well::on_place_checks()` intentionally does not chain to `building_impl::on_place_checks()`.

A well needs groundwater, not road access, and has no labor — the base implementation would emit spurious `#needs_road_access` and `#city_needs_more_workers` warnings. Same rationale as `building_irrigation_ditch` and `building_road` (both deliberately skip the base). The only relevant check is groundwater presence.

Comment-only change; guards against future base-call-chaining sweeps incorrectly adding a base call here. No behaviour change.
@