### PR TITLE
Linux compatibility modifications

### DIFF
--- a/src/content/imagepak.cpp
+++ b/src/content/imagepak.cpp
@@ -441,7 +441,7 @@ bool imagepak::load_zip_pak(pcstr pak, int starting_index) {
     int bmp_last_group_id = 0;
     int last_idx_in_bmp = 1;
 
-    pcstr allow_dirs_to_find[] = { "Mods", "Data" };
+    pcstr allow_dirs_to_find[] = { "mods", "data" };
     bool found = false;
     vfs::path datafile;
 

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -165,7 +165,7 @@ void mods_download_mod_async(xstring name) {
             return;
         }
 
-        std::filesystem::path mods_dir = std::filesystem::path(base_path) / "Mods";
+        std::filesystem::path mods_dir = std::filesystem::path(base_path) / "mods";
         std::filesystem::create_directories(mods_dir);
 
         // Create filename with .sgx extension
@@ -237,7 +237,7 @@ void mods_download_mod_async(xstring name) {
         // Update mod info
         mod.downloaded = true;
         mod.download_progress = 100;
-        mod.path.printf("Mods/%s", filename.c_str());
+        mod.path.printf("mods/%s", filename.c_str());
 
         // Initialize mod metadata (similar to mods_init)
         mod.useridx = imagepak::get_max_useridx() + 1;
@@ -331,7 +331,7 @@ void mods_init() {
             auto it = g_mods.list.find(mod_name);
             if (it == g_mods.list.end()) {
                 mod_info& mod = g_mods.list[mod_name];
-                mod.path.printf("Mods/%s", files->files[i]);
+                mod.path.printf("mods/%s", files->files[i]);
                 mod.name = mod_name;
                 mod.downloaded = true;
                 mod.useridx = imagepak::get_max_useridx() + 1;
@@ -353,8 +353,8 @@ void mods_init() {
         }
     };
 
-    const dir_listing* sgx_files = vfs::dir_find_files_with_extension("Mods", "sgx");
-    append_mods("Mods/", sgx_files);
+    const dir_listing* sgx_files = vfs::dir_find_files_with_extension("mods", "sgx");
+    append_mods("mods/", sgx_files);
 }
 
 const mod_info& mods_find(xstring hash) {

--- a/src/io/gamefiles/smacker.cpp
+++ b/src/io/gamefiles/smacker.cpp
@@ -373,7 +373,7 @@ static int read_header(smacker s) {
     }
     // check signature
     if (header[0] != 'S' || header[1] != 'M' || header[2] != 'K' || header[3] != '2') {
-        logs::error("SMK: file is not an SMK2 video");
+        logs::debug("SMK: file is not an SMK2 video");
         return 0;
     }
     s->width = read_i32(&header[4]);

--- a/src/net/http_client.cpp
+++ b/src/net/http_client.cpp
@@ -4,6 +4,7 @@
 
 #ifdef GAME_HAVE_CURL
 #include <curl/curl.h>
+#include <cstdio>
 #endif
 
 #ifdef GAME_HAVE_CURL
@@ -45,6 +46,32 @@ http_get_result http_get(pcstr url, long timeout_sec, bool capture_headers) {
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+
+    // Some platforms (e.g. Ubuntu/Debian) store CA certificates in locations
+    // that libcurl's built-in auto-detection does not check, causing SSL
+    // verification failures at runtime.  Try to locate a CA bundle file if
+    // libcurl was built without a default, or the default is inaccessible.
+    {
+        const char *cainfo = nullptr;
+        curl_easy_getinfo(curl, CURLINFO_CAINFO, &cainfo);
+        if (!cainfo || !*cainfo || std::fopen(cainfo, "r") == nullptr) {
+            static const char *fallback_paths[] = {
+                "/etc/ssl/certs/ca-certificates.crt",
+                "/etc/pki/tls/certs/ca-bundle.crt",
+                "/usr/share/ssl/certs/ca-bundle.crt",
+                "/usr/local/share/certs/ca-root-nss.crt",
+                nullptr
+            };
+            for (const char **p = fallback_paths; *p; ++p) {
+                std::FILE *fp = std::fopen(*p, "r");
+                if (fp) {
+                    std::fclose(fp);
+                    curl_easy_setopt(curl, CURLOPT_CAINFO, *p);
+                    break;
+                }
+            }
+        }
+    }
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "Akhenaten/1.0");
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_sec);
 

--- a/src/window/intro_video.cpp
+++ b/src/window/intro_video.cpp
@@ -1,6 +1,7 @@
 #include "intro_video.h"
 
 #include "core/log.h"
+#include "content/vfs.h"
 #include "graphics/graphics.h"
 #include "graphics/screen.h"
 #include "graphics/video.h"
@@ -19,6 +20,8 @@ static struct {
 // Original/Steam use BINKS/; some GOG layouts ship the same files under Video/.
 static const char* PH_INTRO_CANDIDATES[] = {
     "BINKS/high/Intro_big.bik",
+    "BINKS/High/Intro_big.bik",
+    "Binks/High/Intro_big.bik",
     "Video/High/Intro_big.bik",
     "BINKS/low/intro.bik",
     "Video/Low/intro.bik",
@@ -28,6 +31,9 @@ static int start_intro_video(void) {
     const int candidates = (int)(sizeof(PH_INTRO_CANDIDATES) / sizeof(PH_INTRO_CANDIDATES[0]));
     for (int i = 0; i < candidates; i++) {
         const char* path = PH_INTRO_CANDIDATES[i];
+        if (!vfs::file_exists(path)) {
+            continue;
+        }
         if (video_start(path)) {
             video_size(&data.width, &data.height);
             video_init();
@@ -37,6 +43,13 @@ static int start_intro_video(void) {
         }
         logs::info("Intro video: could not open %s", path);
     }
+
+    bstring1024 candidates_log;
+    for (int i = 0; i < candidates; i++) {
+        if (i > 0) candidates_log.append("\n");
+        candidates_log.append(PH_INTRO_CANDIDATES[i]);
+    }
+    logs::error("Intro video: none of the candidate paths exist:\n%s", candidates_log.c_str());
     return 0;
 }
 


### PR DESCRIPTION
fix: locate CA certificate bundle at runtime on platforms curl's auto-detection misses

curl's built-in auto-detection for CA bundle paths does not cover common
locations on Ubuntu/Debian (/etc/ssl/certs/ca-certificates.crt) and
some other platforms. At runtime, query the built-in default via
CURLINFO_CAINFO and fall back to well-known paths if it's empty or
inaccessible.

Additionally, fixed case-sensitivity issues in file references that caused
failures on Linux due to filename case mismatches.

Also suppressed a few unnecessary error messages that could appear in the logs.

