### PR TITLE
figures: fix fireman speech — voice-key prefix, named-key localization, and .WAV case

### DIFF
--- a/src/figuretype/figure_fireman.cpp
+++ b/src/figuretype/figure_fireman.cpp
@@ -32,7 +32,7 @@ void figure_fireman::figure_before_action() {
 
 sound_key figure_fireman::phrase_key() const {
     if (base.action_state == ACTION_74_FIREMAN_GOING_TO_FIRE) {
-        return "going_to_fire";
+        return "fireman_going_to_fire";
     }
 
     svector<sound_key, 10> keys;
@@ -41,7 +41,7 @@ sound_key figure_fireman::phrase_key() const {
         keys.push_back("fighting_fire");
 
         int index = rand() % keys.size();
-        return keys[index];
+        return xstring().printf("fireman_%s", keys[index].c_str());
     }
 
     if (g_city.health.value < 20) {

--- a/src/scripts/figures.js
+++ b/src/scripts/figures.js
@@ -10,19 +10,19 @@ figure_fireman {
   }
 
   sounds {
-  	fireman_fighting_fire {sound:"fireman_e01.wav", group: 242, text:0}
-	fireman_going_to_fire {sound:"fireman_e02.wav", group: 242, text:1}
-	fireman_fighting_fire_also {sound:"fireman_e03.WAV", group: 242, text:2}
-	fireman_desease_can_start_at_any_moment {sound:"fireman_g01.WAV", group: 242, text:3}
-	fireman_no_food_in_city {sound:"fireman_g02.WAV", group: 242, text:4}
-	fireman_city_not_safety_workers_leaving {sound:"fireman_g03.WAV", group: 242, text:5}
-	fireman_need_workers {sound:"fireman_g04.WAV", group: 242, text:6}
-	fireman_gods_are_angry {sound:"fireman_g05.WAV", group: 242, text:8}
-	fireman_hight_fire_level {sound:"fireman_g06.WAV", group: 242, text:7}
-	fireman_need_more_workers {sound:"fireman_g07.WAV", group: 242, text:9}
-	fireman_low_entertainment {sound:"fireman_g08.WAV", group: 242, text:10}
-	fireman_gods_are_pleasures {sound:"fireman_g09.WAV", group: 242, text:11}
-	fireman_city_is_amazing {sound:"fireman_g10.wav", group: 242, text:12}
+  	fireman_fighting_fire {sound:"fireman_e01.wav"}
+	fireman_going_to_fire {sound:"fireman_e02.wav"}
+	fireman_fighting_fire_also {sound:"fireman_e03.wav"}
+	fireman_desease_can_start_at_any_moment {sound:"fireman_g01.wav"}
+	fireman_no_food_in_city {sound:"fireman_g02.wav"}
+	fireman_city_not_safety_workers_leaving {sound:"fireman_g03.wav"}
+	fireman_need_workers {sound:"fireman_g04.wav"}
+	fireman_gods_are_angry {sound:"fireman_g05.wav"}
+	fireman_hight_fire_level {sound:"fireman_g06.wav"}
+	fireman_need_more_workers {sound:"fireman_g07.wav"}
+	fireman_low_entertainment {sound:"fireman_g08.wav"}
+	fireman_gods_are_pleasures {sound:"fireman_g09.wav"}
+	fireman_city_is_amazing {sound:"fireman_g10.wav"}
   }
 
   category : figure_category_citizen


### PR DESCRIPTION
<h2><span>Summary</span></h2><p class="isSelectedEnd"><span>The fireman's speech was broken in two ways:</span></p><ul data-spread="false"><li><span>The sound files for the </span><strong><span>going-to-fire</span></strong><span> and </span><strong><span>fighting-fire</span></strong><span> events were never requested, so </span><code dir="ltr"><span>fireman_e01.wav</span></code><span> etc. never played even though the files were present.</span></li><li><span>The phrase shown in the figure info window fell back to an unlocalized </span><code dir="ltr"><span>#242.0</span></code><span> placeholder.</span></li></ul><h2><span>Problem</span></h2><h3><span>1. Missing voice-key prefix</span></h3><p class="isSelectedEnd"><code dir="ltr"><span>figure_fireman::phrase_key()</span></code><span> returned bare keys in its two fire-related branches:</span></p><ul data-spread="false"><li><code dir="ltr"><span>ACTION_74_FIREMAN_GOING_TO_FIRE</span></code><span> → </span><code dir="ltr"><span>going_to_fire</span></code></li><li><code dir="ltr"><span>ACTION_75_FIREMAN_AT_FIRE</span></code><span> → </span><code dir="ltr"><span>fighting_fire</span></code><span> / </span><code dir="ltr"><span>fighting_fire_also</span></code></li></ul><p class="isSelectedEnd"><span>However, the sound table in </span><code dir="ltr"><span>figures.js</span></code><span> registers these as:</span></p><ul data-spread="false"><li><code dir="ltr"><span>fireman_going_to_fire</span></code></li><li><code dir="ltr"><span>fireman_fighting_fire</span></code></li><li><code dir="ltr"><span>fireman_fighting_fire_also</span></code></li></ul><p class="isSelectedEnd"><span>Because of this mismatch, the lookup in </span><code dir="ltr"><span>figure_sounds_t::operator[]</span></code><span> missed the entries. The fallback entry had an empty sound filename, so the game attempted to load </span><code dir="ltr"><span>Voice/Walker/</span></code><span> and fell back to TTS synthesis instead of playing the existing </span><code dir="ltr"><span>.wav</span></code><span> files.</span></p><p class="isSelectedEnd"><span>Background: the </span><code dir="ltr"><span>fcdd1a306</span></code><span> rename added the </span><code dir="ltr"><span>fireman_</span></code><span> prefix to the JS keys and the roaming branch, but the two early-return branches were overlooked.</span></p><h3><span>2. Extension case mismatch</span></h3><p class="isSelectedEnd"><code dir="ltr"><span>figures.js</span></code><span> referenced:</span></p><ul data-spread="false"><li><code dir="ltr"><span>fireman_e03.WAV</span></code></li><li><code dir="ltr"><span>fireman_g01.WAV</span></code><span>–</span><code dir="ltr"><span>fireman_g09.WAV</span></code></li></ul><p class="isSelectedEnd"><span>while the files on disk use lowercase </span><code dir="ltr"><span>.wav</span></code><span>.</span></p><p class="isSelectedEnd"><span>Since </span><code dir="ltr"><span>AUDIO/Voice/Walker</span></code><span> is not part of the VFS case-correction cache, these files could not be found on case-sensitive filesystems.</span></p><h3><span>3. Legacy </span><code dir="ltr"><span>group</span></code><span>/</span><code dir="ltr"><span>text</span></code><span> references</span></h3><p class="isSelectedEnd"><span>The entries still contained </span><code dir="ltr"><span>group: 242</span></code><span> and </span><code dir="ltr"><span>text: N</span></code><span>, but:</span></p><ul data-spread="false"><li><code dir="ltr"><span>text: N</span></code><span> serializes to an empty string.</span></li><li><span>Group </span><code dir="ltr"><span>242</span></code><span> has no </span><code dir="ltr"><span>localization_base_*</span></code><span> entries.</span></li></ul><p class="isSelectedEnd"><span>As a result, the info window displayed the </span><code dir="ltr"><span>#242.0</span></code><span> placeholder instead of the phrase text.</span></p><h2><span>Changes</span></h2>
File | Change
-- | --
src/figuretype/figure_fireman.cpp | phrase_key() now returns fireman_going_to_fire and builds fireman_%s in the fighting branch, consistent with the roaming branch.
src/scripts/figures.js | Removed group: / text: from the fireman sound entries following the water-carrier pattern, and lowercased all .WAV extensions.

<p class="isSelectedEnd"><span>With the </span><code dir="ltr"><span>group</span></code><span>/</span><code dir="ltr"><span>text</span></code><span> fields removed, the existing fallback chain:</span></p><p class="isSelectedEnd"><code dir="ltr"><span>reaction.text</span></code><span> → </span><code dir="ltr"><span>lang_get_string(group, id)</span></code><span> → </span><code dir="ltr"><span>"#key"</span></code></p><p class="isSelectedEnd"><span>resolves </span><code dir="ltr"><span>#fireman_fighting_fire</span></code><span>, etc. through </span><code dir="ltr"><span>lang_text_from_key()</span></code><span> against the named keys in </span><code dir="ltr"><span>localization_{en,de,hu,ru,ru_f}.js</span></code><span>.</span></p><p class="isSelectedEnd"><span>This is the same mechanism already used by the water carrier (</span><code dir="ltr"><span>#water_*</span></code><span>).</span></p><p class="isSelectedEnd"><span>Sound playback continues to use the </span><code dir="ltr"><span>sound:</span></code><span> field, so fireman speech now both plays correctly and displays localized phrase text in the figure info window.</span></p>
<img width="922" height="707" alt="Képernyőkép 2026-08-21 13-08-39" src="https://github.com/user-attachments/assets/5ba4a415-b698-4c64-ae96-c1259fa8d074" />
<img width="922" height="707" alt="Képernyőkép 2026-08-21 14-32-33" src="https://github.com/user-attachments/assets/49f96877-d087-446b-8ef5-ddc5db4a4a77" />

