### PR TITLE
Chain building_weaver::on_place_checks to base

### DIFF
--- a/src/building/building_weaver.cpp
+++ b/src/building/building_weaver.cpp
@@ -12,6 +12,8 @@
 REPLICATE_STATIC_PARAMS_FROM_CONFIG(building_weaver);
 
 void building_weaver::on_place_checks() {
+    building_impl::on_place_checks();
+
     if (g_city.buildings.count_industry_active(RESOURCE_FLAX) > 0) {
         return;
     }


### PR DESCRIPTION
@
`building_weaver::on_place_checks()` overrode the base method without chaining to `building_impl::on_place_checks()`, silently dropping the base `#needs_road_access` / `#city_needs_more_workers` warnings and the `es()` JS `on_place_checks` event dispatch.

Fix adds `building_impl::on_place_checks()` as the first statement of the override, matching its sibling workshops (jewels, papyrus) and the `fishing_wharf` pattern. No logic or save-format change — purely restoring the base dispatch.

Build verified OK (preset `win-msvc-relwithdebinfo-vs2022`).
@