### PR TITLE
Localization files must be preloaded before config refresh

### DIFF
--- a/src/graphics/elements/lang_text.cpp
+++ b/src/graphics/elements/lang_text.cpp
@@ -208,9 +208,7 @@ bool lang_android_load_localization_base_en_direct(pcstr path) {
 void ANK_REGISTER_CONFIG_ITERATOR(config_load_localization) {
     g_config_arch.r("game_languages", game_languages);
     g_localization.clear();
-
     lang_reload_localized_files();
-
     lang_reload_localized_tables();
 }
 

--- a/src/graphics/elements/lang_text.cpp
+++ b/src/graphics/elements/lang_text.cpp
@@ -208,6 +208,9 @@ bool lang_android_load_localization_base_en_direct(pcstr path) {
 void ANK_REGISTER_CONFIG_ITERATOR(config_load_localization) {
     g_config_arch.r("game_languages", game_languages);
     g_localization.clear();
+
+    lang_reload_localized_files();
+
     lang_reload_localized_tables();
 }
 


### PR DESCRIPTION
### What changed

`modules.js` now pre-loads the localization files for the current language before the config refresh.

### Why

The JS UI templates are baked by `config_load_info_window` during the same config refresh. `#key`-based texts (e.g. window titles) are resolved at that point, so the current language's base/table files must already be loaded into the VM.

Previously, only the English localization files were pre-loaded, causing these texts to be baked in English and never re-resolved when another language was active.

`lang_reload_localized_files()` is safe to call here because `game_languages` has just been populated, so it does not recurse into `config::refresh`.
