### PR TITLE
fix: remove dead destination_city_id < 0 guard in is_at_destination

### DIFF
--- a/src/empire/empire_traders.cpp
+++ b/src/empire/empire_traders.cpp
@@ -77,10 +77,8 @@ void empire_trader::update() {
 }
 
 bool empire_trader::is_at_destination() const {
-    if (destination_city_id < 0) {
-        return false;
-    }
-
+    // destination_city_id is uint8_t, so a "< 0" sentinel check is impossible here;
+    // an unset/invalid destination is caught by the route checks below instead.
     const map_route_object& route = g_empire.get_route_object(trade_route_id);
     if (!route.in_use || route.num_points == 0) {
         return false;

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
`empire_trader::is_at_destination()` opened with `if (destination_city_id < 0) return false;`, but `destination_city_id` is a `uint8_t` (empire_traders.h:18), so the comparison is always false — dead code that also triggers a compiler warning.

Removed the dead guard and replaced it with a comment. An unset/invalid destination is already handled by the route checks below (`!route.in_use || route.num_points == 0`). Behaviour-preserving (the removed branch was unreachable).

Note: the `destination_city_id == -1` check in `create_trader` (line 144) is unaffected — that is the signed `int` parameter, not the `uint8_t` member field.

Builds cleanly (`win-msvc-relwithdebinfo-vs2022`).
@