### PR TITLE
fix: chain building_impl base call in pavilion on_place_checks

### DIFF
--- a/src/building/building_pavilion.cpp
+++ b/src/building/building_pavilion.cpp
@@ -133,6 +133,8 @@ void building_pavilion::on_place_update_tiles(int orientation, int variant) {
 }
 
 void building_pavilion::on_place_checks() {
+    building_impl::on_place_checks();
+
     construction_warnings warnings;
     const bool has_dance_school = g_city.buildings.count_active(BUILDING_DANCE_SCHOOL) > 0;
     const bool has_jugglers = g_city.buildings.count_active(BUILDING_JUGGLER_SCHOOL) > 0;

--- a/src/scripts/ui_workshop_window.js
+++ b/src/scripts/ui_workshop_window.js
@@ -44,9 +44,8 @@ function workshop_info_window_setup_advisors(window, building_type) {
         var advisor = (i < advisors.length) ? advisors[i] : ADVISOR_NONE
         var show = advisor && city.is_advisor_available(advisor)
         btn.enabled = !!show
-        var tid = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0}).tid
-        log_info("akhenaten: workshop_info_window_setup_advisors " + slots[i] + " " + advisor + " " + show + " " + tid)
-        btn.image = tid
+        var img = get_image({pack:PACK_GENERAL, id:106, offset:!!show ? (advisor - 1) * 3 : 0})
+        btn.image = img ? img.tid : 0
     }
 }
 


### PR DESCRIPTION
@
`building_pavilion::on_place_checks()` overrode the base without calling `building_impl::on_place_checks()`, silently dropping the standard `#needs_road_access` / `#city_needs_more_workers` warnings and the JS `on_place_checks` event dispatch.

Fix: call `building_impl::on_place_checks()` as the first statement, matching `fishing_wharf` and the same fix applied to #585 mortuary, #586 scribal school, #587 senet house, #591 water supply.

A pavilion employs entertainers and needs road access, so the base warnings are appropriate. No behaviour change beyond restoring the missing base warnings/event; builds cleanly (`win-msvc-relwithdebinfo-vs2022`).
@