### PR TITLE
Fix rich text link rendering: & as non-breaking space, highlight extent, and accented characters

### DIFF
--- a/src/graphics/elements/rich_text.cpp
+++ b/src/graphics/elements/rich_text.cpp
@@ -159,12 +159,15 @@ int rich_text_t::get_word_width(pcstr str, int in_link, int* num_chars) {
                     break;
                 } else {
                     (*num_chars)++;
+                    const bool is_link = (*str >= '0' && *str <= '9');
                     while (*str >= '0' && *str <= '9') {
                         str++;
                         (*num_chars)++;
                     }
-                    in_link = 1;
-                    start_link = 1;
+                    if (is_link) {
+                        in_link = 1;
+                        start_link = 1;
+                    }
                 }
             }
         }
@@ -176,6 +179,11 @@ int rich_text_t::get_word_width(pcstr str, int in_link, int* num_chars) {
 
             width += normal_font_def->space_width;
             last_letter_spacing = 0;
+            start_link = 0;
+        } else if (*str == '&' && in_link) {
+            width += normal_font_def->space_width;
+            last_letter_spacing = 0;
+            word_char_seen = 1;
         } else if ((unsigned char)*str > ' ') {
             // normal char
             const auto glyph = font_letter_id(normal_font_def, (const uint8_t*)str, &num_bytes);
@@ -188,9 +196,14 @@ int rich_text_t::get_word_width(pcstr str, int in_link, int* num_chars) {
             }
 
             word_char_seen = 1;
-            if (num_bytes > 1 && start_link) {
-                // add space before links in multibyte charsets
-                width += normal_font_def->space_width;
+            if (start_link) {
+                // In CJK charsets (Chinese, Korean - 3-byte UTF-8 glyphs) a link
+                // can start with a wide glyph with no space before it; insert a
+                // leading space so it doesn't glue to the preceding text.
+                // Accented Latin / Cyrillic (2-byte) must NOT get this space.
+                if (num_bytes > 2) {
+                    width += normal_font_def->space_width;
+                }
                 start_link = 0;
             }
         }
@@ -261,16 +274,18 @@ void rich_text_t::draw_line(painter &ctx, pcstr str, int x, int y, color clr, bo
 
             int num_bytes = 1;
             
-            // Handle spaces separately, just like text_draw does
-            if (*str == ' ') {
+            // Handle spaces separately, just like text_draw does.
+            if (*str == ' ' || (*str == '&' && num_link_chars > 0)) {
                 x += def->space_width;
                 num_bytes = 1;
+                start_link = 0;
             } else {
                 const auto glyph = font_letter_id(def, (const uint8_t*)str, &num_bytes);
                 if (glyph.imagid >= 0) {
-                    if (num_bytes > 1 && start_link) {
-                        // add space before links in multibyte charsets
-                        x += def->space_width;
+                    if (start_link) {
+                        if (num_bytes > 2) {
+                            x += def->space_width;
+                        }
                         start_link = 0;
                     }
 
@@ -287,6 +302,9 @@ void rich_text_t::draw_line(painter &ctx, pcstr str, int x, int y, color clr, bo
 
             if (num_link_chars > 0) {
                 num_link_chars -= num_bytes;
+                if (num_link_chars == 0) {
+                    def = normal_font_def;
+                }
             }
 
             str += num_bytes;


### PR DESCRIPTION
# Summary

Fixes three rendering bugs in `src/graphics/elements/rich_text.cpp` that affected the clickable help links embedded in game messages.

These links use the `@NNmy&link&text` markup inherited from the original Pharaoh text format, where `&` acts as a word separator inside a link.

The changes are purely in the rich-text renderer and work for all languages (`en`/`de`/`hu`/`ru`/…) with no changes to any message or script data.

## 1. `&` inside a link now renders as a non-breaking space

Previously, the `&` character was rendered as a zero-width, invisible character. The original Pharaoh bitmap font has no glyph for ASCII `&` (`CHAR_TO_FONT_IMAGE_DEFAULT` maps `0x26` to `0`), so link phrases were displayed with merged words:

* `@67Temples&and&Shrines` → `TemplesandShrines`
* `@29Overseer&of the&Temples` → `Overseerof the Temples`

With the custom TTF font used by non-English languages, a literal `&` was drawn instead.

Now, `&` inside a link is measured and drawn as a regular space:

* `@67Temples&and&Shrines` → **`Temples and Shrines`** (one unbroken clickable region)
* `@29Overseer&of&the&Temples` → **`Overseer of the Temples`**
* Line wrapping never splits a multi-word link, since `&` keeps the phrase glued together and is not treated as a word boundary.

The link hit-region width (`get_word_width`) and the drawn text now match in both measuring passes.

## 2. Link highlight no longer bleeds past the link

The font pointer was switched to the link font (yellow) at the start of a link but was never restored when the link ended.

As a result, the rest of the wrapped line stayed highlighted. For example, the whole:

> `…knows the mood of the gods, so check in`

could previously be rendered with the link color.

The normal font is now restored as soon as the last link character is drawn.

## 3. No spurious spaces before accented characters

The old "add space before links in multibyte charsets" hack (added upstream for Chinese) fired on any multibyte character while `start_link` was still set.

`start_link` was only cleared when the first multibyte character appeared. For links starting with ASCII letters, this caused a stray space before later accented characters:

* `@51vallás` → `vall ás`

Links starting with a 2-byte accented character also received a double space:

* `@358Útakadályt`
* `@92глиняныx…`

### Fix

* Clear `start_link` after the first character of the link is consumed, in both the measurement and drawing passes.
* Restrict the leading-space hack to 3+ byte UTF-8 glyphs (CJK — Chinese/Korean/kana), which is its original purpose.
* Accented Latin and Cyrillic characters (2-byte UTF-8) no longer get the leading space.

## Additional detail

`get_word_width` now only enters link mode for real links (`@<digits>`), not for `@Y` (colored text) or `@I` (inline icon) markers.

This ensures that the `&` terminator of `@Y…&` colored strings keeps its original meaning and is not incorrectly measured as a space.

## Verification

* `cmake --build` succeeds; all targets compile.
* Byte-level simulation of the modified `get_word_width` / `draw_line` logic confirms:

  * `Temples&and&Shrines` → `Temples and Shrines`
  * `@29Overseer&of @29the&Temples` → `Overseer of the Temples`
  * `@51vallás` → `vallás` (no stray space)
  * Hungarian `@358Út&akadályokat` and Russian `@92глиняныx&кapьepax` → single space, no double space
  * Chinese/Korean links keep the leading separation space.

<img width="949" height="892" alt="Képernyőkép 2026-08-14 18-19-15" src="https://github.com/user-attachments/assets/4637f536-bf41-472c-beef-5f2c50b00000" />
<img width="952" height="892" alt="Képernyőkép 2026-08-14 18-10-39" src="https://github.com/user-attachments/assets/ef3427c9-63ae-496d-a01d-b205456fcc67" />
