### PR TITLE
Fix exit-time SIGSEGV and stale GL error in GPU filter teardown

### DIFF
--- a/ext/gpupixel/core/framebuffer.cc
+++ b/ext/gpupixel/core/framebuffer.cc
@@ -34,6 +34,7 @@ Framebuffer::Framebuffer(int width, int height, bool onlyGenerateTexture /* = fa
 
 Framebuffer::~Framebuffer() {
     gpupixel::GPUPixelContext::getInstance()->runSync([&] {
+        glGetError();
         bool bDeleteTex = (_texture != -1);
         bool bDeleteFB = (_framebuffer != -1);
 

--- a/src/platform/renderer.cpp
+++ b/src/platform/renderer.cpp
@@ -1283,6 +1283,7 @@ void platform_renderer_resume() {
 void platform_renderer_destroy(void) {
     auto &data = g_renderer_data;
     destroy_render_texture();
+    platform_render_shutdown_filters();
     if (data.renderer) {
         SDL_DestroyRenderer(data.renderer);
         data.renderer = 0;

--- a/src/platform/renderer.h
+++ b/src/platform/renderer.h
@@ -43,6 +43,7 @@ void platform_renderer_resume();
 void platform_renderer_destroy();
 void platform_render_setup_options(xstring driver);
 void platform_render_init_filters();
+void platform_render_shutdown_filters();
 bool platform_render_support_filters();
 bool platform_render_any_filter_active();
 void platform_render_create_context();

--- a/src/platform/renderer_filters.cpp
+++ b/src/platform/renderer_filters.cpp
@@ -154,7 +154,7 @@ void platform_render_init_filters() {
 
     gpupixel::GPUPixelContext::initOpengl();
 
-    data.sourceImage = gpupixel::SourceImage::create_from_memory(0, 0, 4, nullptr);
+    data.sourceImage = gpupixel::SourceImage::create_from_memory(1, 1, 4, nullptr);
     if (!data.sourceImage) {
         logs::warn("GPU filters disabled: failed to initialize GPUPixel shaders");
         data.render_support_filters = false;
@@ -204,6 +204,51 @@ void platform_render_init_filters() {
     }
 
     data.sourceImage->addTarget(data.outputImage);
+}
+
+void platform_render_shutdown_filters() {
+    auto &data = g_renderer_filter;
+
+    if (!data.render_support_filters) {
+        return;
+    }
+
+    glGetError();
+
+    data.outputImage.reset();
+    data.sourceImage.reset();
+
+    data.bilaterial.reset();
+    data.grayscale.reset();
+    data.brightness.reset();
+    data.contrast.reset();
+    data.saturation.reset();
+    data.exposure.reset();
+    data.hue.reset();
+    data.colorInvert.reset();
+    data.posterize.reset();
+    data.gaussianBlur.reset();
+    data.boxBlur.reset();
+    data.beautyFace.reset();
+    data.blusher.reset();
+    data.boxDifference.reset();
+    data.boxMonoBlur.reset();
+    data.cannyEdgeDetection.reset();
+    data.crosshatch.reset();
+    data.emboss.reset();
+    data.faceReshape.reset();
+    data.glassSphere.reset();
+    data.halftone.reset();
+    data.lipstick.reset();
+    data.nonMaximumSuppression.reset();
+    data.pixellation.reset();
+    data.rgb.reset();
+    data.smoothToon.reset();
+    data.toon.reset();
+    data.weakPixelInclusion.reset();
+    data.whiteBalance.reset();
+
+    data.render_support_filters = false;
 }
 
 void game_debug_show_filter_property_float(gpupixel::FilterPtr filter, const char *name, const float step = 1.f) {
@@ -980,6 +1025,8 @@ bool platform_render_whiteBalance_options() {
 void platform_render_proceed_filter(int w, int h, int format, const std::vector<uint8_t>&pixels, std::vector<uint8_t> &output_pixels) {
     auto &data = g_renderer_filter;
 
+    glGetError();
+
     data.sourceImage->init(w, h, SDL_BYTESPERPIXEL(format), (uint8_t *)pixels.data());
     data.sourceImage->proceed();
 
@@ -1145,6 +1192,7 @@ void config_load_filter_properties(bool header) {
 #else
 
 void platform_render_init_filters() {}
+void platform_render_shutdown_filters() {}
 bool platform_render_support_filters() { return false; }
 bool platform_render_any_filter_active() { return false; }
 void platform_render_proceed_filter(int w, int h, int format, const std::vector<uint8_t> &pixels, std::vector<uint8_t> &output_pixels) {}

--- a/src/platform/renderer_filters.cpp
+++ b/src/platform/renderer_filters.cpp
@@ -154,6 +154,13 @@ void platform_render_init_filters() {
 
     gpupixel::GPUPixelContext::initOpengl();
 
+    // Create the source image with a non-zero size (1x1). A 0x0 source image
+    // would create a degenerate 0x0 framebuffer texture on startup, which Mesa
+    // rejects with GL_INVALID_VALUE (glTexImage2D/glFramebufferTexture2D) and
+    // left a stale error behind that gpupixel's CHECK_GL later misreported as
+    // its own "GL ERROR ... framebuffer.cc:41". The real dimensions are set
+    // later in platform_render_proceed_filter() -> sourceImage->init(w,h,...),
+    // so this placeholder only needs to be a valid texture.
     data.sourceImage = gpupixel::SourceImage::create_from_memory(1, 1, 4, nullptr);
     if (!data.sourceImage) {
         logs::warn("GPU filters disabled: failed to initialize GPUPixel shaders");
@@ -1025,6 +1032,10 @@ bool platform_render_whiteBalance_options() {
 void platform_render_proceed_filter(int w, int h, int format, const std::vector<uint8_t>&pixels, std::vector<uint8_t> &output_pixels) {
     auto &data = g_renderer_filter;
 
+    // GPUPixel shares the SDL OpenGL context. SDL renderer calls (rendercopy,
+    // readpixels, ...) may leave an unread GL error behind; gpupixel's CHECK_GL
+    // would then misattribute that stale error to itself and spam bogus
+    // "GL ERROR" log lines. Clear the error state before gpupixel does any GL.
     glGetError();
 
     data.sourceImage->init(w, h, SDL_BYTESPERPIXEL(format), (uint8_t *)pixels.data());


### PR DESCRIPTION
# Fix exit-time SIGSEGV and stale GL error in GPU filter teardown

## Problem

The game can intermittently crash with `SIGSEGV` after the game has already exited.

The crash occurs approximately 1 in 8 runs in our testing and, in some configurations, is accompanied by:

```text
GL ERROR 0x0501 GL_INVALID_VALUE ... framebuffer.cc:41
```

The issue was identified while investigating the savegame-loading fix (#656), but it is not established when the exit-time crash was first introduced.

### Root cause

The renderer's global `g_renderer_filter`, which owns the `gpupixel::SourceImage` and filter objects, has process lifetime. Its destructors therefore run after `main()` returns, long after the SDL renderer and its OpenGL context have been destroyed during the game's normal teardown.

GPUPixel destructors such as `GLProgram::~GLProgram` and `Framebuffer::~Framebuffer` issue OpenGL calls (`glDeleteProgram`, `glDeleteTextures`, etc.) through `runSync`. Calling these functions after the OpenGL context has been destroyed is undefined behaviour, which manifests as either a flaky exit-time crash or bogus GL errors.

Captured backtrace (exit-time, without this fix):

```text
crash_handler
 → _Function_handler<GLProgram::~GLProgram lambda>::_M_invoke
 → _Function_base::~_Function_base
 → gpupixel::SourceImage::~SourceImage
 → _Sp_counted_base::_M_release
```

## Proof that the fix is needed

We ran the same savegame-loading test (`184_request_saveload` integral test) on the same machine, with 8 runs for each configuration:

<table>
  <thead>
    <tr>
      <th>State</th>
      <th>Result</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><strong>A — without this PR</strong></td>
      <td>1 × <code>SIGSEGV</code> at exit (<code>exit=1</code>), 0 GL-error lines</td>
    </tr>
    <tr>
      <td><strong>B — with this PR</strong></td>
      <td>8/8 clean (<code>exit=0</code>), all PASS, 0 crashes, 0 GL-error lines</td>
    </tr>
  </tbody>
</table>

## Changes

* `src/platform/renderer_filters.cpp`

  * Adds `platform_render_shutdown_filters()`.
  * Explicitly releases the GPUPixel output image, source image, and all filter instances while the OpenGL context is still alive.
  * Marks GPU filters as inactive after teardown.
  * Creates the initial `SourceImage` at `1x1` instead of `0x0`. A `0x0` source image creates a degenerate framebuffer texture on startup, which Mesa rejects with `GL_INVALID_VALUE` and leaves a stale error in the OpenGL error state. The actual dimensions are set later by `platform_render_proceed_filter()`, so the initial image only needs to be a valid texture.
  * Clears the GL error state before handing control to GPUPixel in `platform_render_proceed_filter()`. SDL and GPUPixel share the same OpenGL context, so SDL renderer operations can leave an unread GL error which GPUPixel's `CHECK_GL` would otherwise incorrectly attribute to itself.

* `src/platform/renderer.cpp`

  * `platform_renderer_destroy()` now calls `platform_render_shutdown_filters()` before `SDL_DestroyRenderer()`.

* `src/platform/renderer.h`

  * Adds the declaration for `platform_render_shutdown_filters()`, together with a no-op stub for builds where GPU filters are unavailable.

* `ext/gpupixel/core/framebuffer.cc`

  * `Framebuffer::~Framebuffer()` now clears any pre-existing GL error before its `CHECK_GL`-guarded deletion calls, ensuring that errors reported there originate from its own OpenGL operations.

## Why the `framebuffer.cc` change is part of this PR

Once the GPUPixel destructors are correctly run while the OpenGL context is still alive, another issue in GPUPixel's teardown becomes visible.

During `SourceImage` teardown, GPUPixel can perform unchecked `glDeleteProgram` calls on invalid program handles. This leaves `GL_INVALID_VALUE` in the OpenGL error state.

The next `CHECK_GL` in the pipeline — `Framebuffer::~Framebuffer()`, at line 41 — then incorrectly attributes that stale error to itself:

```text
GL ERROR 0x0501 GL_INVALID_VALUE in func:operator()(),
in file:../gpupixel/core/framebuffer.cc, at line 41
```

The one-line `glGetError()` clear in `Framebuffer::~Framebuffer()` prevents this stale error from being misreported. This was verified by deleting textures from a valid object without producing a GL error.

There is a similar stale-error boundary during normal filter processing: SDL and GPUPixel share the same OpenGL context, so SDL operations may leave a GL error pending when GPUPixel starts its work. Clearing the error before GPUPixel operations prevents its `CHECK_GL` calls from reporting errors originating from earlier SDL operations.

A deeper fix for GPUPixel's invalid `glDeleteProgram` teardown would be an upstream GPUPixel issue rather than a game-specific change. Previously, this problem was effectively hidden because the destructors were running against an already-destroyed OpenGL context.

## Verification

* `cmake --build build -j 24` — green.
* Integral tests:

  * `59_autosave_slots`
  * `106_meidum_complex_rating_saveload`
  * `108_overlays_menu_ids`
  * `184_request_saveload`
  * `48_hunting_lodge`
  * `65_zoo_place`
  * all PASS, `exit=0`, with no GL errors or crashes.
* `184_request_saveload` repeated 8× with the fix: **8/8 clean**, compared with **1/8 crashes without the fix**.
* Existing user savegames load normally.
* No user data was modified; test save artefacts were cleaned up.
