### PR TITLE
fix: chain building_impl base call in bandstand on_place_checks

### DIFF
--- a/src/building/building_bandstand.cpp
+++ b/src/building/building_bandstand.cpp
@@ -135,6 +135,8 @@ void building_bandstand::on_place(int orientation, int variant) {
 }
 
 void building_bandstand::on_place_checks() {
+    building_impl::on_place_checks();
+
     construction_warnings warnings;
     const bool has_conservatory = g_city.buildings.count_active(BUILDING_CONSERVATORY) > 0;
     const bool has_jungles = g_city.buildings.count_active(BUILDING_JUGGLER_SCHOOL) > 0;


### PR DESCRIPTION
@
`building_bandstand::on_place_checks()` overrode the base without calling `building_impl::on_place_checks()`, silently dropping the standard `#needs_road_access` / `#city_needs_more_workers` warnings and the JS `on_place_checks` event dispatch.

Fix: call `building_impl::on_place_checks()` as the first statement, matching the same fix applied to #585 mortuary, #586 scribal school, #587 senet house, #591 water supply, #600 pavilion.

A bandstand employs entertainers and needs road access, so the base warnings are appropriate. No behaviour change beyond restoring the missing base warnings/event; builds cleanly (`win-msvc-relwithdebinfo-vs2022`).
@