### PR TITLE
Chain building_impl::on_place_checks in water lift override

### DIFF
--- a/src/building/building_water_lift.cpp
+++ b/src/building/building_water_lift.cpp
@@ -35,6 +35,8 @@ void building_water_lift::on_place_update_tiles(int orientation, int variant) {
 }
 
 void building_water_lift::on_place_checks() {
+    building_impl::on_place_checks();
+
     construction_warnings warnings;
 
     const bool has_water_lift = g_city.buildings.count_active(BUILDING_WATER_LIFT) > 0;


### PR DESCRIPTION
@
`building_water_lift::on_place_checks()` overrode the base method without chaining to `building_impl::on_place_checks()`, silently skipping the base `#needs_road_access` / `#city_needs_more_workers` warnings and the `es()` JS `on_place_checks` event dispatch.

Fix adds `building_impl::on_place_checks()` as the first statement of the override, matching the `fishing_wharf` pattern. No logic or save-format change — purely restoring the base dispatch.

Build verified OK (preset `win-msvc-relwithdebinfo-vs2022`).
@