### PR TITLE
Fix build-planner crash/glitch when cursor leaves the map viewport

### DIFF
--- a/src/building/construction/build_planner.cpp
+++ b/src/building/construction/build_planner.cpp
@@ -1154,6 +1154,14 @@ void build_planner::update_preview(tile2i cursor_tile) {
         return;
     }
 
+    if (!cursor_tile.valid()) {
+        // Cursor is outside the camera viewport (e.g. hovering the top menu bar
+        // while a building is selected) -- keep showing the ghost at its last
+        // valid position instead of re-running placement checks against a
+        // bogus off-map tile every frame.
+        return;
+    }
+
     end = cursor_tile;
     update_coord_caches();
 

--- a/src/building/construction/build_planner.cpp
+++ b/src/building/construction/build_planner.cpp
@@ -1155,10 +1155,6 @@ void build_planner::update_preview(tile2i cursor_tile) {
     }
 
     if (!cursor_tile.valid()) {
-        // Cursor is outside the camera viewport (e.g. hovering the top menu bar
-        // while a building is selected) -- keep showing the ghost at its last
-        // valid position instead of re-running placement checks against a
-        // bogus off-map tile every frame.
         return;
     }
 

--- a/src/grid/grid.cpp
+++ b/src/grid/grid.cpp
@@ -295,6 +295,12 @@ void map_grid_bound_area(tile2i &tmin, tile2i &tmax) {
     if (tmin.y() < 0) { tmin.set_y(0); }
     if (tmax.x() >= scenario_map_data()->width) { tmax.set_x(scenario_map_data()->width - 1); }
     if (tmax.y() >= scenario_map_data()->height) { tmax.set_y(scenario_map_data()->height - 1); }
+    // tmin/tmax can each independently land out of range on the OTHER side too
+    // (e.g. an already off-map source tile), which the checks above don't cover.
+    if (tmax.x() < 0) { tmax.set_x(0); }
+    if (tmax.y() < 0) { tmax.set_y(0); }
+    if (tmin.x() >= scenario_map_data()->width) { tmin.set_x(scenario_map_data()->width - 1); }
+    if (tmin.y() >= scenario_map_data()->height) { tmin.set_y(scenario_map_data()->height - 1); }
 }
 
 grid_area map_grid_get_area(tile2i tile, int size, int radius) {

--- a/src/widget/widget_city.cpp
+++ b/src/widget/widget_city.cpp
@@ -90,7 +90,7 @@ static tile2i city_planner_cursor_tile_from_mouse() {
 
 tile2i screen_city_t::update_city_view_coords(vec2i pixel) {
     if (!g_camera.contains_pixel(pixel)) {
-        return tile2i(0);
+        return tile2i::invalid;
     }
 
     vec2i screen = g_camera.pixel_to_screentile(pixel);


### PR DESCRIPTION
## Summary
- `update_city_view_coords()` returned `tile2i(0)` when the mouse left the camera viewport (e.g. hovering the top menu bar while a building is selected), which decodes to an off-map tile with negative coordinates instead of a real invalid sentinel; it now returns `tile2i::invalid`.
- `build_planner::update_preview()` had no validity guard against that (unlike `construction_update()`), so it ran the full placement-check pipeline against a bogus off-map tile every frame; it now bails early and keeps the ghost at its last valid position.
- `map_grid_bound_area()` only clamped `tmin` downward and `tmax` upward, missing the case where an already off-map tile puts either bound out of range on the other side; both bounds are now clamped on both sides.

## Test plan
- [ ] Select a building for placement, move the cursor up over the top menu bar, and confirm no crash/glitch and the ghost preview stays at its last valid tile.