### PR TITLE
fix: report success from map_road_find_minimum_tile_xy_classic

### DIFF
--- a/src/grid/road_access.cpp
+++ b/src/grid/road_access.cpp
@@ -91,11 +91,11 @@ bool map_road_find_minimum_tile_xy_classic(tile2i tile, int sizex, int sizey, in
         if (road_index < *min_value) {
             *min_value = road_index;
             *min_grid_offset = grid_offset;
-            found = false;
+            found = true;
         }
     }
 
-    return false;
+    return found;
 }
 
 bool map_has_road_access(tile2i tile, int size) {

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
`map_road_find_minimum_tile_xy_classic()` set `found = false` on a successful match and unconditionally `return false`, contradicting its `bool` contract and the sibling `map_road_find_minimum_tile_xy_nearest()` (which correctly sets `found = true` / `return found`).

Fix: set `found = true` on a match and `return found`.

**Impact:** latent-only — no observable behaviour change today. Both call sites (`map_has_road_access_rotation`, line 127, and line 194) ignore the bool return and instead test the `min_value < 12` out-param, which was written correctly even in the buggy version (the stray `found = false` came after the out-param writes). The fix makes the bool honest so future callers that rely on the return value behave correctly, with no risk to current pathfinding behaviour.

Builds cleanly (`win-msvc-relwithdebinfo-vs2022`).
@