### PR TITLE
Fix scenario_request_get_visible to scan the full event list

### DIFF
--- a/src/scenario/request.cpp
+++ b/src/scenario/request.cpp
@@ -283,11 +283,17 @@ std::vector<scenario_request> scenario_get_visible_requests() {
 
 scenario_request scenario_request_get_visible(int index) {
     int event_index = 0;
-    if (index >= g_scenario.events.events_count()) {
+    const int total_events = g_scenario.events.events_count();
+    if (index >= total_events) {
         return {};
     }
 
-    for (int i = 0; i < MAX_REQUESTS; i++) {
+    // NOTE: must scan the full event list, not just the first MAX_REQUESTS slots --
+    // scenarios routinely accumulate more than MAX_REQUESTS total events (chain
+    // reactions from completed/refused/late requests, gifts, other scenario events),
+    // which can push a later request's event past slot MAX_REQUESTS. Matches the
+    // bound used by scenario_get_visible_requests()/scenario_requests_active_count().
+    for (int i = 0; i < total_events; i++) {
         const event_ph_t* event = g_scenario.events.at(i);
         if (!(event->type == EVENT_TYPE_REQUEST && event->is_active && event->event_state <= e_event_state_overdue)) {
             continue;

--- a/src/scenario/request.cpp
+++ b/src/scenario/request.cpp
@@ -288,11 +288,6 @@ scenario_request scenario_request_get_visible(int index) {
         return {};
     }
 
-    // NOTE: must scan the full event list, not just the first MAX_REQUESTS slots --
-    // scenarios routinely accumulate more than MAX_REQUESTS total events (chain
-    // reactions from completed/refused/late requests, gifts, other scenario events),
-    // which can push a later request's event past slot MAX_REQUESTS. Matches the
-    // bound used by scenario_get_visible_requests()/scenario_requests_active_count().
     for (int i = 0; i < total_events; i++) {
         const event_ph_t* event = g_scenario.events.at(i);
         if (!(event->type == EVENT_TYPE_REQUEST && event->is_active && event->event_state <= e_event_state_overdue)) {


### PR DESCRIPTION
## Summary
- `scenario_request_get_visible()` looped only over the first `MAX_REQUESTS` event slots, so once a scenario accumulated more than `MAX_REQUESTS` total events (chain reactions from completed/refused/late requests, gifts, other scenario events), a later request's event could land past slot `MAX_REQUESTS` and be missed.
- Bound the loop by the total event count instead, matching what `scenario_get_visible_requests()` / `scenario_requests_active_count()` already use.

## Test plan
- [ ] Load a scenario with more than `MAX_REQUESTS` accumulated events and confirm later requests still appear in the requests UI.